### PR TITLE
API 응답 포멧 통일

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/user/model/UserFavoriteDrinks.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/model/UserFavoriteDrinks.java
@@ -1,6 +1,6 @@
 package com.ktb.cafeboo.domain.user.model;
 
-import com.ktb.cafeboo.domain.caffeinediary.model.Drink;
+import com.ktb.cafeboo.domain.drink.model.Drink;
 import com.ktb.cafeboo.global.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/ApiResponse.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/ApiResponse.java
@@ -1,0 +1,49 @@
+package com.ktb.cafeboo.global.apiPayload;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.ktb.cafeboo.global.apiPayload.code.BaseCode;
+import com.ktb.cafeboo.global.apiPayload.code.status.SuccessStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"status", "code", "message", "data"})
+public class ApiResponse<T> {
+    private int status;
+    private String code;
+    private String message;
+    private T data;
+
+    // 성공 응답
+    public static <T> ApiResponse<T> onSuccess(T result) {
+        return new ApiResponse<>(
+                SuccessStatus.OK.getStatus(),
+                SuccessStatus.OK.getCode(),
+                SuccessStatus.OK.getMessage(),
+                result
+        );
+    }
+
+    public static <T> ApiResponse<T> of(BaseCode code, T result) {
+        return new ApiResponse<>(
+                code.getStatus(),
+                code.getCode(),
+                code.getMessage(),
+                result
+        );
+    }
+
+    // 실패 응답
+    public static <T> ApiResponse<T> onFailure(BaseCode errorCode) {
+        return new ApiResponse<>(
+                errorCode.getStatus(),
+                errorCode.getCode(),
+                errorCode.getMessage(),
+                null
+        );
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/code/BaseCode.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/code/BaseCode.java
@@ -1,0 +1,7 @@
+package com.ktb.cafeboo.global.apiPayload.code;
+
+public interface BaseCode {
+    int getStatus();
+    String getCode();
+    String getMessage();
+}

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/ErrorStatus.java
@@ -1,23 +1,20 @@
 package com.ktb.cafeboo.global.apiPayload.code.status;
 
 import com.ktb.cafeboo.global.apiPayload.code.BaseCode;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+@Getter
 @RequiredArgsConstructor
 public enum ErrorStatus implements BaseCode {
-    BAD_REQUEST("400", "잘못된 요청입니다."),
-    UNAUTHORIZED("401", "인증이 필요합니다.");
 
+    BAD_REQUEST(400, "BAD_REQUEST", "잘못된 요청입니다."),
+    UNAUTHORIZED(401, "UNAUTHORIZED", "인증이 필요합니다."),
+    FORBIDDEN(403, "FORBIDDEN", "접근 권한이 없습니다."),
+    NOT_FOUND(404, "NOT_FOUND", "요청한 리소스를 찾을 수 없습니다."),
+    INTERNAL_SERVER_ERROR(500, "INTERNAL_ERROR", "서버 내부 오류가 발생했습니다.");
+
+    private final int status;
     private final String code;
     private final String message;
-
-    @Override
-    public String getCode() {
-        return code;
-    }
-
-    @Override
-    public String getMessage() {
-        return message;
-    }
 }

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/ErrorStatus.java
@@ -1,0 +1,23 @@
+package com.ktb.cafeboo.global.apiPayload.code.status;
+
+import com.ktb.cafeboo.global.apiPayload.code.BaseCode;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum ErrorStatus implements BaseCode {
+    BAD_REQUEST("400", "잘못된 요청입니다."),
+    UNAUTHORIZED("401", "인증이 필요합니다.");
+
+    private final String code;
+    private final String message;
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/SuccessStatus.java
@@ -1,0 +1,23 @@
+package com.ktb.cafeboo.global.apiPayload.code.status;
+
+import com.ktb.cafeboo.global.apiPayload.code.BaseCode;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum SuccessStatus implements BaseCode {
+    OK("200", "요청이 성공적으로 처리되었습니다."),
+    CREATED("201", "리소스가 성공적으로 생성되었습니다.");
+
+    private final String code;
+    private final String message;
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/SuccessStatus.java
@@ -1,23 +1,18 @@
 package com.ktb.cafeboo.global.apiPayload.code.status;
 
 import com.ktb.cafeboo.global.apiPayload.code.BaseCode;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+@Getter
 @RequiredArgsConstructor
 public enum SuccessStatus implements BaseCode {
-    OK("200", "요청이 성공적으로 처리되었습니다."),
-    CREATED("201", "리소스가 성공적으로 생성되었습니다.");
 
+    OK(200, "SUCCESS", "요청이 성공적으로 처리되었습니다."),
+    CREATED(201, "CREATED", "리소스가 성공적으로 생성되었습니다."),
+    NO_CONTENT(204, "NO_CONTENT", "요청은 성공했지만 반환할 데이터가 없습니다.");
+
+    private final int status;
     private final String code;
     private final String message;
-
-    @Override
-    public String getCode() {
-        return code;
-    }
-
-    @Override
-    public String getMessage() {
-        return message;
-    }
 }


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] API 응답 포멧 통일을 위한 apiPayload 패키지 구축
- [x] 공통 응답 포멧 (ApiResponse) 생성
- [x] 응답 상태객체 (SuccessStatus, ErrorStatus) 생성

## 🛠 변경사항
- API 응답의 일관성을 위해 ApiResponse<T> 클래스 작성
- onSuccess: 기본 성공 응답 생성 (SuccessStatus.OK 기반)
- of: 상황별 BaseCode 기반 커스텀 성공 응답 생성
- onFailure: 에러 코드 기반 실패 응답 처리
- data 필드는 null일 경우 JSON 응답에서 제외되도록 설정

## 💬 리뷰 요구사항
- 대면으로 리뷰 진행완료
