### PR TITLE
✨ feat : 일일, 주간 리포트 기능 구현

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/caffeinediary/controller/CaffeineIntakeController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/caffeinediary/controller/CaffeineIntakeController.java
@@ -11,6 +11,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,12 +30,12 @@ public class CaffeineIntakeController {
         @RequestBody CaffeineIntakeRequest request) {
 
         // 1. 더미 유저 조회
-        User dummyUser = userService.getUserById(2L); // 예시: ID가 1인 유저를 조회
+        User dummyUser = userService.findUserById(2L); // 예시: ID가 1인 유저를 조회
         // Long userId = Long.parseLong(userDetails.getUsername()); // Assuming username contains userId -> 더미 유저 사용
         Long userId = dummyUser.getId();
 
         // 2. 서비스 메서드 호출
-        CaffeineIntakeResponse response = caffeineIntakeService.recordCaffeineIntake(dummyUser, request);
+        CaffeineIntakeResponse response = caffeineIntakeService.recordCaffeineIntake(userId, request);
 
         // 3. 응답 반환
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -46,13 +47,14 @@ public class CaffeineIntakeController {
                 .build());
     }
 
-    @PatchMapping
+    @PatchMapping("/{id}")
     public ResponseEntity<ApiResponse<CaffeineIntakeResponse>> updateCaffeineIntake(
         /*@AuthenticationPrincipal UserDetails userDetails,  더미 유저 사용으로 주석 처리*/
+        @PathVariable Long id,
         @RequestBody CaffeineIntakeRequest request) {
 
         // 1. 서비스 메서드 호출
-        CaffeineIntakeResponse response = caffeineIntakeService.updateCaffeineIntake(1L, request);
+        CaffeineIntakeResponse response = caffeineIntakeService.updateCaffeineIntake(id, request);
 
         // 2. 응답 반환
         return ResponseEntity.status(HttpStatus.OK)
@@ -64,13 +66,13 @@ public class CaffeineIntakeController {
                 .build());
     }
 
-    @DeleteMapping
+    @DeleteMapping("/{id}")
     public ResponseEntity<ApiResponse<CaffeineIntakeResponse>>deleteCaffeineIntake(
         /*@AuthenticationPrincipal UserDetails userDetails,  더미 유저 사용으로 주석 처리*/
-        @RequestBody CaffeineIntakeRequest request) {
+        @PathVariable Long id) {
 
         // 1. 서비스 메서드 호출
-        caffeineIntakeService.deleteCaffeineIntake(request.getDrinkId());
+        caffeineIntakeService.deleteCaffeineIntake(id);
 
         // 2. 응답 반환
         return ResponseEntity.status(HttpStatus.NO_CONTENT)

--- a/src/main/java/com/ktb/cafeboo/domain/caffeinediary/model/CaffeineResidual.java
+++ b/src/main/java/com/ktb/cafeboo/domain/caffeinediary/model/CaffeineResidual.java
@@ -7,6 +7,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -25,8 +26,8 @@ public class CaffeineResidual extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    // 기준 날짜 (날짜만)
-    private LocalDate targetDate;
+    // 기준 날짜
+    private LocalDateTime targetDate;
 
     // 기준 시간 (0~23시)
     private Integer hour;

--- a/src/main/java/com/ktb/cafeboo/domain/caffeinediary/repository/CaffeineResidualRepository.java
+++ b/src/main/java/com/ktb/cafeboo/domain/caffeinediary/repository/CaffeineResidualRepository.java
@@ -3,6 +3,7 @@ package com.ktb.cafeboo.domain.caffeinediary.repository;
 import com.ktb.cafeboo.domain.caffeinediary.model.CaffeineResidual;
 import com.ktb.cafeboo.domain.user.model.User;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,7 +13,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CaffeineResidualRepository extends JpaRepository<CaffeineResidual, Long> {
-    Optional<CaffeineResidual> findByUserAndTargetDateAndHour(User user, LocalDate targetDate, int hour);
+    Optional<CaffeineResidual> findByUserAndTargetDateAndHour(User user, LocalDateTime targetDate, int hour);
 
     @Query("SELECT cr FROM CaffeineResidual cr " +
         "WHERE cr.user = :user " +
@@ -26,18 +27,10 @@ public interface CaffeineResidualRepository extends JpaRepository<CaffeineResidu
     /**
      * 현재 시간 기준 전후 35시간의 카페인 잔존량 데이터를 조회합니다.
      */
-    @Query("SELECT cr FROM CaffeineResidual cr " +
-        "WHERE cr.user = :user " +
-        "AND ((cr.targetDate = :previousDate AND cr.hour >= :previousStartHour) " +
-        "     OR (cr.targetDate = :currentDate) " +
-        "     OR (cr.targetDate = :nextDate AND cr.hour <= :nextEndHour)) " +
-        "ORDER BY cr.targetDate ASC, cr.hour ASC")
+    @Query("SELECT r FROM CaffeineResidual r WHERE r.user = :user AND r.targetDate BETWEEN :startTime AND :endTime ORDER BY r.targetDate ASC")
     List<CaffeineResidual> findResidualsByTimeRange(
         @Param("user") User user,
-        @Param("previousDate") LocalDate previousDate,
-        @Param("currentDate") LocalDate currentDate,
-        @Param("nextDate") LocalDate nextDate,
-        @Param("previousStartHour") int previousStartHour,
-        @Param("nextEndHour") int nextEndHour
+        @Param("startTime") LocalDateTime startTime,
+        @Param("endTime") LocalDateTime endTime
     );
 }

--- a/src/main/java/com/ktb/cafeboo/domain/caffeinediary/service/CaffeineIntakeService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/caffeinediary/service/CaffeineIntakeService.java
@@ -8,9 +8,11 @@ import com.ktb.cafeboo.domain.drink.model.Drink;
 import com.ktb.cafeboo.domain.caffeinediary.repository.CaffeineIntakeRepository;
 import com.ktb.cafeboo.domain.caffeinediary.repository.CaffeineResidualRepository;
 import com.ktb.cafeboo.domain.drink.repository.DrinkRepository;
+import com.ktb.cafeboo.domain.drink.service.DrinkService;
 import com.ktb.cafeboo.domain.report.service.DailyStatisticsService;
 import com.ktb.cafeboo.domain.user.model.User;
 import com.ktb.cafeboo.domain.user.repository.UserRepository;
+import com.ktb.cafeboo.domain.user.service.UserService;
 import jakarta.transaction.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -30,9 +32,11 @@ public class CaffeineIntakeService {
 
     private final CaffeineIntakeRepository intakeRepository;
     private final CaffeineResidualRepository residualRepository;
-    private final UserRepository userRepository;
-    private final DrinkRepository drinkRepository;
+
     private final DailyStatisticsService dailyStatisticsService;
+    private final UserService userService;
+    private final DrinkService drinkService;
+    private final ResidualAmountService residualAmountService;
 
     private static final double DEFAULT_HALF_LIFE_HOUR = 5.0; // 평균 반감기
 
@@ -40,29 +44,17 @@ public class CaffeineIntakeService {
     private double k = Math.log(2) / DEFAULT_HALF_LIFE_HOUR;
 
     /**
-     * 음료 정보를 조회하고 캐싱합니다.
-     * @param drinkId 음료 ID
-     * @return 조회된 음료 객체
-     * @throws IllegalArgumentException 해당 ID의 음료가 없을 경우 발생
-     */
-    @Cacheable(value = "drinks", key = "#drinkId") // drinks라는 캐시에 drinkId를 키로 사용하여 캐싱
-    public Drink getDrink(Long drinkId) {
-        return drinkRepository.findById(drinkId)
-            .orElseThrow(() -> new IllegalArgumentException("음료 정보가 없습니다."));
-    }
-
-    /**
      * 새로운 카페인 섭취 기록을 등록하고, 섭취 시간을 기준으로 사용자의 예상 카페인 잔존량을 계산하여 데이터베이스에 업데이트합니다.
      *
-     * @param user    사용자 정보 객체
+     * @param userId    사용자 PK, 고유키
      * @param request 요청으로 보낸 drink 정보
      * @return CaffeineIntakeResponse: 생성된 카페인 섭취 기록에 대한 응답
      * @throws IllegalArgumentException 유저 정보 또는 음료 정보가 없을 경우 발생합니다.
      */
-    public CaffeineIntakeResponse recordCaffeineIntake(User user, CaffeineIntakeRequest request) {
+    public CaffeineIntakeResponse recordCaffeineIntake(Long userId, CaffeineIntakeRequest request) {
         // 0. 데이터 유효성 겁사. 사용자 정보, 음료 정보가 유효하지 않을 시 IllegalArgumentException 발생
-
-        Drink drink = getDrink(request.getDrinkId());
+        User user = userService.findUserById(userId);
+        Drink drink = drinkService.findDrinkById(request.getDrinkId());
 
         // 1. 섭취 정보 저장
         CaffeineIntake intake = CaffeineIntake.builder()
@@ -75,10 +67,10 @@ public class CaffeineIntakeService {
         intakeRepository.save(intake);
 
         // 2. 잔존량 계산
-       updateResidualAmounts(user, request.getIntakeTime(), request.getCaffeineAmount());
+        residualAmountService.updateResidualAmounts(user, request.getIntakeTime(), request.getCaffeineAmount());
 
-//        // 3. DailyStatistics 업데이트
-//        dailyStatisticsService.updateDailyStatistics(1L, request.getCaffeineAmount(), 1L);
+        // 3. DailyStatistics 업데이트
+        dailyStatisticsService.updateDailyStatistics(user, LocalDate.from(request.getIntakeTime()), request.getCaffeineAmount());
 
         // 4. 응답 DTO 생성 및 반환
         return CaffeineIntakeResponse.builder()
@@ -119,8 +111,7 @@ public class CaffeineIntakeService {
 
         // 2. 수정할 필드 적용
         if (request.getDrinkId() != null) {
-            Drink drink = drinkRepository.findById(request.getDrinkId())
-                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 음료 정보입니다."));
+            Drink drink = drinkService.findDrinkById(request.getDrinkId());
             intake.setDrink(drink);
         }
         if (request.getIntakeTime() != null) {
@@ -139,13 +130,13 @@ public class CaffeineIntakeService {
         LocalDateTime newIntakeTime = request.getIntakeTime() != null ? request.getIntakeTime() : intake.getIntakeTime();
 
         // 기존 시간 기준 삭제 ->  수정 이전의 잔존량 삭제
-        modifyResidualAmounts(user, previousIntakeTime, previousCaffeineAmount * previousDrinkCount);
+        residualAmountService.modifyResidualAmounts(user, previousIntakeTime, previousCaffeineAmount);
+        dailyStatisticsService.updateDailyStatistics(user, LocalDate.from(previousIntakeTime), previousCaffeineAmount * -1);
 
         // 새로운 시간 기준으로 update -> 수정 후의 잔존량 계산 및 저장
-        updateResidualAmounts(user, newIntakeTime, newCaffeineAmount * newDrinkCount);
+        residualAmountService.updateResidualAmounts(user, newIntakeTime, newCaffeineAmount);
+        dailyStatisticsService.updateDailyStatistics(user, LocalDate.from(request.getIntakeTime()), request.getCaffeineAmount());
 
-
-        // 4. 수정된 섭취 기록 반환
         return CaffeineIntakeResponse.builder()
             .id(intake.getId())
             .drinkId(intake.getDrink().getId())
@@ -154,89 +145,6 @@ public class CaffeineIntakeService {
             .drinkCount(intake.getDrinkCount())
             .caffeineAmount(intake.getCaffeineAmountMg())
             .build();
-    }
-
-    private void modifyResidualAmounts(User user, LocalDateTime previousIntakeTime, float previousCaffeineAmount) {
-        final LocalDate previousTargetDate = previousIntakeTime.toLocalDate();
-        final LocalDateTime previousEndTime = previousIntakeTime.plusHours(24);
-
-        // 1. 섭취 내역 수정으로 인해 영향을 받는 잔존량 데이터 조회 (24hour)
-        List<CaffeineResidual> residualsToModify = residualRepository.findByUserAndTargetDateBetween(user, previousTargetDate, previousEndTime.toLocalDate());
-
-        // 2. 섭취 내역 수정으로 인해 영향을 받는 잔존량 데이터에 대해 이전 카페인 섭취량의 영향 제거
-        for (CaffeineResidual residual : residualsToModify) {
-            LocalDateTime residualDateTime = LocalDateTime.of(residual.getTargetDate(), LocalTime.of(residual.getHour(), 0));
-
-            // 해당 시점이 이전 섭취 시간과 새로운 섭취 시간 사이에 있는 경우에만 처리
-            if (residualDateTime.isAfter(previousIntakeTime) || residualDateTime.isEqual(previousIntakeTime)) {
-                // 이전 섭취로 인한 잔존량 계산
-                double hoursSincePreviousIntake = ChronoUnit.HOURS.between(previousIntakeTime,
-                    residualDateTime);
-                double previousResidualAmount =
-                    previousCaffeineAmount * Math.exp(-k * hoursSincePreviousIntake);
-
-                // 현재 총 잔존량에서 이전 섭취로 인한 잔존량을 차감
-                float updatedAmount =
-                    residual.getResidueAmountMg() - (float) previousResidualAmount;
-
-                // 음수가 되지 않도록 보정
-                updatedAmount = Math.max(0, updatedAmount);
-
-                residual.setResidueAmountMg(updatedAmount);
-            }
-        }
-
-        // 3. 변경된 데이터 일괄 저장
-        try {
-            residualRepository.saveAll(residualsToModify);
-        } catch (Exception e) {
-            throw new RuntimeException("카페인 잔존량 저장 중 오류가 발생했습니다.", e);
-        }
-    }
-
-    /**
-     * 섭취 시간을 기준으로 24시간 동안의 카페인 잔존량을 계산하고, 기존 잔존량 데이터를 갱신하거나 새로 생성하여 저장합니다.
-     *
-     * @param user                사용자 정보 객체
-     * @param intakeTime          섭취 시간
-     * @param initialCaffeineAmount 섭취 시점의 총 카페인 양 (mg)
-     */
-    private void updateResidualAmounts(User user, LocalDateTime intakeTime, float initialCaffeineAmount) {
-        LocalDateTime endTime = intakeTime.plusHours(24);
-
-        List<CaffeineResidual> residuals = new ArrayList<>();
-        for (int hourOffset = 0; hourOffset <= 24; hourOffset++) {
-            LocalDateTime targetTime = intakeTime.plusHours(hourOffset);
-            LocalDate targetDate = targetTime.toLocalDate();
-            int hour = targetTime.getHour();
-            double timeElapsed = hourOffset;
-            double residualAmount = initialCaffeineAmount * Math.exp(-k * timeElapsed);
-
-            Optional<CaffeineResidual> existingResidual = residualRepository.findByUserAndTargetDateAndHour(user, targetDate, hour);
-            double currentCaffeineAtTargetTime;
-
-            if (existingResidual.isPresent()) {
-                // 기존 데이터가 있으면, 해당 시점의 잔존량에 현재 섭취량의 영향을 더함
-                CaffeineResidual residual = existingResidual.get();
-                double previousResidualAmount = residual.getResidueAmountMg();
-
-                // targetTime의 최종 잔존량 (이전 잔존량은 이미 반감기가 적용된 상태)
-                currentCaffeineAtTargetTime = previousResidualAmount + residualAmount;
-
-                residual.setResidueAmountMg((float) currentCaffeineAtTargetTime);
-                residuals.add(residual);
-            } else {
-                // 기존 데이터가 없으면 새로 생성
-                CaffeineResidual residual = CaffeineResidual.builder()
-                    .user(user)
-                    .targetDate(targetDate)
-                    .hour(hour)
-                    .residueAmountMg((float) residualAmount)
-                    .build();
-                residuals.add(residual);
-            }
-        }
-        residualRepository.saveAll(residuals);
     }
 
     public void deleteCaffeineIntake(Long intakeId) {
@@ -248,7 +156,8 @@ public class CaffeineIntakeService {
         int previousDrinkCount = intake.getDrinkCount();
 
         // 2. 해당 섭취 내역의 영향이 있는 시간 범위 내의 카페인 잔존량 수치 수정
-        modifyResidualAmounts(user, previousIntakeTime, previousCaffeineAmount * previousDrinkCount);
+        residualAmountService.modifyResidualAmounts(user, previousIntakeTime, previousCaffeineAmount);
+        dailyStatisticsService.updateDailyStatistics(user, LocalDate.from(previousIntakeTime), previousCaffeineAmount * -1);
 
         // 3. 해당 데이터 CaffeineIntakes 테이블에서 삭제
         intakeRepository.deleteById(intakeId);

--- a/src/main/java/com/ktb/cafeboo/domain/caffeinediary/service/CaffeineResidualService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/caffeinediary/service/CaffeineResidualService.java
@@ -1,6 +1,5 @@
 package com.ktb.cafeboo.domain.caffeinediary.service;
 
-import com.ktb.cafeboo.domain.caffeinediary.model.CaffeineIntake;
 import com.ktb.cafeboo.domain.caffeinediary.model.CaffeineResidual;
 import com.ktb.cafeboo.domain.caffeinediary.repository.CaffeineResidualRepository;
 import com.ktb.cafeboo.domain.user.model.User;
@@ -9,16 +8,23 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class ResidualAmountService {
+@Slf4j
+public class CaffeineResidualService {
     private final CaffeineResidualRepository residualRepository;
 
+    private static final Integer HOURS_RANGE = 17;
     private static final double DEFAULT_HALF_LIFE_HOUR = 5.0;
     // 카페인 반감기 (현재는 임의로 5시간으로 설정)
     private double k = Math.log(2) / DEFAULT_HALF_LIFE_HOUR;
@@ -32,7 +38,8 @@ public class ResidualAmountService {
 
         // 2. 섭취 내역 수정으로 인해 영향을 받는 잔존량 데이터에 대해 이전 카페인 섭취량의 영향 제거
         for (CaffeineResidual residual : residualsToModify) {
-            LocalDateTime residualDateTime = LocalDateTime.of(residual.getTargetDate(), LocalTime.of(residual.getHour(), 0));
+            LocalDateTime residualDateTime = LocalDateTime.of(
+                LocalDate.from(residual.getTargetDate()), LocalTime.of(residual.getHour(), 0));
 
             // 해당 시점이 이전 섭취 시간과 새로운 섭취 시간 사이에 있는 경우에만 처리
             if (residualDateTime.isAfter(previousIntakeTime) || residualDateTime.isEqual(previousIntakeTime)) {
@@ -67,12 +74,12 @@ public class ResidualAmountService {
         List<CaffeineResidual> residuals = new ArrayList<>();
         for (int hourOffset = 0; hourOffset <= 24; hourOffset++) {
             LocalDateTime targetTime = intakeTime.plusHours(hourOffset);
-            LocalDate targetDate = targetTime.toLocalDate();
+            LocalDateTime targetDateTime = targetTime.toLocalDate().atStartOfDay();
             int hour = targetTime.getHour();
             double timeElapsed = hourOffset;
             double residualAmount = initialCaffeineAmount * Math.exp(-k * timeElapsed);
 
-            Optional<CaffeineResidual> existingResidual = residualRepository.findByUserAndTargetDateAndHour(user, targetDate, hour);
+            Optional<CaffeineResidual> existingResidual = residualRepository.findByUserAndTargetDateAndHour(user, targetDateTime, hour);
             double currentCaffeineAtTargetTime;
 
             if (existingResidual.isPresent()) {
@@ -89,7 +96,7 @@ public class ResidualAmountService {
                 // 기존 데이터가 없으면 새로 생성
                 CaffeineResidual residual = CaffeineResidual.builder()
                     .user(user)
-                    .targetDate(targetDate)
+                    .targetDate(targetDateTime)
                     .hour(hour)
                     .residueAmountMg((float) residualAmount)
                     .build();
@@ -97,5 +104,57 @@ public class ResidualAmountService {
             }
         }
         residualRepository.saveAll(residuals);
+    }
+
+    /**
+     * 현재 시간 기준 전후 17시간의 카페인 잔존량 데이터를 조회합니다.
+     * @param user 조회할 사용자
+     * @param currentDateTime 현재 시간
+     * @return 35시간 범위의 카페인 잔존량 데이터
+     */
+    public List<CaffeineResidual> getCaffeineResidualsByTimeRange(
+        User user,
+        LocalDateTime currentDateTime) {
+
+
+        LocalDateTime startTime = currentDateTime.minusHours(17);
+        LocalDateTime endTime = currentDateTime.plusHours(17);
+
+        log.info("startTime: {}, endTime : {}", startTime, endTime);
+
+        List<CaffeineResidual> residuals = residualRepository.findResidualsByTimeRange(
+            user,
+            startTime.toLocalDate().atStartOfDay(),
+            endTime.toLocalDate().atStartOfDay()
+        );
+
+        // 2. Map으로 변환 (key: "yyyy-MM-dd-HH")
+        Map<String, CaffeineResidual> residualMap = residuals.stream()
+            .collect(Collectors.toMap(
+                r -> r.getTargetDate().toLocalDate().toString() + "-" + r.getHour(),
+                Function.identity()
+            ));
+
+        // 3. 35시간 구간의 모든 시간 포인트 생성 및 매핑
+        List<CaffeineResidual> result = new ArrayList<>();
+        for (int i = -17; i <= 17; i++) {
+            LocalDateTime timePoint = currentDateTime.plusHours(i);
+            String key = timePoint.toLocalDate().toString() + "-" + timePoint.getHour();
+            CaffeineResidual residual = residualMap.get(key);
+
+            if (residual != null) {
+                result.add(residual);
+            } else {
+                result.add(
+                    CaffeineResidual.builder()
+                        .user(user)
+                        .targetDate(timePoint.toLocalDate().atStartOfDay())
+                        .hour(timePoint.getHour())
+                        .residueAmountMg(0f)
+                        .build()
+                );
+            }
+        }
+        return result;
     }
 }

--- a/src/main/java/com/ktb/cafeboo/domain/caffeinediary/service/ResidualAmountService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/caffeinediary/service/ResidualAmountService.java
@@ -1,0 +1,101 @@
+package com.ktb.cafeboo.domain.caffeinediary.service;
+
+import com.ktb.cafeboo.domain.caffeinediary.model.CaffeineIntake;
+import com.ktb.cafeboo.domain.caffeinediary.model.CaffeineResidual;
+import com.ktb.cafeboo.domain.caffeinediary.repository.CaffeineResidualRepository;
+import com.ktb.cafeboo.domain.user.model.User;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ResidualAmountService {
+    private final CaffeineResidualRepository residualRepository;
+
+    private static final double DEFAULT_HALF_LIFE_HOUR = 5.0;
+    // 카페인 반감기 (현재는 임의로 5시간으로 설정)
+    private double k = Math.log(2) / DEFAULT_HALF_LIFE_HOUR;
+
+    public void modifyResidualAmounts(User user, LocalDateTime previousIntakeTime, float previousCaffeineAmount) {
+        final LocalDate previousTargetDate = previousIntakeTime.toLocalDate();
+        final LocalDateTime previousEndTime = previousIntakeTime.plusHours(24);
+
+        // 1. 섭취 내역 수정으로 인해 영향을 받는 잔존량 데이터 조회 (24hour)
+        List<CaffeineResidual> residualsToModify = residualRepository.findByUserAndTargetDateBetween(user, previousTargetDate, previousEndTime.toLocalDate());
+
+        // 2. 섭취 내역 수정으로 인해 영향을 받는 잔존량 데이터에 대해 이전 카페인 섭취량의 영향 제거
+        for (CaffeineResidual residual : residualsToModify) {
+            LocalDateTime residualDateTime = LocalDateTime.of(residual.getTargetDate(), LocalTime.of(residual.getHour(), 0));
+
+            // 해당 시점이 이전 섭취 시간과 새로운 섭취 시간 사이에 있는 경우에만 처리
+            if (residualDateTime.isAfter(previousIntakeTime) || residualDateTime.isEqual(previousIntakeTime)) {
+                // 이전 섭취로 인한 잔존량 계산
+                double hoursSincePreviousIntake = ChronoUnit.HOURS.between(previousIntakeTime,
+                    residualDateTime);
+                double previousResidualAmount =
+                    previousCaffeineAmount * Math.exp(-k * hoursSincePreviousIntake);
+
+                // 현재 총 잔존량에서 이전 섭취로 인한 잔존량을 차감
+                float updatedAmount =
+                    residual.getResidueAmountMg() - (float) previousResidualAmount;
+
+                // 음수가 되지 않도록 보정
+                updatedAmount = Math.max(0, updatedAmount);
+
+                residual.setResidueAmountMg(updatedAmount);
+            }
+        }
+
+        // 3. 변경된 데이터 일괄 저장
+        try {
+            residualRepository.saveAll(residualsToModify);
+        } catch (Exception e) {
+            throw new RuntimeException("카페인 잔존량 저장 중 오류가 발생했습니다.", e);
+        }
+    }
+
+    public void updateResidualAmounts(User user, LocalDateTime intakeTime, float initialCaffeineAmount) {
+        LocalDateTime endTime = intakeTime.plusHours(24);
+
+        List<CaffeineResidual> residuals = new ArrayList<>();
+        for (int hourOffset = 0; hourOffset <= 24; hourOffset++) {
+            LocalDateTime targetTime = intakeTime.plusHours(hourOffset);
+            LocalDate targetDate = targetTime.toLocalDate();
+            int hour = targetTime.getHour();
+            double timeElapsed = hourOffset;
+            double residualAmount = initialCaffeineAmount * Math.exp(-k * timeElapsed);
+
+            Optional<CaffeineResidual> existingResidual = residualRepository.findByUserAndTargetDateAndHour(user, targetDate, hour);
+            double currentCaffeineAtTargetTime;
+
+            if (existingResidual.isPresent()) {
+                // 기존 데이터가 있으면, 해당 시점의 잔존량에 현재 섭취량의 영향을 더함
+                CaffeineResidual residual = existingResidual.get();
+                double previousResidualAmount = residual.getResidueAmountMg();
+
+                // targetTime의 최종 잔존량 (이전 잔존량은 이미 반감기가 적용된 상태)
+                currentCaffeineAtTargetTime = previousResidualAmount + residualAmount;
+
+                residual.setResidueAmountMg((float) currentCaffeineAtTargetTime);
+                residuals.add(residual);
+            } else {
+                // 기존 데이터가 없으면 새로 생성
+                CaffeineResidual residual = CaffeineResidual.builder()
+                    .user(user)
+                    .targetDate(targetDate)
+                    .hour(hour)
+                    .residueAmountMg((float) residualAmount)
+                    .build();
+                residuals.add(residual);
+            }
+        }
+        residualRepository.saveAll(residuals);
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/domain/drink/model/Cafe.java
+++ b/src/main/java/com/ktb/cafeboo/domain/drink/model/Cafe.java
@@ -1,11 +1,21 @@
 package com.ktb.cafeboo.domain.drink.model;
 
 import com.ktb.cafeboo.global.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
+@Entity
+@Table(name = "Cafes")
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class Cafe extends BaseEntity {
 
     private String name;

--- a/src/main/java/com/ktb/cafeboo/domain/drink/model/Drink.java
+++ b/src/main/java/com/ktb/cafeboo/domain/drink/model/Drink.java
@@ -19,6 +19,11 @@ import lombok.Setter;
 @AllArgsConstructor
 @Builder
 public class Drink extends BaseEntity {
+    // 섭취 음료 ID
+    @ManyToOne
+    @JoinColumn(name = "cafe_id", nullable = false)
+    private Cafe cafe;
+
     private String name;
 
     private String type;

--- a/src/main/java/com/ktb/cafeboo/domain/report/controller/DailyReportController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/report/controller/DailyReportController.java
@@ -1,0 +1,49 @@
+package com.ktb.cafeboo.domain.report.controller;
+
+import com.ktb.cafeboo.domain.report.dto.DailyCaffeineReportResponse;
+import com.ktb.cafeboo.domain.caffeinediary.service.CaffeineResidualService;
+import com.ktb.cafeboo.domain.report.service.DailyReportService;
+import com.ktb.cafeboo.domain.report.service.DailyStatisticsService;
+import com.ktb.cafeboo.domain.user.service.UserService;
+import com.ktb.cafeboo.global.ApiResponse;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/reports/daily")
+public class DailyReportController {
+    private final DailyStatisticsService dailyStatisticsService;
+    private final CaffeineResidualService residualService;
+    private final DailyReportService dailyReportService;
+    private final UserService userService;
+    /**
+     * 사용자의 일일 카페인 섭취 현황 데이터를 조회합니다.
+     * 상세 스펙은 @see <a href="https://freckle-pipe-840.notion.site/1ddb43be904c8078b6ecfbeaf23369f6">일일 섭취 현황 조회 API 스펙 문서</a>
+//     * @param user 현재 인증된 사용자
+     * @param targetDate 조회할 날짜 (yyyy-MM-dd), 미입력시 오늘 날짜
+     * @return 일일 카페인 섭취 리포트
+     * @throws IllegalArgumentException 잘못된 요청 파라미터
+//     * @throws AuthenticationException 인증 실패
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<DailyCaffeineReportResponse>> getDailyCaffeineReport(
+        @RequestParam(required = false) LocalDate targetDate) {
+
+        // 일일 리포트 생성
+        DailyCaffeineReportResponse response = dailyReportService.createDailyReport(2L, targetDate, LocalTime.now());
+
+        return ResponseEntity.ok(ApiResponse.<DailyCaffeineReportResponse>builder()
+            .status(200)
+            .code("DAILY_CAFFEINE_REPORT_SUCCESS")
+            .message("일일 카페인 섭취 리포트를 성공적으로 조회했습니다.")
+            .data(response)
+            .build());
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/domain/report/controller/WeeklyReportController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/report/controller/WeeklyReportController.java
@@ -1,0 +1,105 @@
+package com.ktb.cafeboo.domain.report.controller;
+
+import com.ktb.cafeboo.domain.report.dto.DailyCaffeineReportResponse;
+import com.ktb.cafeboo.domain.report.dto.DailyCaffeineReportResponse;
+import com.ktb.cafeboo.domain.report.dto.WeeklyCaffeineReportResponse;
+import com.ktb.cafeboo.domain.report.model.DailyStatistics;
+import com.ktb.cafeboo.domain.report.model.WeeklyReport;
+import com.ktb.cafeboo.domain.report.service.DailyStatisticsService;
+import com.ktb.cafeboo.domain.report.service.WeeklyReportService;
+import com.ktb.cafeboo.global.ApiResponse;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.temporal.IsoFields;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/reports/weekly")
+public class WeeklyReportController {
+    private final WeeklyReportService weeklyReportService;
+    private final DailyStatisticsService dailyStatisticsService;
+
+    /**
+     * 사용자의 일일 카페인 섭취 현황 데이터를 조회합니다.
+     * 상세 스펙은 @see <a href="https://freckle-pipe-840.notion.site/1ddb43be904c80ccbb02c746ff16a3ba">주간 섭취 현황 조회 API 스펙 문서</a>
+     //     * @param user 현재 인증된 사용자
+     * @param targetDate 조회할 날짜 (yyyy-MM-dd), 미입력시 오늘 날짜
+     * @return 일일 카페인 섭취 리포트
+     * @throws IllegalArgumentException 잘못된 요청 파라미터
+    //     * @throws AuthenticationException 인증 실패
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<WeeklyCaffeineReportResponse>> getWeeklyCaffeineReport(
+        @RequestParam(required = false) LocalDate targetDate) {
+        int year = targetDate.get(IsoFields.WEEK_BASED_YEAR);
+        int weekNum = targetDate.get(IsoFields.WEEK_OF_WEEK_BASED_YEAR);
+        int month = targetDate.getMonthValue();
+        LocalDate startDate = targetDate.with(DayOfWeek.MONDAY);
+        LocalDate endDate = startDate.plusDays(6);
+
+        String isoWeek = String.format("%d-W%02d", year, weekNum);
+
+        WeeklyReport weeklyReport = weeklyReportService.getWeeklyReport(2L, targetDate);
+        float weeklyTotal = weeklyReport.getTotalCaffeineMg();
+        //float dailyLimit = user.getDailyLimit();
+        int overLimitDays = weeklyReport.getOverIntakeDays();
+        float dailyAvg = weeklyReport.getDailyCaffeineAvgMg();
+
+        List<DailyStatistics> dailyStats = dailyStatisticsService.getDailyStatisticsForWeek(2L, targetDate);
+
+        List<WeeklyCaffeineReportResponse.DailyIntakeTotal> dailyIntakeTotals = dailyStats.stream()
+            .map(stat -> WeeklyCaffeineReportResponse.DailyIntakeTotal.builder()
+                .date(stat.getDate().toString())
+                .caffeineMg(Math.round(stat.getTotalCaffeineMg()))
+                .build())
+            .collect(Collectors.toList());
+
+        for (int i = 0; i < 7; i++) {
+            LocalDate d = startDate.plusDays(i);
+            boolean exists = dailyIntakeTotals.stream().anyMatch(t -> t.getDate().equals(d.toString()));
+            if (!exists) {
+                dailyIntakeTotals.add(
+                    WeeklyCaffeineReportResponse.DailyIntakeTotal.builder()
+                        .date(d.toString())
+                        .caffeineMg(0)
+                        .build()
+                );
+            }
+        }
+
+        String summaryMessage = "이번 주 평균 섭취량은 권장량의 " + (dailyAvg * 100 / 400) + "% 수준입니다.";
+
+        WeeklyCaffeineReportResponse response = WeeklyCaffeineReportResponse.builder()
+            .filter(WeeklyCaffeineReportResponse.Filter.builder()
+                .year(String.valueOf(year))
+                .month(String.valueOf(month))
+                .week(weekNum + "주차")
+                .build())
+            .isoWeek(isoWeek)
+            .startDate(startDate.toString())
+            .endDate(endDate.toString())
+            .weeklyCaffeineTotal(weeklyTotal)
+            .dailyCaffeineLimit(400)
+            .overLimitDays(overLimitDays)
+            .dailyCaffeineAvg(dailyAvg)
+            .dailyIntakeTotals(dailyIntakeTotals)
+            .summaryMessage(summaryMessage)
+            .build();
+
+        return ResponseEntity.ok(ApiResponse.<com.ktb.cafeboo.domain.report.dto.WeeklyCaffeineReportResponse>builder()
+            .status(200)
+            .code("DAILY_CAFFEINE_REPORT_SUCCESS")
+            .message("주간 카페인 리포트를 성공적으로 조회했습니다.")
+            .data(response)
+            .build());
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/domain/report/dto/DailyCaffeineReportResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/report/dto/DailyCaffeineReportResponse.java
@@ -1,0 +1,27 @@
+package com.ktb.cafeboo.domain.report.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+//import lombok.NoArgsConstructor;  // NoArgsConstructor 제거
+import lombok.AllArgsConstructor;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class DailyCaffeineReportResponse {
+    private String nickname;
+    private float dailyCaffeineLimit;
+    private float dailyCaffeineIntakeMg;
+    private int dailyCaffeineIntakeRate;
+    private String intakeGuide;
+    private float sleepSensitiveThreshold;
+    private List<HourlyCaffeineInfo> caffeineByHour;
+
+    @Getter
+    @AllArgsConstructor
+    public static class HourlyCaffeineInfo {
+        private String time;        // "HH:00" 형식
+        private float caffeineMg;   // 해당 시간의 카페인 잔여량
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/domain/report/dto/WeeklyCaffeineReportResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/report/dto/WeeklyCaffeineReportResponse.java
@@ -1,0 +1,42 @@
+package com.ktb.cafeboo.domain.report.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class WeeklyCaffeineReportResponse {
+    private Filter filter;
+    private String isoWeek;
+    private String startDate;
+    private String endDate;
+    private float weeklyCaffeineTotal;
+    private int dailyCaffeineLimit;
+    private int overLimitDays;
+    private float dailyCaffeineAvg;
+    private List<DailyIntakeTotal> dailyIntakeTotals;
+    private String summaryMessage;
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class Filter {
+        private String year;
+        private String month;
+        private String week;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class DailyIntakeTotal {
+        private String date;
+        private int caffeineMg;
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/domain/report/model/DailyStatistics.java
+++ b/src/main/java/com/ktb/cafeboo/domain/report/model/DailyStatistics.java
@@ -1,0 +1,31 @@
+package com.ktb.cafeboo.domain.report.model;
+
+import com.ktb.cafeboo.domain.drink.model.Cafe;
+import com.ktb.cafeboo.domain.user.model.User;
+import com.ktb.cafeboo.global.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "DailyStatistics")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DailyStatistics extends BaseEntity {
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "weekly_statistics_id", nullable = false)
+    private Long weeklyStatisticsId;
+
+    @Column(name = "date", nullable = false)
+    private LocalDate date;
+
+    @Column(name = "total_caffeine_mg", nullable = false)
+    private Float totalCaffeineMg;
+
+}

--- a/src/main/java/com/ktb/cafeboo/domain/report/model/WeeklyReport.java
+++ b/src/main/java/com/ktb/cafeboo/domain/report/model/WeeklyReport.java
@@ -1,0 +1,44 @@
+package com.ktb.cafeboo.domain.report.model;
+
+import com.ktb.cafeboo.domain.user.model.User;
+import com.ktb.cafeboo.global.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "WeeklyReports")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class WeeklyReport extends BaseEntity {
+
+//    @Column(name = "monthly_statistics_id", nullable = false)
+//    private Long monthlyStatisticsId;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "year", nullable = false)
+    private Integer year;
+
+    @Column(name = "month", nullable = false)
+    private Integer month;
+
+    @Column(name = "week_num", nullable = false)
+    private Integer weekNum;
+
+    @Column(name = "total_caffeine_mg", nullable = false)
+    private Float totalCaffeineMg;
+
+    @Column(name = "daily_caffeine_avg_mg", nullable = false)
+    private Float dailyCaffeineAvgMg;
+
+    @Column(name = "over_intake_days", nullable = false)
+    private Integer overIntakeDays;
+
+    @Column(name = "ai_message")
+    private String aiMessage;
+}

--- a/src/main/java/com/ktb/cafeboo/domain/report/repository/DailyStatisticsRepository.java
+++ b/src/main/java/com/ktb/cafeboo/domain/report/repository/DailyStatisticsRepository.java
@@ -1,0 +1,32 @@
+package com.ktb.cafeboo.domain.report.repository;
+
+import com.ktb.cafeboo.domain.report.model.DailyStatistics;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface DailyStatisticsRepository extends JpaRepository<DailyStatistics, Long> {
+    Optional<DailyStatistics> findByUserIdAndDate(Long userId, LocalDate date);
+
+    // 특정 날짜의 통계 조회
+    Optional<DailyStatistics> findByDate(LocalDate date);
+
+    // 특정 기간의 통계 조회
+    @Query("SELECT ds FROM DailyStatistics ds WHERE ds.date BETWEEN :startDate AND :endDate")
+    List<DailyStatistics> findByDateBetween(
+        @Param("startDate") LocalDate startDate,
+        @Param("endDate") LocalDate endDate
+    );
+
+    // 주간 통계 ID로 조회
+    List<DailyStatistics> findByWeeklyStatisticsId(Long weeklyStatisticsId);
+
+    // 특정 유저의 특정 날짜의 총 카페인 섭취량 조회
+    @Query("SELECT ds.totalCaffeineMg FROM DailyStatistics ds WHERE ds.user.id = :userId AND ds.date = :date")
+    Optional<Float> findTotalCaffeineByDate(@Param("userId") Long userId, @Param("date") LocalDate date);
+
+    List<DailyStatistics> findByUserIdAndDateBetween(Long userId, LocalDate startDate, LocalDate endDate);
+}

--- a/src/main/java/com/ktb/cafeboo/domain/report/repository/WeeklyReportRepository.java
+++ b/src/main/java/com/ktb/cafeboo/domain/report/repository/WeeklyReportRepository.java
@@ -1,0 +1,12 @@
+package com.ktb.cafeboo.domain.report.repository;
+
+import com.ktb.cafeboo.domain.report.model.DailyStatistics;
+import com.ktb.cafeboo.domain.report.model.WeeklyReport;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WeeklyReportRepository extends JpaRepository<WeeklyReport, Long> {
+    Optional<WeeklyReport> findByUserIdAndYearAndWeekNum(Long userId, int year, int weekNum);
+}

--- a/src/main/java/com/ktb/cafeboo/domain/report/service/DailyReportService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/report/service/DailyReportService.java
@@ -1,0 +1,133 @@
+package com.ktb.cafeboo.domain.report.service;
+
+import com.ktb.cafeboo.domain.report.dto.DailyCaffeineReportResponse;
+import com.ktb.cafeboo.domain.report.dto.DailyCaffeineReportResponse.HourlyCaffeineInfo;
+import com.ktb.cafeboo.domain.caffeinediary.model.CaffeineResidual;
+import com.ktb.cafeboo.domain.caffeinediary.service.CaffeineResidualService;
+import com.ktb.cafeboo.domain.user.model.User;
+import com.ktb.cafeboo.domain.user.service.UserService;
+import jakarta.transaction.Transactional;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class DailyReportService {
+
+    private final DailyStatisticsService dailyStatisticsService;
+    private final CaffeineResidualService residualService;
+    private final UserService userService;
+
+    /**
+     * 일일 카페인 리포트를 생성합니다.
+     */
+    public DailyCaffeineReportResponse createDailyReport(Long userId, LocalDate targetDate,
+        LocalTime targetTime) {
+        LocalDateTime currentDateTime = (targetDate != null && targetTime != null) ?
+            LocalDateTime.of(targetDate, targetTime) :
+            LocalDateTime.now();
+
+        // 현재는 더미 유저 데이터 사용
+        User user = userService.findUserById(userId);
+
+        // 일일 총 섭취량 조회
+        float dailyTotal = dailyStatisticsService.getTotalCaffeineForDate(userId, targetDate);
+
+        // 잔여량 데이터 조회
+        List<CaffeineResidual> residuals = residualService.getCaffeineResidualsByTimeRange(user,
+            currentDateTime);
+
+        // 잔여량 데이터 로깅
+        log.info("Caffeine Residuals:");
+        for (CaffeineResidual residual : residuals) {
+            log.info("  Target Date: {}, Target Hour: {}, Residue Amount: {}",
+                residual.getTargetDate(), residual.getHour(), residual.getResidueAmountMg());
+        }
+
+        return DailyCaffeineReportResponse.builder()
+            .nickname(user.getNickname())
+            .dailyCaffeineLimit(400F)
+            .dailyCaffeineIntakeMg(dailyTotal)
+            .dailyCaffeineIntakeRate(calculateIntakeRate(dailyTotal))
+            .intakeGuide(generateIntakeGuide(residuals, currentDateTime))
+            .sleepSensitiveThreshold(100F)
+            .caffeineByHour(createHourlyCaffeineInfo(residuals, currentDateTime))
+            .build();
+    }
+
+    private int calculateIntakeRate(float dailyTotal) {
+        return (int) ((dailyTotal / 400) * 100);
+    }
+
+    private List<HourlyCaffeineInfo> createHourlyCaffeineInfo(
+        List<CaffeineResidual> residuals,
+        LocalDateTime currentDateTime) {
+
+        List<HourlyCaffeineInfo> hourlyInfo = new ArrayList<>();
+        LocalDateTime startTime = currentDateTime.minusHours(17).withMinute(0).withSecond(0).withNano(0);;
+        DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:00");
+
+        for (CaffeineResidual residual : residuals) {
+            float caffeineMg = calculateCaffeineForHour(residual, startTime);
+            String timeInfo = timeFormatter.format(startTime);
+            hourlyInfo.add(new HourlyCaffeineInfo(timeInfo, caffeineMg));
+            startTime = startTime.plusHours(1);
+        }
+        return hourlyInfo;
+    }
+
+    private float calculateCaffeineForHour(CaffeineResidual residual,
+        LocalDateTime timePoint) {
+        float totalCaffeine = 0f;
+        int count = 0;
+
+        LocalDateTime residualTime = residual.getTargetDate().plusHours(residual.getHour());
+        log.info("residualTime : {}, timePoint : {}\n", residualTime, timePoint);
+        // 시간 비교를 단순화: 년, 월, 일, 시간 비교
+        if (residualTime.isEqual(timePoint)) {
+            log.info("Matching residual: timePoint={}, residualTime={}, amount={}", timePoint,
+                residualTime, residual.getResidueAmountMg());
+            totalCaffeine += residual.getResidueAmountMg();
+            count++;
+        } else {
+            log.info("Not Matching residual: timePoint={}, residualTime={}, amount={}", timePoint,
+                residualTime, residual.getResidueAmountMg());
+        }
+        return count > 0 ? totalCaffeine / count : 0f;
+    }
+
+    private String generateIntakeGuide(List<CaffeineResidual> residuals,
+        LocalDateTime currentTime) {
+        float currentResidual = getCurrentResidualAmount(residuals, currentTime);
+        return createGuideMessage(currentResidual);
+    }
+
+    private float getCurrentResidualAmount(List<CaffeineResidual> residuals,
+        LocalDateTime currentTime) {
+        return residuals.stream()
+            .filter(r -> !r.getTargetDate().isAfter(currentTime))
+            .max(Comparator.comparing(CaffeineResidual::getTargetDate))
+            .map(CaffeineResidual::getResidueAmountMg)
+            .orElse(0f);
+    }
+
+
+    private String createGuideMessage(float currentResidual) {
+        if (currentResidual > 100) {
+            return "지금 커피를 추가로 마시면 수면에 영향을 줄 수 있어요.";
+        } else if (currentResidual > 50) {
+            return "커피를 마시더라도 수면에는 크게 영향이 없을 것 같아요.";
+        }
+        return "지금은 커피를 마시기 좋은 시간이에요.";
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/domain/report/service/DailyStatisticsService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/report/service/DailyStatisticsService.java
@@ -1,0 +1,165 @@
+package com.ktb.cafeboo.domain.report.service;
+
+import com.ktb.cafeboo.domain.caffeinediary.model.CaffeineResidual;
+import com.ktb.cafeboo.domain.caffeinediary.repository.CaffeineResidualRepository;
+import com.ktb.cafeboo.domain.report.model.DailyStatistics;
+import com.ktb.cafeboo.domain.report.model.WeeklyReport;
+import com.ktb.cafeboo.domain.report.repository.DailyStatisticsRepository;
+import com.ktb.cafeboo.domain.user.model.User;
+import jakarta.transaction.Transactional;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.IsoFields;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class DailyStatisticsService {
+
+    private final DailyStatisticsRepository dailyStatisticsRepository;
+    private final CaffeineResidualRepository caffeineResidualRepository;
+
+    private final WeeklyReportService weeklyReportService;
+
+    private static final int HOURS_RANGE = 17; // 기준 시간 전 후 17시간
+
+    /**
+     * ISO 8601 기준으로 주차 ID를 생성합니다.
+     * 형식: YYYYWW (예: 202411 - 2024년 11주차)
+     */
+    private Long calculateWeeklyStatisticsId(LocalDate date) {
+        int year = date.get(IsoFields.WEEK_BASED_YEAR);
+        int weekOfYear = date.get(IsoFields.WEEK_OF_WEEK_BASED_YEAR);
+
+        // YYYYWW 형식으로 ID 생성 (예: 202411)
+        return Long.valueOf(String.format("%d%02d", year, weekOfYear));
+    }
+
+    /**
+     * 일일 통계 데이터를 갱신합니다. 섭취 내역이 추가됨에 따라 일일 섭취 카페인 수치를 갱신합니다.
+     * @param user 일일 통계를 기록할 유저 정보
+     * @param date 섭취 내역을 등록/수정한 시점의 연-월-일 정보
+     * @param additionalCaffeine 섭취 내역이 추가/변경됨에 따라 변경될 카페인 수치
+     */
+    public void updateDailyStatistics(User user, LocalDate date, float additionalCaffeine) {
+        DailyStatistics statistics = dailyStatisticsRepository
+            .findByUserIdAndDate(user.getId(), date)
+            .orElseGet(() -> createDailyStatistics(user, date));
+
+        statistics.setTotalCaffeineMg(statistics.getTotalCaffeineMg() + additionalCaffeine);
+        DailyStatistics savedStatistics = dailyStatisticsRepository.save(statistics);
+
+//        WeeklyReport weeklyReport = weeklyReportService.getOrCreateWeeklyReport(user, date);
+//        weeklyReportService.updateWeeklyReport(weeklyReport, getUserDailyLimit(userId));
+    }
+
+    /**
+     * 일일 통계 데이터를 생성합니다.
+     * @param user 일일 통계를 기록할 유저 정보
+     * @param date 섭취 내역을 등록한 시점의 연-월-일 정보
+     */
+    private DailyStatistics createDailyStatistics(User user, LocalDate date) {
+        //해당 날짜가 속한 주의 정보를 가져옴. 없는 경우 새롭게 생성 후 WeeklyReport 테이블에 저장.
+        WeeklyReport weeklyReport = weeklyReportService.getOrCreateWeeklyReport(user, date);
+
+        //일일 통계 데이터를 반환
+        return DailyStatistics.builder()
+            .user(user)
+            .date(date)
+            .totalCaffeineMg(0f)
+            .weeklyStatisticsId(weeklyReport.getId())
+            .build();
+    }
+
+    /**
+     * 특정 날짜의 총 카페인 섭취량을 조회합니다.
+     *
+     * @param date 조회할 날짜
+     * @return 총 카페인 섭취량 (mg)
+     */
+    public float getTotalCaffeineForDate(LocalDate date) {
+        return dailyStatisticsRepository.findTotalCaffeineByDate(date)
+            .orElse(0f);
+    }
+
+    /**
+     * 현재 시간 기준 전후 35시간의 카페인 잔존량 데이터를 조회합니다.
+     *
+     * @param user 조회할 사용자
+     * @param currentDateTime 현재 시간
+     * @return 35시간 범위의 카페인 잔존량 데이터
+     */
+    public List<CaffeineResidual> getCaffeineResidualsByTimeRange(
+        User user,
+        LocalDateTime currentDateTime) {
+
+        LocalDate currentDate = currentDateTime.toLocalDate();
+        LocalDate previousDate = currentDate.minusDays(1);
+        LocalDate nextDate = currentDate.plusDays(1);
+
+        int currentHour = currentDateTime.getHour();
+
+        // 이전 날짜의 시작 시간 계산
+        int previousStartHour = (currentHour + 24 - HOURS_RANGE) % 24;
+        // 다음 날짜의 종료 시간 계산
+        int nextEndHour = (currentHour + HOURS_RANGE) % 24;
+
+        return caffeineResidualRepository.findResidualsByTimeRange(
+            user,
+            previousDate,
+            currentDate,
+            nextDate,
+            previousStartHour,
+            nextEndHour
+        );
+    }
+
+    /**
+     * 조회된 데이터를 시간별로 변환합니다.
+     */
+    public List<HourlyResidualData> convertToHourlyData(
+        List<CaffeineResidual> residuals,
+        LocalDateTime currentDateTime) {
+
+        List<HourlyResidualData> result = new ArrayList<>();
+        LocalDateTime startTime = currentDateTime.minusHours(HOURS_RANGE);
+
+        // 총 35시간(이전 17시간 + 현재 1시간 + 이후 17시간)의 데이터 생성
+        for (int i = 0; i < (HOURS_RANGE * 2 + 1); i++) {
+            LocalDateTime targetDateTime = startTime.plusHours(i);
+            LocalDate targetDate = targetDateTime.toLocalDate();
+            int targetHour = targetDateTime.getHour();
+
+            // 해당 시간의 잔존량 찾기
+            float residualAmount = residuals.stream()
+                .filter(r -> r.getTargetDate().equals(targetDate) && r.getHour() == targetHour)
+                .findFirst()
+                .map(CaffeineResidual::getResidueAmountMg)
+                .orElse(0f);
+
+            result.add(new HourlyResidualData(targetDateTime, residualAmount));
+        }
+
+        return result;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class HourlyResidualData {
+        private LocalDateTime dateTime;
+        private float residualAmount;
+
+        public String getFormattedDateTime() {
+            return dateTime.format(DateTimeFormatter.ofPattern("HH"));
+        }
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/domain/report/service/WeeklyReportService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/report/service/WeeklyReportService.java
@@ -1,0 +1,65 @@
+package com.ktb.cafeboo.domain.report.service;
+
+import com.ktb.cafeboo.domain.report.model.WeeklyReport;
+import com.ktb.cafeboo.domain.report.repository.DailyStatisticsRepository;
+import com.ktb.cafeboo.domain.report.repository.WeeklyReportRepository;
+import com.ktb.cafeboo.domain.user.model.User;
+import com.ktb.cafeboo.domain.user.service.UserService;
+import java.time.LocalDate;
+import java.time.temporal.IsoFields;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class WeeklyReportService {
+
+    private final WeeklyReportRepository weeklyReportRepository;
+    private final UserService userService;
+
+    public WeeklyReport getWeeklyReport(Long userId, LocalDate date) {
+        int year = date.get(IsoFields.WEEK_BASED_YEAR);
+        int weekNum = date.get(IsoFields.WEEK_OF_WEEK_BASED_YEAR);
+        int month = date.getMonthValue();
+
+        return weeklyReportRepository
+            .findByUserIdAndYearAndWeekNum(userId, year, weekNum)
+            .orElseGet(() -> {
+                User user = userService.findUserById(userId);
+                WeeklyReport weeklyReport = WeeklyReport.builder()
+                    .user(user)
+                    .year(year)
+                    .month(month)
+                    .weekNum(weekNum)
+                    .totalCaffeineMg(0f)
+                    .dailyCaffeineAvgMg(0f)
+                    .overIntakeDays(0)
+                    .build();
+
+                // 새로 생성한 WeeklyReport를 데이터베이스에 저장
+                return weeklyReportRepository.save(weeklyReport);
+            });
+    }
+
+    public void updateWeeklyReport(Long userId, WeeklyReport weeklyReport, Float additionalCaffeine){
+        User user = userService.findUserById(userId);
+
+        // 2. 주간 리포트의 총 카페인 섭취량 업데이트
+        float newTotalCaffeine = weeklyReport.getTotalCaffeineMg() + additionalCaffeine;
+        weeklyReport.setTotalCaffeineMg(newTotalCaffeine);
+
+        // 3. 일일 평균 카페인 섭취량 계산 (7일로 나눔)
+        float dailyAverage = newTotalCaffeine / 7.0f;
+        weeklyReport.setDailyCaffeineAvgMg(dailyAverage);
+
+        // 4. 허용치 초과 여부 판단 및 overIntakeDays 증가
+        Float caffeineLimit = 400F; //
+        if (dailyAverage > caffeineLimit) {
+            // 기존 overIntakeDays 값이 null일 수 있으니 0으로 처리
+            int overIntakeDays = weeklyReport.getOverIntakeDays() != null ? weeklyReport.getOverIntakeDays() : 0;
+            weeklyReport.setOverIntakeDays(overIntakeDays + 1);
+        }
+
+        weeklyReportRepository.save(weeklyReport);
+    }
+}


### PR DESCRIPTION
# 📌 Pull Request

## 🔗 관련 이슈
- https://github.com/100-hours-a-week/13-Cafeboo-BE/pull/16

## ✨ 작업한 내용
- [x] 단일 책임 원칙을 고려한 Service 로직 분리
- [x] 일간, 주간 카페인 리포트 조회 기능 구현 
- [x] 특정 엔티티 및 서비스 로직의 리팩토링

## 🛠 변경사항
- DailyStatistics Service에서 잔존량과 관련된 부분을 담당하는 Caffeine Residual Service를 분리했습니다.
- /api/v1/reports/daily, /api/v1/reports/weekly API을 담당하는 Controller 부분을 구현했습니다. 
- Drink 엔티티, CaffeineIntakeController 서비스 기획에 맞게 리팩토링 진행.

## 💬 리뷰 요구사항
- 각 기능 별로 흐름 위주로 체크 해주세요.
- API Response의 경우 작업하던 branch에 대면을 통해 정했던 양식이 반영되어 있지 않은 상태라 merge 진행 후 새로운 branch 파서 수정 진행하겠습니다. 

## 🔍 테스트 방법
- Postman을 활용한 수동 API 호출 및 결과 체크 진행
