### PR TITLE
CustomApiException 및 ApiExceptionHandler 구현을 통한 예외 응답 통일

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/auth/controller/AuthController.java
@@ -4,6 +4,8 @@ import com.ktb.cafeboo.domain.auth.dto.KakaoLoginRequest;
 import com.ktb.cafeboo.domain.auth.dto.KakaoLoginResponse;
 import com.ktb.cafeboo.domain.auth.service.KakaoOauthService;
 import com.ktb.cafeboo.global.apiPayload.ApiResponse;
+import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
+import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
@@ -22,14 +24,13 @@ public class AuthController {
     private final KakaoOauthService kakaoOauthService;
 
     @PostMapping("/oauth")
-    public ResponseEntity<Void> redirectToOauth(@RequestParam("type") String type) {
-        String redirectUrl;
+    public ResponseEntity<ApiResponse<String>> redirectToOauth(@RequestParam("type") String type) {
 
-        if ("kakao".equalsIgnoreCase(type)) {
-            redirectUrl = kakaoOauthService.buildKakaoAuthorizationUrl();
-        } else {
-            throw new IllegalArgumentException("지원하지 않는 소셜 로그인 타입입니다.");
+        if (!"kakao".equalsIgnoreCase(type)) {
+            throw new CustomApiException(ErrorStatus.UNSUPPORTED_SOCIAL_LOGIN_TYPE);
         }
+
+        String redirectUrl = kakaoOauthService.buildKakaoAuthorizationUrl();
 
         HttpHeaders headers = new HttpHeaders();
         headers.setLocation(URI.create(redirectUrl));

--- a/src/main/java/com/ktb/cafeboo/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/auth/controller/AuthController.java
@@ -39,6 +39,6 @@ public class AuthController {
     @PostMapping("/kakao")
     public ResponseEntity<ApiResponse<KakaoLoginResponse>> kakaoLogin(@RequestBody KakaoLoginRequest request) {
         KakaoLoginResponse loginResponse = kakaoOauthService.login(request.getCode());
-        return ResponseEntity.ok(ApiResponse.success(200,"LOGIN_SUCCESS", "로그인 성공", loginResponse));
+        return ResponseEntity.ok(ApiResponse.onSuccess(loginResponse));
     }
 }

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/ApiResponse.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/ApiResponse.java
@@ -1,6 +1,5 @@
 package com.ktb.cafeboo.global.apiPayload;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.ktb.cafeboo.global.apiPayload.code.BaseCode;
 import com.ktb.cafeboo.global.apiPayload.code.status.SuccessStatus;

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/ApiResponse.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/ApiResponse.java
@@ -19,21 +19,21 @@ public class ApiResponse<T> {
     private T data;
 
     // 성공 응답
-    public static <T> ApiResponse<T> onSuccess(T result) {
+    public static <T> ApiResponse<T> onSuccess(T data) {
         return new ApiResponse<>(
                 SuccessStatus.OK.getStatus(),
                 SuccessStatus.OK.getCode(),
                 SuccessStatus.OK.getMessage(),
-                result
+                data
         );
     }
 
-    public static <T> ApiResponse<T> of(BaseCode code, T result) {
+    public static <T> ApiResponse<T> of(BaseCode code, T data) {
         return new ApiResponse<>(
                 code.getStatus(),
                 code.getCode(),
                 code.getMessage(),
-                result
+                data
         );
     }
 

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/ErrorStatus.java
@@ -8,11 +8,16 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ErrorStatus implements BaseCode {
 
+    // 기본 오류
     BAD_REQUEST(400, "BAD_REQUEST", "잘못된 요청입니다."),
     UNAUTHORIZED(401, "UNAUTHORIZED", "인증이 필요합니다."),
     FORBIDDEN(403, "FORBIDDEN", "접근 권한이 없습니다."),
     NOT_FOUND(404, "NOT_FOUND", "요청한 리소스를 찾을 수 없습니다."),
-    INTERNAL_SERVER_ERROR(500, "INTERNAL_ERROR", "서버 내부 오류가 발생했습니다.");
+    INTERNAL_SERVER_ERROR(500, "INTERNAL_ERROR", "서버 내부 오류가 발생했습니다."),
+
+    // auth 도메인 관련 오류
+    UNSUPPORTED_SOCIAL_LOGIN_TYPE(400, "UNSUPPORTED_SOCIAL_LOGIN_TYPE", "지원하지 않는 소셜 로그인 타입입니다.");
+
 
     private final int status;
     private final String code;

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/exception/ApiExceptionHandler.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/exception/ApiExceptionHandler.java
@@ -1,0 +1,28 @@
+package com.ktb.cafeboo.global.apiPayload.exception;
+
+import com.ktb.cafeboo.global.apiPayload.ApiResponse;
+import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
+import com.ktb.cafeboo.global.apiPayload.code.BaseCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ApiExceptionHandler {
+    // 기본 서버 오류
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleGenericException(Exception ex) {
+        return ResponseEntity
+                .status(ErrorStatus.INTERNAL_SERVER_ERROR.getStatus())
+                .body(ApiResponse.onFailure(ErrorStatus.INTERNAL_SERVER_ERROR));
+    }
+
+    @ExceptionHandler(CustomApiException.class)
+    public ResponseEntity<ApiResponse<Void>> handleCustomApiException(CustomApiException ex) {
+        BaseCode error = ex.getErrorCode();
+        return ResponseEntity
+                .status(error.getStatus())
+                .body(ApiResponse.onFailure(error));
+    }
+
+}

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/exception/CustomApiException.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/exception/CustomApiException.java
@@ -1,0 +1,14 @@
+package com.ktb.cafeboo.global.apiPayload.exception;
+
+import com.ktb.cafeboo.global.apiPayload.code.BaseCode;
+import lombok.Getter;
+
+@Getter
+public class CustomApiException extends RuntimeException {
+    private final BaseCode errorCode;
+
+    public CustomApiException(BaseCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] BaseCode 기반 커스텀 예외 클래스 CustomApiException 추가
- [x] ApiExceptionHandler 구현

## 🛠 변경사항
- 컨트롤러, 서비스 등 비즈니스 로직 상에서 에서 try-catch 없이 예외만 던지면 일관된 JSON 구조로 예외 응답 반환

## 💬 리뷰 요구사항
- 예외응답 관리를 위한 exception handler 추가하였습니다.
- 예시로 AuthController에서 지원하지 않는 소셜 타입 오류를 반환하는 부분 참고하시면 좋을 것 같습니다.

## 🔍 테스트 방법(선택)
- postman으로 정상 예외 응답 생성 확인
