### PR TITLE
♻️refactor: 인증된 사용자 정보 추출 시 @AuthenticationPrincipal 적용

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/auth/controller/AuthController.java
@@ -9,11 +9,13 @@ import com.ktb.cafeboo.global.apiPayload.ApiResponse;
 import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
 import com.ktb.cafeboo.global.apiPayload.code.status.SuccessStatus;
 import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
+import com.ktb.cafeboo.global.security.userdetails.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
@@ -57,12 +59,9 @@ public class AuthController {
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<Void> logout(
-            @RequestHeader("Authorization") String authorizationHeader) {
-
-        String accessToken = authorizationHeader.replace("Bearer ", "");
-        authService.logout(accessToken);
-
+    public ResponseEntity<Void> logout(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = userDetails.getUserId();
+        authService.logout(userId);
         return ResponseEntity.noContent().build(); // 204 No Content
     }
 }

--- a/src/main/java/com/ktb/cafeboo/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/auth/service/AuthService.java
@@ -37,11 +37,8 @@ public class AuthService {
     }
 
     @Transactional
-    public void logout(String accessToken) {
-        String userId = jwtProvider.validateAccessToken(accessToken);
-
-        Long userIdLong = Long.parseLong(userId);
-        User user = userRepository.findById(userIdLong)
+    public void logout(Long userId) {
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomApiException(ErrorStatus.USER_NOT_FOUND));
 
         user.updateRefreshToken(null);

--- a/src/main/java/com/ktb/cafeboo/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ktb/cafeboo/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,59 @@
+package com.ktb.cafeboo.global.security;
+
+import com.ktb.cafeboo.domain.user.model.User;
+import com.ktb.cafeboo.domain.user.repository.UserRepository;
+import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
+import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
+import com.ktb.cafeboo.global.security.userdetails.CustomUserDetails;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+    private final UserRepository userRepository;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        String authorizationHeader = request.getHeader("Authorization");
+
+        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+            String accessToken = authorizationHeader.replace("Bearer ", "");
+
+            try {
+                String userId = jwtProvider.validateAccessToken(accessToken);
+                Long userIdLong = Long.parseLong(userId);
+
+                User user = userRepository.findById(userIdLong)
+                        .orElseThrow(() -> new CustomApiException(ErrorStatus.USER_NOT_FOUND));
+
+                CustomUserDetails userDetails = new CustomUserDetails(user);
+
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+
+            } catch (CustomApiException e) {
+                logger.warn("[JWT 인증 실패] " + e.getErrorCode().getCode() + ": " + e.getMessage());
+                // 인증 실패: SecurityContext는 설정하지 않음
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/global/security/userdetails/CustomUserDetails.java
+++ b/src/main/java/com/ktb/cafeboo/global/security/userdetails/CustomUserDetails.java
@@ -1,0 +1,39 @@
+package com.ktb.cafeboo.global.security.userdetails;
+
+import com.ktb.cafeboo.domain.user.model.User;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+public class CustomUserDetails implements UserDetails {
+
+    private final Long id;
+    private final String role;
+
+    public CustomUserDetails(User user) {
+        this.id = user.getId();
+        this.role = user.getRole().name();
+    }
+
+    public Long getUserId() {
+        return id;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_" + role));
+    }
+
+    @Override public String getUsername() { return String.valueOf(id); }
+    @Override public String getPassword() { return null; } // 비밀번호 인증 안 씀
+    @Override public boolean isAccountNonExpired() { return true; }
+    @Override public boolean isAccountNonLocked() { return true; }
+    @Override public boolean isCredentialsNonExpired() { return true; }
+    @Override public boolean isEnabled() { return true; }
+}
+


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x]  CustomUserDetails 클래스 작성
- [x] JwtAuthenticationFilter 클래스 작성
- [x] 컨트롤러 유저 인증 정보 조회 로직 수정 

## 🛠 변경사항
  - 로그아웃 등 accessToken 기반 인증 API에서 Authorization 헤더 직접 파싱 대신 Spring Security의 @AuthenticationPrincipal 기반 CustomUserDetails 사용
  - 인증된 사용자 ID를 안전하게 접근하도록 서비스 로직 개선

## 💬 리뷰 요구사항
- AuthController에 로그아웃 api 에서 유저 인증 정보 조회해오는 로직 확인해주세요!

