### PR TITLE
✨ feat: 유저 건강 프로필 CRU API 개발

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/user/controller/UserController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/controller/UserController.java
@@ -1,14 +1,13 @@
 package com.ktb.cafeboo.domain.user.controller;
 
-import com.ktb.cafeboo.domain.user.dto.EmailDuplicationResponse;
-import com.ktb.cafeboo.domain.user.dto.UserHealthInfoCreateRequest;
-import com.ktb.cafeboo.domain.user.dto.UserHealthInfoCreateResponse;
+import com.ktb.cafeboo.domain.user.dto.*;
 import com.ktb.cafeboo.domain.user.service.UserHealthInfoService;
 import com.ktb.cafeboo.domain.user.service.UserService;
 import com.ktb.cafeboo.global.apiPayload.ApiResponse;
 import com.ktb.cafeboo.global.apiPayload.code.status.*;
 import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
 import com.ktb.cafeboo.global.security.userdetails.CustomUserDetails;
+import com.ktb.cafeboo.global.util.AuthChecker;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -37,11 +36,21 @@ public class UserController {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody UserHealthInfoCreateRequest request
     ) {
-        if (!userId.equals(userDetails.getUserId())) {
-            throw new CustomApiException(ErrorStatus.ACCESS_DENIED);
-        }
+        AuthChecker.checkOwnership(userId, userDetails.getUserId());
 
         UserHealthInfoCreateResponse response = userHealthInfoService.create(userId, request);
         return ResponseEntity.ok(ApiResponse.of(SuccessStatus.HEALTH_PROFILE_CREATION_SUCCESS, response));
+    }
+
+    @PatchMapping("/{userId}/health")
+    public ResponseEntity<ApiResponse<UserHealthInfoUpdateResponse>> updateHealthInfo(
+            @PathVariable Long userId,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody UserHealthInfoUpdateRequest request
+    ) {
+        AuthChecker.checkOwnership(userId, userDetails.getUserId());
+
+        UserHealthInfoUpdateResponse response = userHealthInfoService.update(userId, request);
+        return ResponseEntity.ok(ApiResponse.of(SuccessStatus.HEALTH_PROFILE_UPDATE_SUCCESS, response));
     }
 }

--- a/src/main/java/com/ktb/cafeboo/domain/user/controller/UserController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/controller/UserController.java
@@ -1,27 +1,47 @@
 package com.ktb.cafeboo.domain.user.controller;
 
 import com.ktb.cafeboo.domain.user.dto.EmailDuplicationResponse;
+import com.ktb.cafeboo.domain.user.dto.UserHealthInfoCreateRequest;
+import com.ktb.cafeboo.domain.user.dto.UserHealthInfoCreateResponse;
+import com.ktb.cafeboo.domain.user.service.UserHealthInfoService;
 import com.ktb.cafeboo.domain.user.service.UserService;
 import com.ktb.cafeboo.global.apiPayload.ApiResponse;
-import com.ktb.cafeboo.global.apiPayload.code.status.SuccessStatus;
+import com.ktb.cafeboo.global.apiPayload.code.status.*;
+import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
+import com.ktb.cafeboo.global.security.userdetails.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
 public class UserController {
 
     private final UserService userService;
+    private final UserHealthInfoService userHealthInfoService;
 
     @GetMapping("/email")
     public ResponseEntity<ApiResponse<EmailDuplicationResponse>> checkEmailDuplication(
             @RequestParam String email) {
         EmailDuplicationResponse response = userService.isEmailDuplicated(email);
         return ResponseEntity.ok(ApiResponse.of(SuccessStatus.EMAIL_DUPLICATION_CHECK_SUCCESS, response));
+    }
+
+    @PostMapping("/{userId}/health")
+    public ResponseEntity<ApiResponse<UserHealthInfoCreateResponse>> createHealthInfo(
+            @PathVariable Long userId,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody UserHealthInfoCreateRequest request
+    ) {
+        if (!userId.equals(userDetails.getUserId())) {
+            throw new CustomApiException(ErrorStatus.ACCESS_DENIED);
+        }
+
+        UserHealthInfoCreateResponse response = userHealthInfoService.create(userId, request);
+        return ResponseEntity.ok(ApiResponse.of(SuccessStatus.HEALTH_PROFILE_CREATION_SUCCESS, response));
     }
 }

--- a/src/main/java/com/ktb/cafeboo/domain/user/controller/UserController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/controller/UserController.java
@@ -53,4 +53,15 @@ public class UserController {
         UserHealthInfoUpdateResponse response = userHealthInfoService.update(userId, request);
         return ResponseEntity.ok(ApiResponse.of(SuccessStatus.HEALTH_PROFILE_UPDATE_SUCCESS, response));
     }
+
+    @GetMapping("/{userId}/health")
+    public ResponseEntity<ApiResponse<UserHealthInfoResponse>> getHealthInfo(
+            @PathVariable Long userId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        AuthChecker.checkOwnership(userId, userDetails.getUserId());
+
+        UserHealthInfoResponse response = userHealthInfoService.getHealthInfo(userId);
+        return ResponseEntity.ok(ApiResponse.of(SuccessStatus.HEALTH_PROFILE_FETCH_SUCCESS, response));
+    }
 }

--- a/src/main/java/com/ktb/cafeboo/domain/user/dto/UserHealthInfoCreateRequest.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/dto/UserHealthInfoCreateRequest.java
@@ -30,7 +30,6 @@ public class UserHealthInfoCreateRequest {
 
     @JsonProperty("wakeUpTime")
     private String wakeUpTime;
-
 }
 
 

--- a/src/main/java/com/ktb/cafeboo/domain/user/dto/UserHealthInfoCreateRequest.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/dto/UserHealthInfoCreateRequest.java
@@ -1,0 +1,36 @@
+package com.ktb.cafeboo.domain.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UserHealthInfoCreateRequest {
+
+    private String gender;
+    private int age;
+    private float height;
+    private float weight;
+
+    @JsonProperty("isPregnant")
+    private Boolean pregnant;
+
+    @JsonProperty("isTakingBirthPill")
+    private Boolean takingBirthPill;
+
+    @JsonProperty("isSmoking")
+    private Boolean smoking;
+
+    @JsonProperty("hasLiverDisease")
+    private Boolean hasLiverDisease;
+
+    @JsonProperty("sleepTime")
+    private String sleepTime;
+
+    @JsonProperty("wakeUpTime")
+    private String wakeUpTime;
+
+}
+
+

--- a/src/main/java/com/ktb/cafeboo/domain/user/dto/UserHealthInfoCreateResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/dto/UserHealthInfoCreateResponse.java
@@ -1,0 +1,13 @@
+package com.ktb.cafeboo.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class UserHealthInfoCreateResponse {
+    private Long userId;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/ktb/cafeboo/domain/user/dto/UserHealthInfoResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/dto/UserHealthInfoResponse.java
@@ -1,0 +1,23 @@
+package com.ktb.cafeboo.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class UserHealthInfoResponse {
+    private String gender;
+    private int age;
+    private float height;
+    private float weight;
+    private boolean isPregnant;
+    private boolean isTakingBirthPill;
+    private boolean isSmoking;
+    private boolean hasLiverDisease;
+    private String sleepTime;
+    private String wakeUpTime;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/ktb/cafeboo/domain/user/dto/UserHealthInfoUpdateRequest.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/dto/UserHealthInfoUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.ktb.cafeboo.domain.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UserHealthInfoUpdateRequest {
+    private String gender;
+    private Integer age;
+    private Float height;
+    private Float weight;
+    private String isPregnant;
+    private String isTakingBirthPill;
+    private String isSmoking;
+    private String hasLiverDisease;
+    private String sleepTime;
+    private String wakeUpTime;
+}

--- a/src/main/java/com/ktb/cafeboo/domain/user/dto/UserHealthInfoUpdateRequest.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/dto/UserHealthInfoUpdateRequest.java
@@ -1,17 +1,33 @@
 package com.ktb.cafeboo.domain.user.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@Setter
 public class UserHealthInfoUpdateRequest {
     private String gender;
     private Integer age;
     private Float height;
     private Float weight;
-    private String isPregnant;
-    private String isTakingBirthPill;
-    private String isSmoking;
-    private String hasLiverDisease;
+
+    @JsonProperty("isPregnant")
+    private Boolean pregnant;
+
+    @JsonProperty("isTakingBirthPill")
+    private Boolean takingBirthPill;
+
+    @JsonProperty("isSmoking")
+    private Boolean smoking;
+
+    @JsonProperty("hasLiverDisease")
+    private Boolean hasLiverDisease;
+
+    @JsonProperty("sleepTime")
     private String sleepTime;
+
+    @JsonProperty("wakeUpTime")
     private String wakeUpTime;
 }
+

--- a/src/main/java/com/ktb/cafeboo/domain/user/dto/UserHealthInfoUpdateResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/dto/UserHealthInfoUpdateResponse.java
@@ -1,0 +1,13 @@
+package com.ktb.cafeboo.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class UserHealthInfoUpdateResponse {
+    private Long userId;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/ktb/cafeboo/domain/user/dto/UserProfileResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/dto/UserProfileResponse.java
@@ -1,0 +1,14 @@
+package com.ktb.cafeboo.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserProfileResponse {
+    private String nickname;
+    private int dailyCaffeineLimitMg;
+    private int coffeeBean;
+    private int challengeCount;
+}
+

--- a/src/main/java/com/ktb/cafeboo/domain/user/mapper/UserHealthInfoMapper.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/mapper/UserHealthInfoMapper.java
@@ -1,6 +1,7 @@
 package com.ktb.cafeboo.domain.user.mapper;
 
 import com.ktb.cafeboo.domain.user.dto.UserHealthInfoCreateRequest;
+import com.ktb.cafeboo.domain.user.dto.UserHealthInfoResponse;
 import com.ktb.cafeboo.domain.user.dto.UserHealthInfoUpdateRequest;
 import com.ktb.cafeboo.domain.user.model.User;
 import com.ktb.cafeboo.domain.user.model.UserHealthInfo;
@@ -38,5 +39,22 @@ public class UserHealthInfoMapper {
         if (dto.getHasLiverDisease() != null) entity.setHasLiverDisease(dto.getHasLiverDisease());
         if (dto.getSleepTime() != null) entity.setSleepTime(LocalTime.parse(dto.getSleepTime()));
         if (dto.getWakeUpTime() != null) entity.setWakeUpTime(LocalTime.parse(dto.getWakeUpTime()));
+    }
+
+    public static UserHealthInfoResponse toResponse(UserHealthInfo entity) {
+        return UserHealthInfoResponse.builder()
+                .gender(entity.getGender())
+                .age(entity.getAge())
+                .height(entity.getHeight())
+                .weight(entity.getWeight())
+                .isPregnant(entity.getPregnant())
+                .isTakingBirthPill(entity.getTakingBirthPill())
+                .isSmoking(entity.getSmoking())
+                .hasLiverDisease(entity.getHasLiverDisease())
+                .sleepTime(entity.getSleepTime().toString())
+                .wakeUpTime(entity.getWakeUpTime().toString())
+                .createdAt(entity.getCreatedAt())
+                .updatedAt(entity.getUpdatedAt())
+                .build();
     }
 }

--- a/src/main/java/com/ktb/cafeboo/domain/user/mapper/UserHealthInfoMapper.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/mapper/UserHealthInfoMapper.java
@@ -1,0 +1,28 @@
+package com.ktb.cafeboo.domain.user.mapper;
+
+import com.ktb.cafeboo.domain.user.dto.UserHealthInfoCreateRequest;
+import com.ktb.cafeboo.domain.user.model.User;
+import com.ktb.cafeboo.domain.user.model.UserHealthInfo;
+
+import java.time.LocalTime;
+
+public class UserHealthInfoMapper {
+
+    public static UserHealthInfo toEntity(UserHealthInfoCreateRequest dto, User user) {
+
+        UserHealthInfo entity = new UserHealthInfo();
+        entity.setUser(user);
+        entity.setGender(dto.getGender());
+        entity.setAge(dto.getAge());
+        entity.setHeight(dto.getHeight());
+        entity.setWeight(dto.getWeight());
+        entity.setPregnant(dto.getPregnant());
+        entity.setTakingBirthPill(dto.getTakingBirthPill());
+        entity.setSmoking(dto.getSmoking());
+        entity.setHasLiverDisease(dto.getHasLiverDisease());
+        entity.setSleepTime(LocalTime.parse(dto.getSleepTime()));
+        entity.setWakeUpTime(LocalTime.parse(dto.getWakeUpTime()));
+
+        return entity;
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/domain/user/mapper/UserHealthInfoMapper.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/mapper/UserHealthInfoMapper.java
@@ -1,6 +1,7 @@
 package com.ktb.cafeboo.domain.user.mapper;
 
 import com.ktb.cafeboo.domain.user.dto.UserHealthInfoCreateRequest;
+import com.ktb.cafeboo.domain.user.dto.UserHealthInfoUpdateRequest;
 import com.ktb.cafeboo.domain.user.model.User;
 import com.ktb.cafeboo.domain.user.model.UserHealthInfo;
 
@@ -8,7 +9,7 @@ import java.time.LocalTime;
 
 public class UserHealthInfoMapper {
 
-    public static UserHealthInfo toEntity(UserHealthInfoCreateRequest dto, User user) {
+    public static UserHealthInfo createEntity(UserHealthInfoCreateRequest dto, User user) {
 
         UserHealthInfo entity = new UserHealthInfo();
         entity.setUser(user);
@@ -24,5 +25,18 @@ public class UserHealthInfoMapper {
         entity.setWakeUpTime(LocalTime.parse(dto.getWakeUpTime()));
 
         return entity;
+    }
+
+    public static void updateEntity(UserHealthInfo entity, UserHealthInfoUpdateRequest dto) {
+        if (dto.getGender() != null) entity.setGender(dto.getGender());
+        if (dto.getAge() != null) entity.setAge(dto.getAge());
+        if (dto.getHeight() != null) entity.setHeight(dto.getHeight());
+        if (dto.getWeight() != null) entity.setWeight(dto.getWeight());
+        if (dto.getPregnant() != null) entity.setPregnant(dto.getPregnant());
+        if (dto.getTakingBirthPill() != null) entity.setTakingBirthPill(dto.getTakingBirthPill());
+        if (dto.getSmoking() != null) entity.setSmoking(dto.getSmoking());
+        if (dto.getHasLiverDisease() != null) entity.setHasLiverDisease(dto.getHasLiverDisease());
+        if (dto.getSleepTime() != null) entity.setSleepTime(LocalTime.parse(dto.getSleepTime()));
+        if (dto.getWakeUpTime() != null) entity.setWakeUpTime(LocalTime.parse(dto.getWakeUpTime()));
     }
 }

--- a/src/main/java/com/ktb/cafeboo/domain/user/model/UserHealthInfo.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/model/UserHealthInfo.java
@@ -2,14 +2,13 @@ package com.ktb.cafeboo.domain.user.model;
 
 import com.ktb.cafeboo.global.BaseEntity;
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalTime;
 
+@Entity
 @Getter
 @Setter
-@Entity
 @Table(name = "user_health_info")
 public class UserHealthInfo extends BaseEntity {
     @OneToOne
@@ -29,17 +28,17 @@ public class UserHealthInfo extends BaseEntity {
     @Column(nullable = false)
     private float weight;
 
-    @Column(nullable = false)
-    private boolean isPregnant;
+    @Column(name = "is_pregnant", nullable = false)
+    private Boolean pregnant;
+
+    @Column(name = "is_taking_birth_pill", nullable = false)
+    private Boolean takingBirthPill;
+
+    @Column(name = "is_smoking", nullable = false)
+    private Boolean smoking;
 
     @Column(nullable = false)
-    private boolean isTakingBirthPill;
-
-    @Column(nullable = false)
-    private boolean isSmoking;
-
-    @Column(nullable = false)
-    private boolean hasLiverDisease;
+    private Boolean hasLiverDisease;
 
     @Column(nullable = false)
     private LocalTime sleepTime;

--- a/src/main/java/com/ktb/cafeboo/domain/user/repository/UserHealthInfoRepository.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/repository/UserHealthInfoRepository.java
@@ -1,0 +1,8 @@
+package com.ktb.cafeboo.domain.user.repository;
+
+import com.ktb.cafeboo.domain.user.model.UserHealthInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserHealthInfoRepository extends JpaRepository<UserHealthInfo, Long> {
+    boolean existsByUserId(Long userId);
+}

--- a/src/main/java/com/ktb/cafeboo/domain/user/service/UserHealthInfoService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/service/UserHealthInfoService.java
@@ -1,9 +1,6 @@
 package com.ktb.cafeboo.domain.user.service;
 
-import com.ktb.cafeboo.domain.user.dto.UserHealthInfoCreateRequest;
-import com.ktb.cafeboo.domain.user.dto.UserHealthInfoCreateResponse;
-import com.ktb.cafeboo.domain.user.dto.UserHealthInfoUpdateRequest;
-import com.ktb.cafeboo.domain.user.dto.UserHealthInfoUpdateResponse;
+import com.ktb.cafeboo.domain.user.dto.*;
 import com.ktb.cafeboo.domain.user.mapper.UserHealthInfoMapper;
 import com.ktb.cafeboo.domain.user.model.User;
 import com.ktb.cafeboo.domain.user.model.UserHealthInfo;
@@ -64,5 +61,16 @@ public class UserHealthInfoService {
                 .userId(userId)
                 .updatedAt(healthInfo.getUpdatedAt())
                 .build();
+    }
+
+    @Transactional(readOnly = true)
+    public UserHealthInfoResponse getHealthInfo(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomApiException(ErrorStatus.USER_NOT_FOUND));
+
+        UserHealthInfo healthInfo = userHealthInfoRepository.findById(userId)
+                .orElseThrow(() -> new CustomApiException(ErrorStatus.HEALTH_PROFILE_NOT_FOUND));
+
+        return UserHealthInfoMapper.toResponse(healthInfo);
     }
 }

--- a/src/main/java/com/ktb/cafeboo/domain/user/service/UserHealthInfoService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/service/UserHealthInfoService.java
@@ -1,0 +1,46 @@
+package com.ktb.cafeboo.domain.user.service;
+
+import com.ktb.cafeboo.domain.user.dto.UserHealthInfoCreateRequest;
+import com.ktb.cafeboo.domain.user.dto.UserHealthInfoCreateResponse;
+import com.ktb.cafeboo.domain.user.mapper.UserHealthInfoMapper;
+import com.ktb.cafeboo.domain.user.model.User;
+import com.ktb.cafeboo.domain.user.model.UserHealthInfo;
+import com.ktb.cafeboo.domain.user.repository.UserHealthInfoRepository;
+import com.ktb.cafeboo.domain.user.repository.UserRepository;
+import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
+import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserHealthInfoService {
+
+    private final UserRepository userRepository;
+    private final UserHealthInfoRepository userHealthInfoRepository;
+
+    @Transactional
+    public UserHealthInfoCreateResponse create(Long userId, UserHealthInfoCreateRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomApiException(ErrorStatus.USER_NOT_FOUND));
+
+        if (userHealthInfoRepository.existsByUserId(userId)) {
+            throw new CustomApiException(ErrorStatus.HEALTH_PROFILE_ALREADY_EXISTS);
+        }
+
+        try {
+            UserHealthInfo entity = UserHealthInfoMapper.toEntity(request, user);
+            userHealthInfoRepository.save(entity);
+
+            return UserHealthInfoCreateResponse.builder()
+                    .userId(user.getId())
+                    .createdAt(entity.getCreatedAt())
+                    .build();
+
+        } catch (Exception e) {
+            // 매핑/저장 중 오류 발생 시 BAD_REQUEST 반환
+            throw new CustomApiException(ErrorStatus.BAD_REQUEST);
+        }
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/domain/user/service/UserHealthInfoService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/service/UserHealthInfoService.java
@@ -2,6 +2,8 @@ package com.ktb.cafeboo.domain.user.service;
 
 import com.ktb.cafeboo.domain.user.dto.UserHealthInfoCreateRequest;
 import com.ktb.cafeboo.domain.user.dto.UserHealthInfoCreateResponse;
+import com.ktb.cafeboo.domain.user.dto.UserHealthInfoUpdateRequest;
+import com.ktb.cafeboo.domain.user.dto.UserHealthInfoUpdateResponse;
 import com.ktb.cafeboo.domain.user.mapper.UserHealthInfoMapper;
 import com.ktb.cafeboo.domain.user.model.User;
 import com.ktb.cafeboo.domain.user.model.UserHealthInfo;
@@ -30,7 +32,7 @@ public class UserHealthInfoService {
         }
 
         try {
-            UserHealthInfo entity = UserHealthInfoMapper.toEntity(request, user);
+            UserHealthInfo entity = UserHealthInfoMapper.createEntity(request, user);
             userHealthInfoRepository.save(entity);
 
             return UserHealthInfoCreateResponse.builder()
@@ -42,5 +44,25 @@ public class UserHealthInfoService {
             // 매핑/저장 중 오류 발생 시 BAD_REQUEST 반환
             throw new CustomApiException(ErrorStatus.BAD_REQUEST);
         }
+    }
+
+    @Transactional
+    public UserHealthInfoUpdateResponse update(Long userId, UserHealthInfoUpdateRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomApiException(ErrorStatus.USER_NOT_FOUND));
+
+        UserHealthInfo healthInfo = userHealthInfoRepository.findById(userId)
+                .orElseThrow(() -> new CustomApiException(ErrorStatus.HEALTH_PROFILE_NOT_FOUND));
+
+        try {
+            UserHealthInfoMapper.updateEntity(healthInfo, request);
+        } catch (Exception e) {
+            throw new CustomApiException(ErrorStatus.BAD_REQUEST);
+        }
+
+        return UserHealthInfoUpdateResponse.builder()
+                .userId(userId)
+                .updatedAt(healthInfo.getUpdatedAt())
+                .build();
     }
 }

--- a/src/main/java/com/ktb/cafeboo/domain/user/service/UserService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/service/UserService.java
@@ -1,7 +1,12 @@
 package com.ktb.cafeboo.domain.user.service;
 
 import com.ktb.cafeboo.domain.user.dto.EmailDuplicationResponse;
+import com.ktb.cafeboo.domain.user.dto.UserProfileResponse;
+import com.ktb.cafeboo.domain.user.model.User;
 import com.ktb.cafeboo.domain.user.repository.UserRepository;
+import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
+import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
+import com.ktb.cafeboo.global.util.AuthChecker;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -15,4 +20,18 @@ public class UserService {
         boolean isDuplicated = userRepository.existsByEmail(email);
         return new EmailDuplicationResponse(email, isDuplicated);
     }
+
+//    public UserProfileResponse getUserProfile(Long targetUserId, Long currentUserId) {
+//        User targetUser = userRepository.findById(targetUserId)
+//                .orElseThrow(() -> new CustomApiException(ErrorStatus.USER_NOT_FOUND));
+//
+//        AuthChecker.checkOwnership(targetUser.getId(), currentUserId);
+//
+//        return new UserProfileResponse(
+//                targetUser.getNickname(),
+//                targetUser.getDailyCaffeineLimitMg(),
+//                targetUser.getCoffeeBean(),
+//                challengeRepository.countByUserId(targetUserId)
+//        );
+//    }
 }

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/ErrorStatus.java
@@ -26,7 +26,9 @@ public enum ErrorStatus implements BaseCode {
     // 유저 관련 오류
     USER_NOT_FOUND(401, "USER_NOT_FOUND", "사용자를 찾을 수 없습니다."),
     ACCESS_DENIED(403, "ACCESS_DENIED", "해당 요청에 대한 권한이 없습니다."),
-    HEALTH_PROFILE_ALREADY_EXISTS(400, "HEALTH_PROFILE_ALREADY_EXISTS", "이미 건강 정보가 등록되어 있습니다.");
+    HEALTH_PROFILE_ALREADY_EXISTS(400, "HEALTH_PROFILE_ALREADY_EXISTS", "이미 건강 정보가 등록되어 있습니다."),
+    HEALTH_PROFILE_NOT_FOUND(404, "HEALTH_PROFILE_NOT_FOUND", "건강 정보가 존재하지 않습니다."),
+    ;
 
     private final int status;
     private final String code;

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/ErrorStatus.java
@@ -13,7 +13,7 @@ public enum ErrorStatus implements BaseCode {
     UNAUTHORIZED(401, "UNAUTHORIZED", "인증이 필요합니다."),
     FORBIDDEN(403, "FORBIDDEN", "접근 권한이 없습니다."),
     NOT_FOUND(404, "NOT_FOUND", "요청한 리소스를 찾을 수 없습니다."),
-    INTERNAL_SERVER_ERROR(500, "INTERNAL_ERROR", "서버 내부 오류가 발생했습니다."),
+    INTERNAL_SERVER_ERROR(500, "INTERNAL_ERROR", "요청을 처리하는 도중 서버에서 문제가 발생했습니다."),
 
     // 인증 관련 오류
     UNSUPPORTED_SOCIAL_LOGIN_TYPE(400, "UNSUPPORTED_SOCIAL_LOGIN_TYPE", "지원하지 않는 소셜 로그인 타입입니다."),

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/ErrorStatus.java
@@ -9,7 +9,7 @@ import lombok.RequiredArgsConstructor;
 public enum ErrorStatus implements BaseCode {
 
     // 기본 오류
-    BAD_REQUEST(400, "BAD_REQUEST", "잘못된 요청입니다."),
+    BAD_REQUEST(400, "BAD_REQUEST", "요청 형식 또는 값이 올바르지 않습니다."),
     UNAUTHORIZED(401, "UNAUTHORIZED", "인증이 필요합니다."),
     FORBIDDEN(403, "FORBIDDEN", "접근 권한이 없습니다."),
     NOT_FOUND(404, "NOT_FOUND", "요청한 리소스를 찾을 수 없습니다."),
@@ -24,9 +24,9 @@ public enum ErrorStatus implements BaseCode {
     REFRESH_TOKEN_MISMATCH(401, "REFRESH_TOKEN_MISMATCH", "리프레시 토큰이 일치하지 않습니다."),
 
     // 유저 관련 오류
-    USER_NOT_FOUND(401, "USER_NOT_FOUND", "사용자를 찾을 수 없습니다.");
-
-
+    USER_NOT_FOUND(401, "USER_NOT_FOUND", "사용자를 찾을 수 없습니다."),
+    ACCESS_DENIED(403, "ACCESS_DENIED", "해당 요청에 대한 권한이 없습니다."),
+    HEALTH_PROFILE_ALREADY_EXISTS(400, "HEALTH_PROFILE_ALREADY_EXISTS", "이미 건강 정보가 등록되어 있습니다.");
 
     private final int status;
     private final String code;

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/SuccessStatus.java
@@ -19,7 +19,9 @@ public enum SuccessStatus implements BaseCode {
     // 유저 관련 응답
     EMAIL_DUPLICATION_CHECK_SUCCESS(200, "EMAIL_DUPLICATION_CHECK_SUCCESS", "이메일 중복 확인 결과를 반환했습니다."),
     BASIC_PROFILE_FETCH_SUCCESS(200, "BASIC_PROFILE_FETCH_SUCCESS", "기본 프로필이 성공적으로 조회되었습니다."),
-    HEALTH_PROFILE_CREATION_SUCCESS(201, "HEALTH_PROFILE_CREATION_SUCCESS", "건강 프로필이 성공적으로 저장되었습니다.");
+    HEALTH_PROFILE_CREATION_SUCCESS(201, "HEALTH_PROFILE_CREATION_SUCCESS", "건강 프로필이 성공적으로 저장되었습니다."),
+    HEALTH_PROFILE_UPDATE_SUCCESS(200, "HEALTH_PROFILE_UPDATE_SUCCESS", "건강 프로필이 성공적으로 수정되었습니다."),
+    ;
 
 
     private final int status;

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/SuccessStatus.java
@@ -17,7 +17,10 @@ public enum SuccessStatus implements BaseCode {
     TOKEN_REFRESH_SUCCESS(200, "TOKEN_REFRESH_SUCCESS", "액세스 토큰이 성공적으로 재발급되었습니다."),
 
     // 유저 관련 응답
-    EMAIL_DUPLICATION_CHECK_SUCCESS(200, "EMAIL_DUPLICATION_CHECK_SUCCESS", "이메일 중복 확인 결과를 반환했습니다.");
+    EMAIL_DUPLICATION_CHECK_SUCCESS(200, "EMAIL_DUPLICATION_CHECK_SUCCESS", "이메일 중복 확인 결과를 반환했습니다."),
+    BASIC_PROFILE_FETCH_SUCCESS(200, "BASIC_PROFILE_FETCH_SUCCESS", "기본 프로필이 성공적으로 조회되었습니다."),
+    HEALTH_PROFILE_CREATION_SUCCESS(201, "HEALTH_PROFILE_CREATION_SUCCESS", "건강 프로필이 성공적으로 저장되었습니다.");
+
 
     private final int status;
     private final String code;

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/SuccessStatus.java
@@ -21,7 +21,7 @@ public enum SuccessStatus implements BaseCode {
     BASIC_PROFILE_FETCH_SUCCESS(200, "BASIC_PROFILE_FETCH_SUCCESS", "기본 프로필이 성공적으로 조회되었습니다."),
     HEALTH_PROFILE_CREATION_SUCCESS(201, "HEALTH_PROFILE_CREATION_SUCCESS", "건강 프로필이 성공적으로 저장되었습니다."),
     HEALTH_PROFILE_UPDATE_SUCCESS(200, "HEALTH_PROFILE_UPDATE_SUCCESS", "건강 프로필이 성공적으로 수정되었습니다."),
-    ;
+    HEALTH_PROFILE_FETCH_SUCCESS(200, "HEALTH_PROFILE_FETCH_SUCCESS", "건강 프로필이 성공적으로 조회되었습니다.");
 
 
     private final int status;

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/exception/ApiExceptionHandler.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/exception/ApiExceptionHandler.java
@@ -4,6 +4,7 @@ import com.ktb.cafeboo.global.apiPayload.ApiResponse;
 import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
 import com.ktb.cafeboo.global.apiPayload.code.BaseCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -17,6 +18,13 @@ public class ApiExceptionHandler {
                 .body(ApiResponse.onFailure(ErrorStatus.INTERNAL_SERVER_ERROR));
     }
 
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponse<?>> handleHttpMessageNotReadable(HttpMessageNotReadableException ex) {
+        return ResponseEntity
+                .badRequest()
+                .body(ApiResponse.onFailure(ErrorStatus.BAD_REQUEST));
+    }
+
     @ExceptionHandler(CustomApiException.class)
     public ResponseEntity<ApiResponse<Void>> handleCustomApiException(CustomApiException ex) {
         BaseCode error = ex.getErrorCode();
@@ -24,5 +32,4 @@ public class ApiExceptionHandler {
                 .status(error.getStatus())
                 .body(ApiResponse.onFailure(error));
     }
-
 }

--- a/src/main/java/com/ktb/cafeboo/global/config/SecurityConfig.java
+++ b/src/main/java/com/ktb/cafeboo/global/config/SecurityConfig.java
@@ -1,14 +1,20 @@
 package com.ktb.cafeboo.global.config;
 
+import com.ktb.cafeboo.global.security.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -20,7 +26,9 @@ public class SecurityConfig {
                         "/api/v1/users/email"
                 ).permitAll()
                 .anyRequest().authenticated()
-            );
+            )
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
         return http.build();
     }
 }

--- a/src/main/java/com/ktb/cafeboo/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ktb/cafeboo/global/security/JwtAuthenticationFilter.java
@@ -50,10 +50,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
             } catch (CustomApiException e) {
                 logger.warn("[JWT 인증 실패] " + e.getErrorCode().getCode() + ": " + e.getMessage());
-                // 인증 실패: SecurityContext는 설정하지 않음
             }
         }
-
         filterChain.doFilter(request, response);
     }
 }

--- a/src/main/java/com/ktb/cafeboo/global/util/AuthChecker.java
+++ b/src/main/java/com/ktb/cafeboo/global/util/AuthChecker.java
@@ -7,7 +7,7 @@ public class AuthChecker {
 
     public static void checkOwnership(Long ownerId, Long currentUserId) {
         if (!ownerId.equals(currentUserId)) {
-            throw new CustomApiException(ErrorStatus.FORBIDDEN);
+            throw new CustomApiException(ErrorStatus.ACCESS_DENIED);
         }
     }
 }


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] 유저 건강 프로필 생성 API 개발
- [x] 유저 건강 프로필 수정 API 개발
- [x] 유저 건강 프로필 조회 API 개발

## 🛠 변경사항
- UserHealthInfoController, UserHealthInfoService 추가
- UserHealthInfoMapper에 toEntity, updateEntity, toResponse 메서드 구현
- 건강 정보 관련 요청/응답 DTO 5종 정의 및 적용
- 응답 상태 코드 Enum 추가

## 💬 리뷰 요구사항
- Dto 매핑 로직에 집중해서 검토해주세요

## 🔍 테스트 방법(선택)
- Postmane 으로 /api/v1/users/{userId}/health 경로에 대해 POST, PATCH, GET 메서드 요청 수행
- 주요 응답(건강 정보 중복 생성 시 400, 본인 외 유저 ID 접근 시 403, 건강 정보 미등록 시 404) 확인 완료
