### PR TITLE
🐛fix: JWT subject 누락 및 파싱 예외 대응 로직 추가

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/auth/service/AuthService.java
@@ -28,7 +28,7 @@ public class AuthService {
         }
 
         String newAccessToken = jwtProvider.createAccessToken(
-                user.getEmail(),
+                user.getId().toString(),
                 user.getLoginType().name(),
                 user.getRole().name()
         );

--- a/src/main/java/com/ktb/cafeboo/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ktb/cafeboo/global/security/JwtAuthenticationFilter.java
@@ -35,8 +35,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             String accessToken = authorizationHeader.replace("Bearer ", "");
 
             try {
-                String userId = jwtProvider.validateAccessToken(accessToken);
-                Long userIdLong = Long.parseLong(userId);
+                String userIdStr = jwtProvider.validateAccessToken(accessToken);
+
+                if (userIdStr == null || !userIdStr.matches("\\d+")) {
+                    throw new CustomApiException(ErrorStatus.ACCESS_TOKEN_INVALID);
+                }
+
+                Long userIdLong = Long.parseLong(userIdStr);
 
                 User user = userRepository.findById(userIdLong)
                         .orElseThrow(() -> new CustomApiException(ErrorStatus.USER_NOT_FOUND));

--- a/src/main/java/com/ktb/cafeboo/global/security/JwtProvider.java
+++ b/src/main/java/com/ktb/cafeboo/global/security/JwtProvider.java
@@ -30,7 +30,7 @@ public class JwtProvider {
 
     private String createToken(String userId, String loginType, String role, long validityInMillis) {
         return JWT.create()
-                .withSubject(userId)
+                .withSubject(String.valueOf(userId))
                 .withClaim("loginType", loginType)
                 .withClaim("role", role)
                 .withExpiresAt(new Date(System.currentTimeMillis() + validityInMillis))
@@ -39,10 +39,14 @@ public class JwtProvider {
 
     public String validateAccessToken(String token) {
         try {
-            return JWT.require(Algorithm.HMAC256(SECRET_KEY))
+            String subject = JWT.require(Algorithm.HMAC256(SECRET_KEY))
                     .build()
                     .verify(token)
                     .getSubject();
+            if (subject == null) {
+                throw new CustomApiException(ErrorStatus.ACCESS_TOKEN_INVALID);
+            }
+            return subject;
         } catch (TokenExpiredException e) {
             throw new CustomApiException(ErrorStatus.ACCESS_TOKEN_EXPIRED);
         } catch (JWTVerificationException e) {
@@ -52,10 +56,14 @@ public class JwtProvider {
 
     public String validateRefreshToken(String token) {
         try {
-            return JWT.require(Algorithm.HMAC256(SECRET_KEY))
+            String subject = JWT.require(Algorithm.HMAC256(SECRET_KEY))
                     .build()
                     .verify(token)
                     .getSubject();
+            if (subject == null) {
+                throw new CustomApiException(ErrorStatus.REFRESH_TOKEN_INVALID);
+            }
+            return subject;
         } catch (TokenExpiredException e) {
             throw new CustomApiException(ErrorStatus.REFRESH_TOKEN_EXPIRED);
         } catch (JWTVerificationException e) {


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] AuthService내 토큰 리프레시 로직 오류 수정
- [x] JwtProvider, JwtProvider내 토큰 subject null 체크 로직 추가

## 🛠 변경사항
- Refresh 토큰 생성 시 subject를 userId가 아닌 email로 잘못 설정한 문제 수정
- JwtProvider에서 subject가 null일 경우 예외 처리 로직 추가
- JwtProvider에서 Long.parseLong 수행 전 null 및 형식 검증 로직 추가
- 사용자 인증 실패 시 ACCESS_TOKEN_INVALID 예외를 안전하게 반환하도록 개선

## 💬 리뷰 요구사항

## 🔍 테스트 방법(선택)
- Postman을 사용하여 재발급 받은 토큰이 정상적으로 인증되는 것을 테스트하였습니다.
