### PR TITLE
✨feat: 유저 알림설정 정보 생성, 조회, 수정 기능 구현

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/user/controller/UserController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.ktb.cafeboo.domain.user.controller;
 
 import com.ktb.cafeboo.domain.user.dto.*;
+import com.ktb.cafeboo.domain.user.service.UserAlarmSettingService;
 import com.ktb.cafeboo.domain.user.service.UserCaffeineInfoService;
 import com.ktb.cafeboo.domain.user.service.UserHealthInfoService;
 import com.ktb.cafeboo.domain.user.service.UserService;
@@ -24,6 +25,7 @@ public class UserController {
     private final UserService userService;
     private final UserHealthInfoService userHealthInfoService;
     private final UserCaffeineInfoService userCaffeineInfoService;
+    private final UserAlarmSettingService userAlarmSettingService;
 
     @GetMapping("/email")
     public ResponseEntity<ApiResponse<EmailDuplicationResponse>> checkEmailDuplication(
@@ -102,5 +104,41 @@ public class UserController {
 
         UserCaffeineInfoResponse response = userCaffeineInfoService.getCaffeineInfo(userId);
         return ResponseEntity.ok(ApiResponse.of(SuccessStatus.CAFFEINE_PROFILE_FETCH_SUCCESS, response));
+    }
+
+    @PostMapping("/{userId}/alarm")
+    public ResponseEntity<ApiResponse<UserAlarmSettingCreateResponse>> createAlarmSetting(
+            @PathVariable Long userId,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody UserAlarmSettingCreateRequest request
+    ) {
+        AuthChecker.checkOwnership(userId, userDetails.getUserId());
+
+        UserAlarmSettingCreateResponse response = userAlarmSettingService.create(userId, request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.of(SuccessStatus.ALARM_SETTING_CREATION_SUCCESS, response));
+    }
+
+    @PatchMapping("/{userId}/alarm")
+    public ResponseEntity<ApiResponse<UserAlarmSettingUpdateResponse>> updateAlarmSetting(
+            @PathVariable Long userId,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody UserAlarmSettingUpdateRequest request
+    ) {
+        AuthChecker.checkOwnership(userId, userDetails.getUserId());
+
+        UserAlarmSettingUpdateResponse response = userAlarmSettingService.update(userId, request);
+        return ResponseEntity.ok(ApiResponse.of(SuccessStatus.ALARM_SETTING_UPDATE_SUCCESS, response));
+    }
+
+    @GetMapping("/{userId}/alarm")
+    public ResponseEntity<ApiResponse<UserAlarmSettingResponse>> getAlarmSetting(
+            @PathVariable Long userId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        AuthChecker.checkOwnership(userId, userDetails.getUserId());
+
+        UserAlarmSettingResponse response = userAlarmSettingService.get(userId);
+        return ResponseEntity.ok(ApiResponse.of(SuccessStatus.ALARM_SETTING_FETCH_SUCCESS, response));
     }
 }

--- a/src/main/java/com/ktb/cafeboo/domain/user/dto/UserAlarmSettingCreateRequest.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/dto/UserAlarmSettingCreateRequest.java
@@ -1,0 +1,13 @@
+package com.ktb.cafeboo.domain.user.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class UserAlarmSettingCreateRequest {
+    private boolean alarmWhenExceedIntake;
+    private boolean alarmBeforeSleep;
+    private boolean alarmForChat;
+}
+

--- a/src/main/java/com/ktb/cafeboo/domain/user/dto/UserAlarmSettingCreateResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/dto/UserAlarmSettingCreateResponse.java
@@ -1,0 +1,14 @@
+package com.ktb.cafeboo.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class UserAlarmSettingCreateResponse {
+    private Long userId;
+    private LocalDateTime createdAt;
+}
+

--- a/src/main/java/com/ktb/cafeboo/domain/user/dto/UserAlarmSettingResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/dto/UserAlarmSettingResponse.java
@@ -1,0 +1,17 @@
+package com.ktb.cafeboo.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class UserAlarmSettingResponse {
+    private boolean alarmWhenExceedIntake;
+    private boolean alarmBeforeSleep;
+    private boolean alarmForChat;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}
+

--- a/src/main/java/com/ktb/cafeboo/domain/user/dto/UserAlarmSettingUpdateRequest.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/dto/UserAlarmSettingUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.ktb.cafeboo.domain.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UserAlarmSettingUpdateRequest {
+    private Boolean alarmWhenExceedIntake;
+    private Boolean alarmBeforeSleep;
+    private Boolean alarmForChat;
+}
+

--- a/src/main/java/com/ktb/cafeboo/domain/user/dto/UserAlarmSettingUpdateResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/dto/UserAlarmSettingUpdateResponse.java
@@ -1,0 +1,14 @@
+package com.ktb.cafeboo.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class UserAlarmSettingUpdateResponse {
+    private Long userId;
+    private LocalDateTime updatedAt;
+}
+

--- a/src/main/java/com/ktb/cafeboo/domain/user/mapper/UserAlarmSettingMapper.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/mapper/UserAlarmSettingMapper.java
@@ -1,0 +1,40 @@
+package com.ktb.cafeboo.domain.user.mapper;
+
+import com.ktb.cafeboo.domain.user.dto.*;
+import com.ktb.cafeboo.domain.user.model.User;
+import com.ktb.cafeboo.domain.user.model.UserAlarmSetting;
+
+public class UserAlarmSettingMapper {
+
+    public static UserAlarmSetting toEntity(UserAlarmSettingCreateRequest dto, User user) {
+        UserAlarmSetting entity = new UserAlarmSetting();
+        entity.setUser(user);
+        entity.setAlarmWhenExceedIntake(dto.isAlarmWhenExceedIntake());
+        entity.setAlarmBeforeSleep(dto.isAlarmBeforeSleep());
+        entity.setAlarmForChat(dto.isAlarmForChat());
+        return entity;
+    }
+
+    public static void updateEntity(UserAlarmSetting entity, UserAlarmSettingUpdateRequest dto) {
+        if (dto.getAlarmWhenExceedIntake() != null) {
+            entity.setAlarmWhenExceedIntake(dto.getAlarmWhenExceedIntake());
+        }
+        if (dto.getAlarmBeforeSleep() != null) {
+            entity.setAlarmBeforeSleep(dto.getAlarmBeforeSleep());
+        }
+        if (dto.getAlarmForChat() != null) {
+            entity.setAlarmForChat(dto.getAlarmForChat());
+        }
+    }
+
+
+    public static UserAlarmSettingResponse toResponse(UserAlarmSetting entity) {
+        return UserAlarmSettingResponse.builder()
+                .alarmWhenExceedIntake(entity.isAlarmWhenExceedIntake())
+                .alarmBeforeSleep(entity.isAlarmBeforeSleep())
+                .alarmForChat(entity.isAlarmForChat())
+                .createdAt(entity.getCreatedAt())
+                .updatedAt(entity.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/domain/user/model/UserAlarmSetting.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/model/UserAlarmSetting.java
@@ -16,12 +16,11 @@ public class UserAlarmSetting extends BaseEntity {
     private User user;
 
     @Column(nullable = false)
-    private boolean alarmWhenExceedIntake = false;
+    private boolean alarmWhenExceedIntake;
 
     @Column(nullable = false)
-    private boolean alarmBeforeSleep = false;
+    private boolean alarmBeforeSleep;
 
     @Column(nullable = false)
-    private boolean alarmForChat = false;
-
+    private boolean alarmForChat;
 }

--- a/src/main/java/com/ktb/cafeboo/domain/user/model/UserCaffeinInfo.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/model/UserCaffeinInfo.java
@@ -29,9 +29,9 @@ public class UserCaffeinInfo extends BaseEntity {
     private LocalTime frequentDrinkTime;
 
     @Column(nullable = false)
-    private float dailyCaffeineLimitMg = 100.0f;
+    private float dailyCaffeineLimitMg = 400.0f;
 
     @Column(nullable = false)
-    private float sleepSensitiveThresholdMg = 400.0f;
+    private float sleepSensitiveThresholdMg = 100.0f;
 
 }

--- a/src/main/java/com/ktb/cafeboo/domain/user/repository/UserAlarmSettingRepository.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/repository/UserAlarmSettingRepository.java
@@ -1,0 +1,9 @@
+package com.ktb.cafeboo.domain.user.repository;
+
+import com.ktb.cafeboo.domain.user.model.UserAlarmSetting;
+import com.ktb.cafeboo.domain.user.model.UserCaffeinInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserAlarmSettingRepository extends JpaRepository<UserAlarmSetting, Long> {
+    boolean existsByUserId(Long userId);
+}

--- a/src/main/java/com/ktb/cafeboo/domain/user/service/UserAlarmSettingService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/service/UserAlarmSettingService.java
@@ -1,0 +1,72 @@
+package com.ktb.cafeboo.domain.user.service;
+
+import com.ktb.cafeboo.domain.user.dto.*;
+import com.ktb.cafeboo.domain.user.model.User;
+import com.ktb.cafeboo.domain.user.model.UserAlarmSetting;
+import com.ktb.cafeboo.domain.user.repository.UserAlarmSettingRepository;
+import com.ktb.cafeboo.domain.user.repository.UserRepository;
+import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
+import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import com.ktb.cafeboo.domain.user.mapper.UserAlarmSettingMapper;
+
+@Service
+@RequiredArgsConstructor
+public class UserAlarmSettingService {
+
+    private final UserRepository userRepository;
+    private final UserAlarmSettingRepository userAlarmSettingRepository;
+
+    @Transactional
+    public UserAlarmSettingCreateResponse create(Long userId, UserAlarmSettingCreateRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomApiException(ErrorStatus.USER_NOT_FOUND));
+
+        if (userAlarmSettingRepository.existsByUserId(userId)) {
+            throw new CustomApiException(ErrorStatus.ALARM_SETTING_ALREADY_EXISTS);
+        }
+
+        try {
+            UserAlarmSetting entity = UserAlarmSettingMapper.toEntity(request, user);
+            userAlarmSettingRepository.save(entity);
+            return UserAlarmSettingCreateResponse.builder()
+                    .userId(user.getId())
+                    .createdAt(entity.getCreatedAt())
+                    .build();
+        } catch (Exception e) {
+            throw new CustomApiException(ErrorStatus.BAD_REQUEST);
+        }
+    }
+
+    @Transactional
+    public UserAlarmSettingUpdateResponse update(Long userId, UserAlarmSettingUpdateRequest request) {
+        userRepository.findById(userId)
+                .orElseThrow(() -> new CustomApiException(ErrorStatus.USER_NOT_FOUND));
+
+        UserAlarmSetting entity = userAlarmSettingRepository.findById(userId)
+                .orElseThrow(() -> new CustomApiException(ErrorStatus.ALARM_SETTING_NOT_FOUND));
+
+        try {
+            UserAlarmSettingMapper.updateEntity(entity, request);
+            return UserAlarmSettingUpdateResponse.builder()
+                    .userId(userId)
+                    .updatedAt(entity.getUpdatedAt())
+                    .build();
+        } catch (Exception e) {
+            throw new CustomApiException(ErrorStatus.BAD_REQUEST);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public UserAlarmSettingResponse get(Long userId) {
+        userRepository.findById(userId)
+                .orElseThrow(() -> new CustomApiException(ErrorStatus.USER_NOT_FOUND));
+
+        UserAlarmSetting entity = userAlarmSettingRepository.findById(userId)
+                .orElseThrow(() -> new CustomApiException(ErrorStatus.ALARM_SETTING_NOT_FOUND));
+
+        return UserAlarmSettingMapper.toResponse(entity);
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/domain/user/service/UserCaffeineInfoService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/service/UserCaffeineInfoService.java
@@ -25,7 +25,7 @@ public class UserCaffeineInfoService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomApiException(ErrorStatus.USER_NOT_FOUND));
 
-        if (userCaffeineInfoRepository.existsById(userId)) {
+        if (userCaffeineInfoRepository.existsByUserId(userId)) {
             throw new CustomApiException(ErrorStatus.CAFFEINE_PROFILE_ALREADY_EXISTS);
         }
 

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/ErrorStatus.java
@@ -32,7 +32,9 @@ public enum ErrorStatus implements BaseCode {
 
     CAFFEINE_PROFILE_ALREADY_EXISTS(409, "CAFFEINE_PROFILE_ALREADY_EXISTS", "이미 카페인 정보가 등록되어 있습니다."),
     CAFFEINE_PROFILE_NOT_FOUND(404, "CAFFEINE_PROFILE_NOT_FOUND", "카페인 정보가 존재하지 않습니다."),
-    ;
+
+    ALARM_SETTING_ALREADY_EXISTS(409, "ALARM_SETTING_ALREADY_EXISTS", "이미 알림 설정이 존재합니다."),
+    ALARM_SETTING_NOT_FOUND(404, "ALARM_SETTING_NOT_FOUND", "알림 설정 정보를 찾을 수 없습니다.");
 
     private final int status;
     private final String code;

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/SuccessStatus.java
@@ -29,7 +29,12 @@ public enum SuccessStatus implements BaseCode {
     CAFFEINE_PROFILE_CREATION_SUCCESS(201, "CAFFEINE_PROFILE_CREATION_SUCCESS", "카페인 프로필이 성공적으로 저장되었습니다."),
     CAFFEINE_PROFILE_UPDATE_SUCCESS(200, "CAFFEINE_PROFILE_UPDATE_SUCCESS", "카페인 프로필이 성공적으로 수정되었습니다."),
     CAFFEINE_PROFILE_FETCH_SUCCESS(200, "CAFFEINE_PROFILE_FETCH_SUCCESS", "카페인 프로필이 성공적으로 조회되었습니다."),
-  
+
+    // 유저 알림 설정 관련 응답
+    ALARM_SETTING_CREATION_SUCCESS(201, "ALARM_SETTING_CREATION_SUCCESS", "알람 설정이 성공적으로 저장되었습니다."),
+    ALARM_SETTING_UPDATE_SUCCESS(200, "ALARM_SETTING_UPDATE_SUCCESS", "알람 설정이 성공적으로 수정되었습니다."),
+    ALARM_SETTING_FETCH_SUCCESS(200, "ALARM_SETTING_FETCH_SUCCESS", "알람 설정 정보가 성공적으로 조회되었습니다."),
+
     //카페인 섭취 관련 응답
     CAFFEINE_INTAKE_RECORDED(201, "CAFFEINE_INTAKE_RECORDED", "카페인 섭취 내역이 성공적으로 등록되었습니다."),
     CAFFEINE_INTAKE_UPDATED(200, "CAFFEINE_INTAKE_UPDATED", "카페인 섭취 내역이 성공적으로 갱신되었습니다."),


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] 유저 알림설정 정보 생성 API 개발
- [x] 유저 알림설정 정보 수정 API 개발
- [x] 유저 알림설정 정보 조회 API 개발

## 🛠 변경사항
- UserAlarmSettingController, UserAlarmSettingService, UserAlarmSettingRepository 추가
- UserAlarmSettingMapper에 toEntity, updateEntity, toResponse 메서드 구현
- 알림설정 정보 관련 요청/응답 DTO 5종 정의 및 적용
- 응답 상태 코드 Enum 추가

## 💬 리뷰 요구사항
- Dto 구성에 관해 고민사항이 있습니다. 추후 리팩토링 사항으로 고려 중입니다

## 🔍 테스트 방법(선택)
- Postmane 으로 /api/v1/users/{userId}/alarm 경로에 대해 POST, PATCH, GET 메서드 요청 수행
- 주요 응답(알림설정 정보 중복 생성 시 409, 본인 외 유저 ID 접근 시 403, 알림설정 정보 미등록 시 404) 확인 완료
