### PR TITLE
🐛fix: 카카오 로그인 응답의 온보딩 여부 판단 로직 수정

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/auth/dto/KakaoLoginResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/auth/dto/KakaoLoginResponse.java
@@ -8,5 +8,5 @@ import lombok.Getter;
 public class KakaoLoginResponse {
     private String accessToken;
     private String refreshToken;
-    private boolean isNewUser;
+    private boolean requiresOnboarding;
 }

--- a/src/main/java/com/ktb/cafeboo/domain/user/service/UserService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/service/UserService.java
@@ -40,6 +40,12 @@ public class UserService {
         return new EmailDuplicationResponse(email, isDuplicated);
     }
 
+    public boolean hasCompletedOnboarding(User user) {
+        return user.getHealthInfo() != null
+                && user.getCaffeinInfo() != null
+                && user.getAlarmSetting() != null;
+    }
+
 //    public UserProfileResponse getUserProfile(Long targetUserId, Long currentUserId) {
 //        User targetUser = userRepository.findById(targetUserId)
 //                .orElseThrow(() -> new CustomApiException(ErrorStatus.USER_NOT_FOUND));


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] 단순 회원가입 여부가 아닌 health, caffeine, alarm 정보 등록 여부를 기준으로 온보딩 필요 여부 판단
- [x] UserService에 hasCompletedOnboarding(user) 메서드 추가하여 유저의 온보딩 완료 상태 판단 로직 분리
- [x] login 메서드 내 분기 로직 개선: 기존 유저라도 온보딩 미완료 시 requiresOnboarding=true로 처리

## 🛠 변경사항
 - KakaoLoginResponse dto 필드명 수정
 - KakaoOauthService login 메서드 내 온보딩 완료 상태 판단 로직 수정
 - UserService 내 온보딩 상태 검증 메서드 추가

## 💬 리뷰 요구사항

## 🔍 테스트 방법(선택)
- 온보딩 데이터 유무에 따른 requiresOnboarding 필드 정상 반환 확인
