### PR TITLE
유저 기본 프로필 조회 API 구현

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/user/controller/UserController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/controller/UserController.java
@@ -34,6 +34,18 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.of(SuccessStatus.EMAIL_DUPLICATION_CHECK_SUCCESS, response));
     }
 
+    @GetMapping("/{userId}/profile")
+    public ResponseEntity<ApiResponse<UserProfileResponse>> getUserProfile(
+            @PathVariable Long userId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        AuthChecker.checkOwnership(userId, userDetails.getUserId());
+
+        UserProfileResponse response = userService.getUserProfile(userId, userDetails.getUserId());
+        return ResponseEntity.ok(ApiResponse.of(SuccessStatus.BASIC_PROFILE_FETCH_SUCCESS, response));
+    }
+
+
     @PostMapping("/{userId}/health")
     public ResponseEntity<ApiResponse<UserHealthInfoCreateResponse>> createHealthInfo(
             @PathVariable Long userId,

--- a/src/main/java/com/ktb/cafeboo/domain/user/service/UserService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/service/UserService.java
@@ -6,7 +6,6 @@ import com.ktb.cafeboo.domain.user.model.User;
 import com.ktb.cafeboo.domain.user.repository.UserRepository;
 import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
 import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
-import com.ktb.cafeboo.global.util.AuthChecker;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -40,18 +39,21 @@ public class UserService {
         return new EmailDuplicationResponse(email, isDuplicated);
     }
 
-//    public UserProfileResponse getUserProfile(Long targetUserId, Long currentUserId) {
-//        User targetUser = userRepository.findById(targetUserId)
-//                .orElseThrow(() -> new CustomApiException(ErrorStatus.USER_NOT_FOUND));
-//
-//        AuthChecker.checkOwnership(targetUser.getId(), currentUserId);
-//
-//        return new UserProfileResponse(
-//                targetUser.getNickname(),
-//                targetUser.getDailyCaffeineLimitMg(),
-//                targetUser.getCoffeeBean(),
-//                challengeRepository.countByUserId(targetUserId)
-//        );
-//    }
+    public UserProfileResponse getUserProfile(Long targetUserId, Long currentUserId) {
+        User targetUser = userRepository.findById(targetUserId)
+                .orElseThrow(() -> new CustomApiException(ErrorStatus.USER_NOT_FOUND));
 
+        float dailyCaffeineLimit = targetUser.getCaffeinInfo() != null
+                ? targetUser.getCaffeinInfo().getDailyCaffeineLimitMg()
+                : 400.0f;
+
+        // int challengeCount = challengeRepository.countByUserId(targetUserId); // TODO: 챌린지 추가 이후 실제 구현 필요
+
+        return new UserProfileResponse(
+                targetUser.getNickname(),
+                (int) dailyCaffeineLimit,
+                targetUser.getCoffeeBean(),
+                0
+        );
+    }
 }

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/ErrorStatus.java
@@ -24,7 +24,7 @@ public enum ErrorStatus implements BaseCode {
     REFRESH_TOKEN_MISMATCH(401, "REFRESH_TOKEN_MISMATCH", "리프레시 토큰이 일치하지 않습니다."),
 
     // 유저 관련 오류
-    USER_NOT_FOUND(401, "USER_NOT_FOUND", "사용자를 찾을 수 없습니다."),
+    USER_NOT_FOUND(404, "USER_NOT_FOUND", "사용자를 찾을 수 없습니다."),
     ACCESS_DENIED(403, "ACCESS_DENIED", "해당 요청에 대한 권한이 없습니다."),
 
     HEALTH_PROFILE_ALREADY_EXISTS(409, "HEALTH_PROFILE_ALREADY_EXISTS", "이미 건강 정보가 등록되어 있습니다."),


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] 닉네임, 데일리 카페인 한도, 커피콩, 챌린지 수 포함한 응답 반환 API 추가

## 🛠 변경사항
- UserService에 getUserProfile 메서드 추가
- UserController에 GET /api/v1/users/{userId}/profile 엔드포인트 추가

## 💬 리뷰 요구사항
- 추후 challengeCount 계산 로직을 실제 챌린지 기능과 연동할 예정인데, 해당 위치나 설계 방식에 대한 피드백 좋습니다

## 🔍 테스트 방법(선택)
- Postman 테스트