### PR TITLE
✨feat: AI 서버 연동을 통한 최대 카페인 허용량 예측 기능 구현

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/auth/dto/KakaoLoginResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/auth/dto/KakaoLoginResponse.java
@@ -1,11 +1,14 @@
 package com.ktb.cafeboo.domain.auth.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 @AllArgsConstructor
 public class KakaoLoginResponse {
+    private String userId;
     private String accessToken;
     private String refreshToken;
     private boolean requiresOnboarding;

--- a/src/main/java/com/ktb/cafeboo/domain/auth/dto/TokenRefreshResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/auth/dto/TokenRefreshResponse.java
@@ -1,10 +1,13 @@
 package com.ktb.cafeboo.domain.auth.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 @AllArgsConstructor
 public class TokenRefreshResponse {
+    private String userId;
     private String accessToken;
 }

--- a/src/main/java/com/ktb/cafeboo/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/auth/service/AuthService.java
@@ -33,7 +33,10 @@ public class AuthService {
                 user.getRole().name()
         );
 
-        return new TokenRefreshResponse(newAccessToken);
+        return TokenRefreshResponse.builder()
+                .userId(userId)
+                .accessToken(newAccessToken)
+                .build();
     }
 
     @Transactional

--- a/src/main/java/com/ktb/cafeboo/domain/auth/service/KakaoOauthService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/auth/service/KakaoOauthService.java
@@ -81,6 +81,11 @@ public class KakaoOauthService {
         user.updateRefreshToken(refreshToken);
         userRepository.save(user);
 
-        return new KakaoLoginResponse(accessToken, refreshToken, requiresOnboarding);
+        return KakaoLoginResponse.builder()
+                .userId(user.getId().toString())
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .requiresOnboarding(requiresOnboarding)
+                .build();
     }
 }

--- a/src/main/java/com/ktb/cafeboo/domain/recommend/service/CaffeineRecommendationService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/recommend/service/CaffeineRecommendationService.java
@@ -1,0 +1,64 @@
+package com.ktb.cafeboo.domain.recommend.service;
+
+import com.ktb.cafeboo.domain.user.model.User;
+import com.ktb.cafeboo.domain.user.model.UserCaffeinInfo;
+import com.ktb.cafeboo.domain.user.model.UserHealthInfo;
+import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
+import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
+import com.ktb.cafeboo.global.infra.ai.client.AiServerClient;
+import com.ktb.cafeboo.global.infra.ai.dto.PredictCaffeineLimitByRuleRequest;
+import com.ktb.cafeboo.global.infra.ai.dto.PredictCaffeineLimitByRuleResponse;
+import com.ktb.cafeboo.domain.user.repository.UserRepository;
+import com.ktb.cafeboo.domain.user.repository.UserCaffeineInfoRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CaffeineRecommendationService {
+
+    private final AiServerClient aiServerClient;
+    private final UserRepository userRepository;
+    private final UserCaffeineInfoRepository userCaffeineInfoRepository;
+
+    @Transactional
+    public float getPredictedCaffeineLimitByRule(User user) {
+        // [RULE 기반] 사용자 상태정보를 바탕으로 하루 최대 카페인 허용량 예측
+        UserCaffeinInfo caffeinInfo = user.getCaffeinInfo();
+        if (caffeinInfo == null) {
+            throw new CustomApiException(ErrorStatus.CAFFEINE_PROFILE_NOT_FOUND);
+        }
+
+        UserHealthInfo healthInfo = user.getHealthInfo();
+        if (healthInfo == null) {
+            throw new CustomApiException(ErrorStatus.HEALTH_PROFILE_NOT_FOUND);
+        }
+
+        PredictCaffeineLimitByRuleRequest request = PredictCaffeineLimitByRuleRequest.builder()
+                .userId(user.getId().toString())
+                .modelHint("rule")  // 명시적으로 rule 기반임을 전달
+                .gender(healthInfo.getGender())
+                .age(healthInfo.getAge())
+                .weight(healthInfo.getWeight())
+                .height((int) healthInfo.getHeight())
+                .isSmoker(healthInfo.getSmoking() ? 1 : 0)
+                .takeHormonalContraceptive(healthInfo.getTakingBirthPill() ? 1 : 0)
+                .caffeineSensitivity(caffeinInfo.getCaffeineSensitivity())
+                .build();
+
+        PredictCaffeineLimitByRuleResponse response = aiServerClient.predictCaffeineLimitByRule(request);
+
+        if (!"success".equals(response.getStatus())) {
+            log.error("[AI 서버 호출 오류] code: {}, detail: {}",
+                    response.getData().getCode(),
+                    response.getData().getDetail()
+            );
+            throw new CustomApiException(ErrorStatus.AI_SERVER_ERROR);
+        }
+
+        return response.getData().getMaxCaffeineMg();
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/domain/recommend/service/CaffeineRecommendationService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/recommend/service/CaffeineRecommendationService.java
@@ -1,7 +1,6 @@
 package com.ktb.cafeboo.domain.recommend.service;
 
 import com.ktb.cafeboo.domain.user.model.User;
-import com.ktb.cafeboo.domain.user.model.UserCaffeinInfo;
 import com.ktb.cafeboo.domain.user.model.UserHealthInfo;
 import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
 import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
@@ -24,14 +23,8 @@ public class CaffeineRecommendationService {
     private final UserRepository userRepository;
     private final UserCaffeineInfoRepository userCaffeineInfoRepository;
 
-    @Transactional
-    public float getPredictedCaffeineLimitByRule(User user) {
+    public float getPredictedCaffeineLimitByRule(User user, int caffeineSensitivity) {
         // [RULE 기반] 사용자 상태정보를 바탕으로 하루 최대 카페인 허용량 예측
-        UserCaffeinInfo caffeinInfo = user.getCaffeinInfo();
-        if (caffeinInfo == null) {
-            throw new CustomApiException(ErrorStatus.CAFFEINE_PROFILE_NOT_FOUND);
-        }
-
         UserHealthInfo healthInfo = user.getHealthInfo();
         if (healthInfo == null) {
             throw new CustomApiException(ErrorStatus.HEALTH_PROFILE_NOT_FOUND);
@@ -46,7 +39,7 @@ public class CaffeineRecommendationService {
                 .height((int) healthInfo.getHeight())
                 .isSmoker(healthInfo.getSmoking() ? 1 : 0)
                 .takeHormonalContraceptive(healthInfo.getTakingBirthPill() ? 1 : 0)
-                .caffeineSensitivity(caffeinInfo.getCaffeineSensitivity())
+                .caffeineSensitivity(caffeineSensitivity)
                 .build();
 
         PredictCaffeineLimitByRuleResponse response = aiServerClient.predictCaffeineLimitByRule(request);

--- a/src/main/java/com/ktb/cafeboo/domain/user/dto/UserAlarmSettingCreateResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/dto/UserAlarmSettingCreateResponse.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
 @Getter
 @Builder
 public class UserAlarmSettingCreateResponse {
-    private Long userId;
+    private String userId;
     private LocalDateTime createdAt;
 }
 

--- a/src/main/java/com/ktb/cafeboo/domain/user/dto/UserAlarmSettingUpdateResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/dto/UserAlarmSettingUpdateResponse.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
 @Getter
 @Builder
 public class UserAlarmSettingUpdateResponse {
-    private Long userId;
+    private String userId;
     private LocalDateTime updatedAt;
 }
 

--- a/src/main/java/com/ktb/cafeboo/domain/user/dto/UserCaffeineInfoCreateResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/dto/UserCaffeineInfoCreateResponse.java
@@ -9,7 +9,7 @@ import java.util.List;
 @Getter
 @Builder
 public class UserCaffeineInfoCreateResponse {
-    private Long userId;
+    private String userId;
     private LocalDateTime createdAt;
 }
 

--- a/src/main/java/com/ktb/cafeboo/domain/user/dto/UserCaffeineInfoUpdateResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/dto/UserCaffeineInfoUpdateResponse.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
 @Getter
 @Builder
 public class UserCaffeineInfoUpdateResponse {
-    private Long userId;
+    private String userId;
     private LocalDateTime updatedAt;
 }
 

--- a/src/main/java/com/ktb/cafeboo/domain/user/dto/UserHealthInfoCreateResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/dto/UserHealthInfoCreateResponse.java
@@ -8,6 +8,6 @@ import java.time.LocalDateTime;
 @Getter
 @Builder
 public class UserHealthInfoCreateResponse {
-    private Long userId;
+    private String userId;
     private LocalDateTime createdAt;
 }

--- a/src/main/java/com/ktb/cafeboo/domain/user/dto/UserHealthInfoUpdateResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/dto/UserHealthInfoUpdateResponse.java
@@ -8,6 +8,6 @@ import java.time.LocalDateTime;
 @Getter
 @Builder
 public class UserHealthInfoUpdateResponse {
-    private Long userId;
+    private String userId;
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/ktb/cafeboo/domain/user/mapper/UserCaffeineInfoMapper.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/mapper/UserCaffeineInfoMapper.java
@@ -19,9 +19,6 @@ public class UserCaffeineInfoMapper {
                 .caffeineSensitivity(dto.getCaffeineSensitivity())
                 .averageDailyCaffeineIntake(dto.getAverageDailyCaffeineIntake())
                 .frequentDrinkTime(LocalTime.parse(dto.getFrequentDrinkTime()))
-                // TODO: 인공지능 서버로 하루 임계치 계산 필요
-                .dailyCaffeineLimitMg(400)
-                .sleepSensitiveThresholdMg(100)
                 .build();
     }
 

--- a/src/main/java/com/ktb/cafeboo/domain/user/model/UserFavoriteDrinkType.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/model/UserFavoriteDrinkType.java
@@ -13,7 +13,6 @@ import org.hibernate.annotations.Where;
 @Getter
 @Setter
 @NoArgsConstructor
-@Where(clause = "deleted_at IS NULL")
 public class UserFavoriteDrinkType {
 
     @Id

--- a/src/main/java/com/ktb/cafeboo/domain/user/service/UserAlarmSettingService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/service/UserAlarmSettingService.java
@@ -32,7 +32,7 @@ public class UserAlarmSettingService {
             UserAlarmSetting entity = UserAlarmSettingMapper.toEntity(request, user);
             userAlarmSettingRepository.save(entity);
             return UserAlarmSettingCreateResponse.builder()
-                    .userId(user.getId())
+                    .userId(user.getId().toString())
                     .createdAt(entity.getCreatedAt())
                     .build();
         } catch (Exception e) {
@@ -42,16 +42,18 @@ public class UserAlarmSettingService {
 
     @Transactional
     public UserAlarmSettingUpdateResponse update(Long userId, UserAlarmSettingUpdateRequest request) {
-        userRepository.findById(userId)
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomApiException(ErrorStatus.USER_NOT_FOUND));
 
-        UserAlarmSetting entity = userAlarmSettingRepository.findById(userId)
-                .orElseThrow(() -> new CustomApiException(ErrorStatus.ALARM_SETTING_NOT_FOUND));
+        UserAlarmSetting entity = user.getAlarmSetting();
+        if (entity == null) {
+            throw new CustomApiException(ErrorStatus.ALARM_SETTING_NOT_FOUND);
+        }
 
         try {
             UserAlarmSettingMapper.updateEntity(entity, request);
             return UserAlarmSettingUpdateResponse.builder()
-                    .userId(userId)
+                    .userId(user.getId().toString())
                     .updatedAt(entity.getUpdatedAt())
                     .build();
         } catch (Exception e) {
@@ -61,11 +63,13 @@ public class UserAlarmSettingService {
 
     @Transactional(readOnly = true)
     public UserAlarmSettingResponse get(Long userId) {
-        userRepository.findById(userId)
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomApiException(ErrorStatus.USER_NOT_FOUND));
 
-        UserAlarmSetting entity = userAlarmSettingRepository.findById(userId)
-                .orElseThrow(() -> new CustomApiException(ErrorStatus.ALARM_SETTING_NOT_FOUND));
+        UserAlarmSetting entity = user.getAlarmSetting();
+        if (entity == null) {
+            throw new CustomApiException(ErrorStatus.ALARM_SETTING_NOT_FOUND);
+        }
 
         return UserAlarmSettingMapper.toResponse(entity);
     }

--- a/src/main/java/com/ktb/cafeboo/domain/user/service/UserCaffeineInfoService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/service/UserCaffeineInfoService.java
@@ -74,7 +74,7 @@ public class UserCaffeineInfoService {
             userCaffeineInfoRepository.save(entity);
 
             return UserCaffeineInfoCreateResponse.builder()
-                    .userId(user.getId())
+                    .userId(user.getId().toString())
                     .createdAt(entity.getCreatedAt())
                     .build();
 
@@ -88,8 +88,10 @@ public class UserCaffeineInfoService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomApiException(ErrorStatus.USER_NOT_FOUND));
 
-        UserCaffeinInfo entity = userCaffeineInfoRepository.findById(userId)
-                .orElseThrow(() -> new CustomApiException(ErrorStatus.CAFFEINE_PROFILE_NOT_FOUND));
+        UserCaffeinInfo entity = user.getCaffeinInfo();
+        if (entity == null) {
+            throw new CustomApiException(ErrorStatus.CAFFEINE_PROFILE_NOT_FOUND);
+        }
 
         try {
             UserCaffeineInfoMapper.updateEntity(entity, request);
@@ -122,7 +124,7 @@ public class UserCaffeineInfoService {
             }
 
             return UserCaffeineInfoUpdateResponse.builder()
-                    .userId(user.getId())
+                    .userId(user.getId().toString())
                     .updatedAt(entity.getUpdatedAt())
                     .build();
         } catch (Exception e) {
@@ -132,11 +134,13 @@ public class UserCaffeineInfoService {
 
     @Transactional(readOnly = true)
     public UserCaffeineInfoResponse getCaffeineInfo(Long userId) {
-        userRepository.findById(userId)
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomApiException(ErrorStatus.USER_NOT_FOUND));
 
-        UserCaffeinInfo entity = userCaffeineInfoRepository.findById(userId)
-                .orElseThrow(() -> new CustomApiException(ErrorStatus.CAFFEINE_PROFILE_NOT_FOUND));
+        UserCaffeinInfo entity = user.getCaffeinInfo();
+        if (entity == null) {
+            throw new CustomApiException(ErrorStatus.CAFFEINE_PROFILE_NOT_FOUND);
+        }
 
         return UserCaffeineInfoMapper.toResponse(entity);
     }

--- a/src/main/java/com/ktb/cafeboo/domain/user/service/UserCaffeineInfoService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/service/UserCaffeineInfoService.java
@@ -48,7 +48,7 @@ public class UserCaffeineInfoService {
 
             // AI 서버 호출로 하루 최대 카페인 허용량 예측
             try {
-                float predictedLimit = caffeineRecommendationService.getPredictedCaffeineLimitByRule(user);
+                float predictedLimit = caffeineRecommendationService.getPredictedCaffeineLimitByRule(user, entity.getCaffeineSensitivity());
                 entity.setDailyCaffeineLimitMg(predictedLimit);
             } catch (Exception e) {
                 log.warn("[AI 서버 호출 실패] 기존 카페인 허용량으로 설정합니다. userId: {}", userId);
@@ -79,6 +79,7 @@ public class UserCaffeineInfoService {
                     .build();
 
         } catch (Exception e) {
+            log.error(e.getMessage(), e);
             throw new CustomApiException(ErrorStatus.BAD_REQUEST);
         }
     }
@@ -98,7 +99,7 @@ public class UserCaffeineInfoService {
 
             // AI 서버 호출로 하루 최대 카페인 허용량 예측
             try {
-                float predictedLimit = caffeineRecommendationService.getPredictedCaffeineLimitByRule(user);
+                float predictedLimit = caffeineRecommendationService.getPredictedCaffeineLimitByRule(user, entity.getCaffeineSensitivity());
                 entity.setDailyCaffeineLimitMg(predictedLimit);
             } catch (Exception e) {
                 log.warn("[AI 서버 호출 실패] 기존 최대 허용 카페인량 유지. userId: {}", userId);

--- a/src/main/java/com/ktb/cafeboo/domain/user/service/UserHealthInfoService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/service/UserHealthInfoService.java
@@ -65,7 +65,7 @@ public class UserHealthInfoService {
             try {
                 UserCaffeinInfo caffeinInfo = user.getCaffeinInfo();
                 if (caffeinInfo != null) {
-                    float predictedLimit = caffeineRecommendationService.getPredictedCaffeineLimitByRule(user);
+                    float predictedLimit = caffeineRecommendationService.getPredictedCaffeineLimitByRule(user, caffeinInfo.getCaffeineSensitivity());
                     caffeinInfo.setDailyCaffeineLimitMg(predictedLimit);
                 }
             } catch (Exception e) {

--- a/src/main/java/com/ktb/cafeboo/domain/user/service/UserHealthInfoService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/service/UserHealthInfoService.java
@@ -1,23 +1,28 @@
 package com.ktb.cafeboo.domain.user.service;
 
+import com.ktb.cafeboo.domain.recommend.service.CaffeineRecommendationService;
 import com.ktb.cafeboo.domain.user.dto.*;
 import com.ktb.cafeboo.domain.user.mapper.UserHealthInfoMapper;
 import com.ktb.cafeboo.domain.user.model.User;
+import com.ktb.cafeboo.domain.user.model.UserCaffeinInfo;
 import com.ktb.cafeboo.domain.user.model.UserHealthInfo;
 import com.ktb.cafeboo.domain.user.repository.UserHealthInfoRepository;
 import com.ktb.cafeboo.domain.user.repository.UserRepository;
 import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
 import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class UserHealthInfoService {
 
     private final UserRepository userRepository;
     private final UserHealthInfoRepository userHealthInfoRepository;
+    private final CaffeineRecommendationService caffeineRecommendationService;
 
     @Transactional
     public UserHealthInfoCreateResponse create(Long userId, UserHealthInfoCreateRequest request) {
@@ -53,6 +58,19 @@ public class UserHealthInfoService {
 
         try {
             UserHealthInfoMapper.updateEntity(healthInfo, request);
+
+            // 건강 정보 수정 시, 최대 허용 카페인량 업데이트
+            try {
+                UserCaffeinInfo caffeinInfo = user.getCaffeinInfo();
+                if (caffeinInfo != null) {
+                    float predictedLimit = caffeineRecommendationService.getPredictedCaffeineLimitByRule(user);
+                    caffeinInfo.setDailyCaffeineLimitMg(predictedLimit);
+                }
+            } catch (Exception e) {
+                log.warn("[AI 서버 호출 실패] 기존 최대 허용 카페인량 유지. userId: {}", userId);
+                // 값 유지
+            }
+
         } catch (Exception e) {
             throw new CustomApiException(ErrorStatus.BAD_REQUEST);
         }

--- a/src/main/java/com/ktb/cafeboo/domain/user/service/UserHealthInfoService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/service/UserHealthInfoService.java
@@ -38,7 +38,7 @@ public class UserHealthInfoService {
             userHealthInfoRepository.save(entity);
 
             return UserHealthInfoCreateResponse.builder()
-                    .userId(user.getId())
+                    .userId(user.getId().toString())
                     .createdAt(entity.getCreatedAt())
                     .build();
 
@@ -53,8 +53,10 @@ public class UserHealthInfoService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomApiException(ErrorStatus.USER_NOT_FOUND));
 
-        UserHealthInfo healthInfo = userHealthInfoRepository.findById(userId)
-                .orElseThrow(() -> new CustomApiException(ErrorStatus.HEALTH_PROFILE_NOT_FOUND));
+        UserHealthInfo healthInfo = user.getHealthInfo();
+        if (healthInfo == null) {
+            throw new CustomApiException(ErrorStatus.HEALTH_PROFILE_NOT_FOUND);
+        }
 
         try {
             UserHealthInfoMapper.updateEntity(healthInfo, request);
@@ -76,7 +78,7 @@ public class UserHealthInfoService {
         }
 
         return UserHealthInfoUpdateResponse.builder()
-                .userId(userId)
+                .userId(userId.toString())
                 .updatedAt(healthInfo.getUpdatedAt())
                 .build();
     }
@@ -86,8 +88,10 @@ public class UserHealthInfoService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomApiException(ErrorStatus.USER_NOT_FOUND));
 
-        UserHealthInfo healthInfo = userHealthInfoRepository.findById(userId)
-                .orElseThrow(() -> new CustomApiException(ErrorStatus.HEALTH_PROFILE_NOT_FOUND));
+        UserHealthInfo healthInfo = user.getHealthInfo();
+        if (healthInfo == null) {
+            throw new CustomApiException(ErrorStatus.HEALTH_PROFILE_NOT_FOUND);
+        }
 
         return UserHealthInfoMapper.toResponse(healthInfo);
     }

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/ErrorStatus.java
@@ -36,12 +36,14 @@ public enum ErrorStatus implements BaseCode {
     ALARM_SETTING_ALREADY_EXISTS(409, "ALARM_SETTING_ALREADY_EXISTS", "이미 알림 설정이 존재합니다."),
     ALARM_SETTING_NOT_FOUND(404, "ALARM_SETTING_NOT_FOUND", "알림 설정 정보를 찾을 수 없습니다."),
 
-    //섭취 내역 관련 오류
+    // 섭취 내역 관련 오류
     INTAKE_INFO_NOT_FOUND(404, "INTAKE_INFO_NOT_FOUND", "섭취 내역을 찾을 수 없습니다."),
 
-    //음료 관련 오류
-    DRINK_NOT_FOUND(404, "DRINK_NOT_FOUND", "음료 정보를 찾을 수 없습니다.")
-    ;
+    // 음료 관련 오류
+    DRINK_NOT_FOUND(404, "DRINK_NOT_FOUND", "음료 정보를 찾을 수 없습니다."),
+
+    // 외부 시스템 관련 오류
+    AI_SERVER_ERROR(502, "AI_SERVER_ERROR", "AI 서버와의 통신 중 오류가 발생했습니다.");
 
     private final int status;
     private final String code;

--- a/src/main/java/com/ktb/cafeboo/global/infra/ai/client/AiServerClient.java
+++ b/src/main/java/com/ktb/cafeboo/global/infra/ai/client/AiServerClient.java
@@ -1,7 +1,7 @@
 package com.ktb.cafeboo.global.infra.ai.client;
 
-import com.ktb.cafeboo.global.infra.ai.dto.PredictCaffeineLimitRequest;
-import com.ktb.cafeboo.global.infra.ai.dto.PredictCaffeineLimitResponse;
+import com.ktb.cafeboo.global.infra.ai.dto.PredictCaffeineLimitByRuleRequest;
+import com.ktb.cafeboo.global.infra.ai.dto.PredictCaffeineLimitByRuleResponse;
 import com.ktb.cafeboo.global.infra.ai.dto.PredictCanIntakeCaffeineRequest;
 import com.ktb.cafeboo.global.infra.ai.dto.PredictCanIntakeCaffeineResponse;
 import lombok.RequiredArgsConstructor;
@@ -15,19 +15,20 @@ public class AiServerClient {
 
     private final WebClient aiServerWebClient;
 
-    public PredictCaffeineLimitResponse predictCaffeineLimit(PredictCaffeineLimitRequest request) {
+    public PredictCaffeineLimitByRuleResponse predictCaffeineLimitByRule(PredictCaffeineLimitByRuleRequest request) {
         return aiServerWebClient.post()
                 .uri("/internal/ai/predict_limit")
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(request)
                 .retrieve()
-                .bodyToMono(PredictCaffeineLimitResponse.class)
+                .bodyToMono(PredictCaffeineLimitByRuleResponse.class)
                 .block();
     }
 
     public PredictCanIntakeCaffeineResponse predictCanIntakeCaffeine(PredictCanIntakeCaffeineRequest request) {
         return aiServerWebClient.post()
                 .uri("/internal/ai/can_intake_caffeine")
+                .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(request)
                 .retrieve()
                 .bodyToMono(PredictCanIntakeCaffeineResponse.class)

--- a/src/main/java/com/ktb/cafeboo/global/infra/ai/dto/PredictCaffeineLimitByRuleRequest.java
+++ b/src/main/java/com/ktb/cafeboo/global/infra/ai/dto/PredictCaffeineLimitByRuleRequest.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 @Getter
 @Builder
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public class PredictCaffeineLimitRequest {
+public class PredictCaffeineLimitByRuleRequest {
     private String userId;
     private String modelHint;
     private String gender;

--- a/src/main/java/com/ktb/cafeboo/global/infra/ai/dto/PredictCaffeineLimitByRuleResponse.java
+++ b/src/main/java/com/ktb/cafeboo/global/infra/ai/dto/PredictCaffeineLimitByRuleResponse.java
@@ -1,20 +1,25 @@
 package com.ktb.cafeboo.global.infra.ai.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Getter;
 
 @Getter
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public class PredictCaffeineLimitResponse {
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PredictCaffeineLimitByRuleResponse {
     private String status;
     private String message;
     private Data data;
 
     @Getter
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Data {
         private String userId;
-        private float maxCaffeineMg;
+        private Float maxCaffeineMg;
+        private String code;
+        private String detail;
     }
 }

--- a/src/main/java/com/ktb/cafeboo/global/infra/ai/dto/PredictCaffeineLimitRequest.java
+++ b/src/main/java/com/ktb/cafeboo/global/infra/ai/dto/PredictCaffeineLimitRequest.java
@@ -1,10 +1,13 @@
 package com.ktb.cafeboo.global.infra.ai.dto;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class PredictCaffeineLimitRequest {
     private String userId;
     private String modelHint;

--- a/src/main/java/com/ktb/cafeboo/global/infra/ai/dto/PredictCaffeineLimitResponse.java
+++ b/src/main/java/com/ktb/cafeboo/global/infra/ai/dto/PredictCaffeineLimitResponse.java
@@ -1,14 +1,18 @@
 package com.ktb.cafeboo.global.infra.ai.dto;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Getter;
 
 @Getter
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class PredictCaffeineLimitResponse {
     private String status;
     private String message;
     private Data data;
 
     @Getter
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     public static class Data {
         private String userId;
         private float maxCaffeineMg;

--- a/src/main/java/com/ktb/cafeboo/global/infra/ai/dto/PredictCanIntakeCaffeineRequest.java
+++ b/src/main/java/com/ktb/cafeboo/global/infra/ai/dto/PredictCanIntakeCaffeineRequest.java
@@ -1,10 +1,13 @@
 package com.ktb.cafeboo.global.infra.ai.dto;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class PredictCanIntakeCaffeineRequest {
     private String userId;
     private double currentTime;

--- a/src/main/java/com/ktb/cafeboo/global/infra/ai/dto/PredictCanIntakeCaffeineResponse.java
+++ b/src/main/java/com/ktb/cafeboo/global/infra/ai/dto/PredictCanIntakeCaffeineResponse.java
@@ -1,14 +1,18 @@
 package com.ktb.cafeboo.global.infra.ai.dto;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Getter;
 
 @Getter
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class PredictCanIntakeCaffeineResponse {
     private String status;
     private String message;
     private Data data;
 
     @Getter
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     public static class Data {
         private String userId;
         private String caffeineStatus;  // "Y" or "N"


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] 카페인 정보 생성/수정 시, 최대 카페인 허용량 계산
- [x] 건강 정보 수정 시, 최대 카페인 허용량 계산
- [x] 룰기반 예측임을 명시하도록 네이밍 수정
- [x] AI 예측 실패 시 기본값 설정 및 로깅 처리

## 🛠 변경사항
- CaffeineRecommendationService 신규 생성
- UserCaffeineInfoService, UserHealthInfoService 내 AI 서버 호출 로직 추가
- AI 서버 요청/응답 DTO 및 예외 처리 보완
- 기존 userId 타입 일관화를 위한 DTO 필드 수정(Long → String)

## 💬 리뷰 요구사항
- 서비스 레이어에서의 예측 실패 fallback 로직이 적절한지 검토 부탁드립니다.

## 🔍 테스트 방법(선택)
- 현재 인공지능 서버 배포 전이라 통신 테스트는 수행하지 못하였습니다
