### PR TITLE
✨Feat: AI 배치 전략에 맞춰 스케줄링을 통해 비동기 요청 보내는 기능

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/report/controller/DailyReportController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/report/controller/DailyReportController.java
@@ -42,12 +42,17 @@ public class DailyReportController {
     @GetMapping
     public ResponseEntity<ApiResponse<DailyCaffeineReportResponse>> getDailyCaffeineReport(
         @AuthenticationPrincipal CustomUserDetails userDetails,
-        @RequestParam(required = false) LocalDate targetDate) {
+        @RequestParam(required = false, name = "date") String targetDate) {
 
         Long userId = userDetails.getId();
+        LocalDate date;
 
+        if(targetDate == null)
+            date = LocalDate.now();
+        else
+            date = LocalDate.parse(targetDate);
         // 일일 리포트 생성
-        DailyCaffeineReportResponse response = dailyReportService.createDailyReport(userId, targetDate, LocalTime.now());
+        DailyCaffeineReportResponse response = dailyReportService.createDailyReport(userId, date, LocalTime.now());
 
         return ResponseEntity.ok(ApiResponse.of(SuccessStatus.DAILY_CAFFEINE_REPORT_SUCCESS, response));
     }

--- a/src/main/java/com/ktb/cafeboo/domain/report/controller/WeeklyReportController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/report/controller/WeeklyReportController.java
@@ -5,6 +5,7 @@ import com.ktb.cafeboo.domain.caffeinediary.service.CaffeineIntakeService;
 import com.ktb.cafeboo.domain.report.dto.WeeklyCaffeineReportResponse;
 import com.ktb.cafeboo.domain.report.model.DailyStatistics;
 import com.ktb.cafeboo.domain.report.service.DailyStatisticsService;
+import com.ktb.cafeboo.domain.report.service.WeeklyReportScheduler;
 import com.ktb.cafeboo.domain.report.service.WeeklyReportService;
 import com.ktb.cafeboo.global.apiPayload.ApiResponse;
 import com.ktb.cafeboo.global.apiPayload.code.status.SuccessStatus;
@@ -28,6 +29,7 @@ public class WeeklyReportController {
     private final WeeklyReportService weeklyReportService;
     private final DailyStatisticsService dailyStatisticsService;
     private final CaffeineIntakeService intakeService;
+    private final WeeklyReportScheduler weeklyReportScheduler;
     /**
      * 사용자의 일일 카페인 섭취 현황 데이터를 조회합니다.
      * 상세 스펙은 @see <a href="https://freckle-pipe-840.notion.site/1ddb43be904c80ccbb02c746ff16a3ba">주간 섭취 현황 조회 API 스펙 문서</a>
@@ -67,5 +69,11 @@ public class WeeklyReportController {
         WeeklyCaffeineReportResponse response = weeklyReportService.getWeeklyReport(userId, targetYear, targetMonth, targetWeek, dailyStats, intakes);
 
         return ResponseEntity.ok(ApiResponse.of(SuccessStatus.WEEKLY_CAFFEINE_REPORT_SUCCESS, response));
+    }
+
+    @GetMapping("/test")
+    public void getWeeklyCaffeineReport(
+        @AuthenticationPrincipal CustomUserDetails userDetails){
+        weeklyReportScheduler.generateWeeklyReports();
     }
 }

--- a/src/main/java/com/ktb/cafeboo/domain/report/model/MonthlyReport.java
+++ b/src/main/java/com/ktb/cafeboo/domain/report/model/MonthlyReport.java
@@ -13,6 +13,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.Where;
+import org.w3c.dom.Text;
 
 @Entity
 @Table(name = "MonthlyReports")
@@ -43,7 +44,4 @@ public class MonthlyReport extends BaseEntity {
 
     @Column(name = "weekly_caffeine_avg_mg", nullable = false)
     private float weeklyCaffeineAvgMg;
-
-    @Column(name = "ai_message")
-    private String aiMessage;
 }

--- a/src/main/java/com/ktb/cafeboo/domain/report/model/WeeklyReport.java
+++ b/src/main/java/com/ktb/cafeboo/domain/report/model/WeeklyReport.java
@@ -42,6 +42,7 @@ public class WeeklyReport extends BaseEntity {
     @Column(name = "over_intake_days", nullable = false)
     private Integer overIntakeDays;
 
-    @Column(name = "ai_message")
+    @Lob
+    @Column(name = "ai_message", columnDefinition = "TEXT")
     private String aiMessage;
 }

--- a/src/main/java/com/ktb/cafeboo/domain/report/service/MonthlyReportService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/report/service/MonthlyReportService.java
@@ -41,7 +41,6 @@ public class MonthlyReportService {
                     .yearlyStatisticsId(yearlyReport)
                     .totalCaffeineMg(0f)
                     .weeklyCaffeineAvgMg(0f)
-                    .aiMessage("")
                     .build();
                 return monthlyReportRepository.save(newReport);
             });

--- a/src/main/java/com/ktb/cafeboo/domain/report/service/WeeklyReportScheduler.java
+++ b/src/main/java/com/ktb/cafeboo/domain/report/service/WeeklyReportScheduler.java
@@ -1,0 +1,290 @@
+package com.ktb.cafeboo.domain.report.service;
+
+import com.ktb.cafeboo.domain.caffeinediary.model.CaffeineIntake;
+import com.ktb.cafeboo.domain.caffeinediary.model.CaffeineResidual;
+import com.ktb.cafeboo.domain.caffeinediary.repository.CaffeineIntakeRepository;
+import com.ktb.cafeboo.domain.caffeinediary.service.CaffeineResidualService;
+import com.ktb.cafeboo.domain.report.dto.CoffeeTimeStats;
+import com.ktb.cafeboo.domain.report.model.WeeklyReport;
+import com.ktb.cafeboo.domain.report.repository.WeeklyReportRepository;
+import com.ktb.cafeboo.domain.user.model.User;
+import com.ktb.cafeboo.domain.user.repository.UserRepository;
+import com.ktb.cafeboo.global.infra.ai.client.AiServerClient;
+import com.ktb.cafeboo.global.infra.ai.dto.CreateWeeklyReportRequest;
+import com.ktb.cafeboo.global.infra.ai.dto.CreateWeeklyReportResponse;
+import jakarta.transaction.Transactional;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.IsoFields;
+import java.time.temporal.WeekFields;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class WeeklyReportScheduler {
+    private final UserRepository userRepository;
+    private final AiServerClient aiServerClient;
+    private final WeeklyReportRepository weeklyReportRepository;
+    private final CaffeineIntakeRepository intakeRepository;
+    private final CaffeineResidualService caffeineResidualService;
+
+    @Scheduled(cron = "0 0 0 * * SUN") // 매주 일요일 0시
+    public void generateWeeklyReports() {
+//        LocalDate endDate = LocalDate.now().minusDays(1); // 지난 주 토요일
+//        LocalDate startDate = endDate.minusDays(6);       // 지난 주 일요일
+
+        int targetYear = 2024;
+        int targetWeekNum = 19;
+
+        // ISO 8601 표준 (월요일 시작, 한 주의 최소 4일 포함)을 따르는 WeekFields 객체 생성
+        WeekFields isoWeekFields = WeekFields.of(Locale.getDefault());
+
+        // 해당 년도의 첫 번째 날짜
+        LocalDate firstDayOfYear = LocalDate.of(targetYear, 1, 1);
+
+        // 첫 번째 주(week 1)의 첫 번째 날 (월요일) 찾기
+        LocalDate firstMonday = firstDayOfYear;
+        if (firstMonday.getDayOfWeek() != DayOfWeek.MONDAY) {
+            firstMonday = firstMonday.with(WeekFields.ISO.dayOfWeek(), 1); // 해당 주의 월요일로 이동
+            if (firstMonday.getYear() > targetYear) {
+                firstMonday = firstDayOfYear.plusWeeks(1).with(WeekFields.ISO.dayOfWeek(), 1);
+            }
+        }
+
+        // targetWeekNum 주의 시작 날짜 계산
+        LocalDate startDate = firstMonday.plusWeeks(targetWeekNum - 1);
+
+        // targetWeekNum 주의 마지막 날짜 계산 (일요일)
+        LocalDate endDate = startDate.plusDays(6);
+
+        int weeknum = startDate.get(IsoFields.WEEK_OF_WEEK_BASED_YEAR);
+        int year = startDate.getYear();
+
+        Mono.fromCallable(userRepository::findAll)
+            .flatMapMany(Flux::fromIterable)
+            .flatMap(user -> createWeeklyReportRequest(user, startDate, endDate)
+                .flatMap(request -> Mono.fromCallable(() -> aiServerClient.createWeeklyReportAnalysis(request))
+                    .flatMap(response -> saveWeeklyReport(user, year, weeknum, request, response))
+                    .onErrorResume(e -> {
+                        log.error("유저 {} 주간 보고서 생성 실패: {}", user.getId(), e.getMessage());
+                        return Mono.empty();
+                    })
+                )
+            )
+            .subscribeOn(Schedulers.boundedElastic())
+            .subscribe(
+                report -> log.info("유저 {} 주간 보고서 생성 완료: {}", report.getUser().getId(), report.getWeekNum()),
+                error -> log.error("주간 보고서 생성 중 에러 발생: {}", error.getMessage()),
+                () -> log.info("주간 보고서 생성 작업 완료")
+            );
+    }
+
+
+
+    private Mono<CreateWeeklyReportRequest> createWeeklyReportRequest(User user, LocalDate startDate, LocalDate endDate) {
+        return Mono.fromCallable(() -> intakeRepository.findByUserIdAndIntakeTimeBetween(user.getId(), startDate.atStartOfDay(), endDate.atTime(LocalTime.MAX)))
+            .flatMap(intakes -> {
+                // 2. 통계 계산
+                Map<DayOfWeek, Double> dailyCaffeine = intakes.stream()
+                    .collect(Collectors.groupingBy(
+                        record -> record.getIntakeTime().getDayOfWeek(),
+                        Collectors.summingDouble(CaffeineIntake::getCaffeineAmountMg)
+                    ));
+                DayOfWeek highlightDayHigh = dailyCaffeine.entrySet().stream()
+                    .max(Map.Entry.comparingByValue())
+                    .map(Map.Entry::getKey)
+                    .orElse(null);
+                DayOfWeek highlightDayLow = dailyCaffeine.entrySet().stream()
+                    .min(Map.Entry.comparingByValue())
+                    .map(Map.Entry::getKey)
+                    .orElse(null);
+                String highlightDayHighStr = (highlightDayHigh != null) ? highlightDayHigh.toString().substring(0, 3) : "Mon";
+                String highlightDayLowStr = (highlightDayLow != null) ? highlightDayLow.toString().substring(0, 3) : "Mon";
+
+                CoffeeTimeStats coffeeTimeStats = calculate(user, intakes);
+                LocalTime firstAvg = coffeeTimeStats.firstAvg;
+                LocalTime lastAvg = coffeeTimeStats.lastAvg;
+                int lateNightDays = coffeeTimeStats.lateNightDays;
+
+                // 예시: 하루 평균, 권장량 등은 실제 데이터로 계산
+                double totalCaffeine = intakes.stream()
+                    .mapToDouble(CaffeineIntake::getCaffeineAmountMg)
+                    .sum();
+                double dailyAvg = totalCaffeine / 7.0;
+                double recommendedLimit = user.getCaffeinInfo().getDailyCaffeineLimitMg(); // user에서 가져오기
+
+                String period = startDate.toString() + " ~ " + endDate.toString();
+
+                int over100mgBeforeSleepDays = 0;
+
+                for (LocalDate date = startDate; !date.isAfter(endDate); date = date.plusDays(1)) {
+                    // CaffeineResidualService에서 해당 날짜, 해당 시간의 잔여 카페인(mg) 조회
+                    CaffeineResidual residual = caffeineResidualService.findByUserAndTargetDateAndHour(user, date.atStartOfDay(), user.getHealthInfo().getSleepTime().getHour());
+                    if (residual.getResidueAmountMg() > 100.0) {
+                        over100mgBeforeSleepDays++;
+                    }
+                }
+
+                // 3. CreateWeeklyReportRequest 빌드
+                CreateWeeklyReportRequest request = CreateWeeklyReportRequest.builder()
+                    .userId(user.getId().toString())
+                    .period(period)
+                    .avgCaffeinePerDay((int) dailyAvg)
+                    .recommendedDailyLimit((int) recommendedLimit)
+                    .percentageOfLimit((int) (dailyAvg * 100 / recommendedLimit))
+                    .highlightDayHigh(highlightDayHighStr)
+                    .highlightDayLow(highlightDayLowStr)
+                    .firstCoffeeAvg(firstAvg != null ? firstAvg.toString() : null)
+                    .lastCoffeeAvg(lastAvg != null ? lastAvg.toString() : null)
+                    .lateNightCaffeineDays(lateNightDays)
+                    .over100mgBeforeSleepDays(over100mgBeforeSleepDays)
+                    .averageSleepQuality("good")
+                    .build();
+
+                // null 체크
+                if (highlightDayHighStr == null || highlightDayLowStr == null
+                    || firstAvg == null || lastAvg == null) {
+                    // 필수 값이 하나라도 null이면 Mono.empty() 반환
+                    return Mono.empty();
+                }
+
+                return Mono.just(request);
+            });
+
+//        String period = startDate.toString() + " ~ " + endDate.toString();
+//
+//        // highlight_day_high 계산
+//        Map<DayOfWeek, Double> dailyCaffeine = intakes.stream()
+//            .collect(Collectors.groupingBy(record -> record.getIntakeTime().getDayOfWeek(),
+//                Collectors.summingDouble(CaffeineIntake::getCaffeineAmountMg)));
+//        DayOfWeek highlightDayHigh = dailyCaffeine.entrySet().stream()
+//            .max(Map.Entry.comparingByValue())
+//            .map(Map.Entry::getKey)
+//            .orElse(null);
+//
+//        // hightlight_day_low 계산
+//        DayOfWeek highlightDayLow = dailyCaffeine.entrySet().stream()
+//            .min(Map.Entry.comparingByValue())
+//            .map(Map.Entry::getKey)
+//            .orElse(null);
+//        String highlightDayHighStr = (highlightDayHigh != null) ? highlightDayHigh.toString().substring(0, 3) : null;
+//        String highlightDayLowStr = (highlightDayLow != null) ? highlightDayLow.toString().substring(0, 3) : null;
+//
+//        CoffeeTimeStats coffee_time_stats = calculate(intakes);
+//        LocalTime firstAvg = coffee_time_stats.firstAvg;
+//        LocalTime lastAvg = coffee_time_stats.lastAvg;
+//        int lateNightDays = coffee_time_stats.lateNightDays;
+//
+//        CreateWeeklyReportRequest request = CreateWeeklyReportRequest.builder()
+//            .userId(userId.toString())
+//            .period(period)
+//            .avgCaffeinePerDay((int)dailyAvg)
+//            .recommendedDailyLimit((int)userCaffeinInfo.getDailyCaffeineLimitMg())
+//            .percentageOfLimit((int)dailyAvg / (int)userCaffeinInfo.getDailyCaffeineLimitMg())
+//            .highlightDayHigh(highlightDayHighStr)
+//            .highlightDayLow(highlightDayLowStr)
+//            .firstCoffeeAvg(firstAvg.toString())
+//            .lastCoffeeAvg(lastAvg.toString())
+//            .lateNightCaffeineDays(lateNightDays)
+//            .over100mgBeforeSleepDays(0)
+//            .build();
+//
+//        System.out.println("userId: " + request.getUserId());
+//        System.out.println("period: " + request.getPeriod());
+//        System.out.println("avgCaffeinePerDay: " + request.getAvgCaffeinePerDay());
+//        System.out.println("recommendedDailyLimit: " + request.getRecommendedDailyLimit());
+//        System.out.println("percentageOfLimit: " + request.getPercentageOfLimit());
+//        System.out.println("highlightDayHigh: " + request.getHighlightDayHigh());
+//        System.out.println("highlightDayLow: " + request.getHighlightDayLow());
+//        System.out.println("firstCoffeeAvg: " + request.getFirstCoffeeAvg());
+//        System.out.println("lastCoffeeAvg: " + request.getLastCoffeeAvg());
+//        System.out.println("lateNightCaffeineDays: " + request.getLateNightCaffeineDays());
+//        System.out.println("over100mgBeforeSleepDays: " + request.getOver100mgBeforeSleepDays());
+//
+//        CreateWeeklyReportResponse response = aiServerClient.createWeeklyReportAnalysis(request);
+//
+//        String summaryMessage = "이번 주 평균 섭취량은 권장량의 " + (dailyAvg * 100 / 400) + "% 수준입니다."
+    }
+
+    private Mono<WeeklyReport> saveWeeklyReport(User user, int year, int weeknum, CreateWeeklyReportRequest request, CreateWeeklyReportResponse response) {
+        WeeklyReport weeklyReport = weeklyReportRepository.findByUserIdAndYearAndWeekNum(user.getId(), year, weeknum)
+            .orElse(null);
+
+        if(weeklyReport == null)
+            return Mono.empty();
+
+        weeklyReport.setAiMessage(response.getData().getReport());
+        return Mono.fromCallable(() -> weeklyReportRepository.save(weeklyReport));
+    }
+
+    private static CoffeeTimeStats calculate(User user, List<CaffeineIntake> intakes) {
+        // 1. 날짜별로 그룹핑
+        Map<LocalDate, List<CaffeineIntake>> byDate = intakes.stream()
+            .collect(Collectors.groupingBy(i -> i.getIntakeTime().toLocalDate()));
+
+        List<LocalTime> firstTimes = new ArrayList<>();
+        List<LocalTime> lastTimes = new ArrayList<>();
+        int lateNightDays = 0;
+
+        LocalTime wakeUpTime = user.getHealthInfo().getWakeUpTime();
+
+        for (Map.Entry<LocalDate, List<CaffeineIntake>> entry : byDate.entrySet()) {
+            LocalDate date = entry.getKey();
+            List<CaffeineIntake> dayIntakes = entry.getValue();
+
+            // intakeTime 기준 정렬
+            List<LocalTime> times = dayIntakes.stream()
+                .map(i -> i.getIntakeTime().toLocalTime())
+                .sorted()
+                .collect(Collectors.toList());
+
+            // 첫/마지막 커피 시간
+            firstTimes.add(times.get(0));
+            lastTimes.add(times.get(times.size() - 1));
+
+            // 22시 ~ 다음날 기상시간 사이 섭취 기록이 있는지 체크
+            LocalDateTime lateStart = date.atTime(22, 0);
+            LocalDateTime lateEnd = date.plusDays(1).atTime(wakeUpTime);
+
+            boolean hasLateNight = dayIntakes.stream()
+                .map(CaffeineIntake::getIntakeTime)
+                .anyMatch(dt -> !dt.isBefore(lateStart) && dt.isBefore(lateEnd));
+
+            if (hasLateNight)
+                lateNightDays++;
+        }
+
+        // 평균 시간 계산 (초 단위로 변환 후 평균)
+        LocalTime firstAvg = averageLocalTimes(firstTimes);
+        LocalTime lastAvg = averageLocalTimes(lastTimes);
+        return new CoffeeTimeStats(firstAvg, lastAvg, lateNightDays);
+    }
+
+    private static LocalTime averageLocalTimes(List<LocalTime> times) {
+        if (times.isEmpty()) return null;
+        double avgSeconds = times.stream()
+            .mapToLong(t -> t.toSecondOfDay())
+            .average()
+            .orElse(0);
+
+        int avgMinutes = (int) Math.round(avgSeconds / 60.0); // 반올림해서 분 단위로
+        int hour = avgMinutes / 60;
+        int minute = avgMinutes % 60;
+        return LocalTime.of(hour, minute);
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/global/infra/ai/client/AiServerClient.java
+++ b/src/main/java/com/ktb/cafeboo/global/infra/ai/client/AiServerClient.java
@@ -32,7 +32,7 @@ public class AiServerClient {
 
     public PredictCanIntakeCaffeineResponse predictCanIntakeCaffeine(PredictCanIntakeCaffeineRequest request) {
         return aiServerWebClient.post()
-                .uri("/internal/ai/can_intake_caffeine")
+                .uri("https://jeff-cloud.com/internal/ai/can_intake_caffeine")
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(request)
                 .retrieve()
@@ -42,7 +42,7 @@ public class AiServerClient {
 
     public CreateWeeklyReportResponse createWeeklyReportAnalysis(CreateWeeklyReportRequest request){
         return aiServerWebClient.post()
-            .uri("/internal/ai/caffeine_weekly_report")
+            .uri("https://jeff-cloud.com/internal/ai/caffeine_weekly_report")
             .bodyValue(request)
             .retrieve()
             .bodyToMono(CreateWeeklyReportResponse.class)

--- a/src/main/java/com/ktb/cafeboo/global/infra/ai/client/AiServerClient.java
+++ b/src/main/java/com/ktb/cafeboo/global/infra/ai/client/AiServerClient.java
@@ -32,7 +32,7 @@ public class AiServerClient {
 
     public PredictCanIntakeCaffeineResponse predictCanIntakeCaffeine(PredictCanIntakeCaffeineRequest request) {
         return aiServerWebClient.post()
-                .uri("https://jeff-cloud.com/internal/ai/can_intake_caffeine")
+                .uri("/internal/ai/can_intake_caffeine")
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(request)
                 .retrieve()
@@ -42,7 +42,7 @@ public class AiServerClient {
 
     public CreateWeeklyReportResponse createWeeklyReportAnalysis(CreateWeeklyReportRequest request){
         return aiServerWebClient.post()
-            .uri("https://jeff-cloud.com/internal/ai/caffeine_weekly_report")
+            .uri("/internal/ai/caffeine_weekly_report")
             .bodyValue(request)
             .retrieve()
             .bodyToMono(CreateWeeklyReportResponse.class)

--- a/src/main/java/com/ktb/cafeboo/global/infra/ai/dto/CreateWeeklyReportRequest.java
+++ b/src/main/java/com/ktb/cafeboo/global/infra/ai/dto/CreateWeeklyReportRequest.java
@@ -42,4 +42,7 @@ public class CreateWeeklyReportRequest {
 
     @JsonProperty("over_100mg_before_sleep_days")
     private Integer over100mgBeforeSleepDays;
+
+    @JsonProperty("average_sleep_quality")
+    private String averageSleepQuality;
 }

--- a/src/main/java/com/ktb/cafeboo/global/infra/ai/dto/CreateWeeklyReportResponse.java
+++ b/src/main/java/com/ktb/cafeboo/global/infra/ai/dto/CreateWeeklyReportResponse.java
@@ -1,5 +1,6 @@
 package com.ktb.cafeboo.global.infra.ai.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 
 @Getter
@@ -10,6 +11,7 @@ public class CreateWeeklyReportResponse {
 
     @Getter
     public static class Data {
+        @JsonProperty("user_id")
         private String userId;
         private String report;
     }


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] AI 배치 전략에 맞춰 스케줄링을 통해 비동기 요청 보내는 기능
- [x] 카페인 섭취 내역 등록 시, 일일 섭취량이 개인 권장량보다 많을 시 overIntakeDays에 반영되지 않는 버그 수정 

## 🛠 변경사항
- 스케줄링을 통해 비동기 요청 보내는 스케줄러 서비스 구현
- DailyStatisticsService에서 데이터 관리 동작 순서 수정

## 💬 리뷰 요구사항
- Report 도메인의 WeeklyReportScheduler 한 번 봐주세요
- WeeklyReport 도메인에 WeeklyReportScheduler의 메서드 호출을 위한 테스트용 API를 작성했습니다. 테스트 후 문제가 없다면 삭제하겠습니다.

## 🔍 테스트 방법(선택)
- postman, dataGrip을 활용한 수동 체크
