### PR TITLE
fix: 카페인 허용량 예측 api 요청 dto 변경에 따른 서비스 로직 수정

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/recommend/service/CaffeineRecommendationService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/recommend/service/CaffeineRecommendationService.java
@@ -10,8 +10,6 @@ import com.ktb.cafeboo.global.infra.ai.dto.PredictCaffeineLimitByRuleResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 
 @Slf4j

--- a/src/main/java/com/ktb/cafeboo/domain/recommend/service/CaffeineRecommendationService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/recommend/service/CaffeineRecommendationService.java
@@ -7,12 +7,12 @@ import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
 import com.ktb.cafeboo.global.infra.ai.client.AiServerClient;
 import com.ktb.cafeboo.global.infra.ai.dto.PredictCaffeineLimitByRuleRequest;
 import com.ktb.cafeboo.global.infra.ai.dto.PredictCaffeineLimitByRuleResponse;
-import com.ktb.cafeboo.domain.user.repository.UserRepository;
-import com.ktb.cafeboo.domain.user.repository.UserCaffeineInfoRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 
 @Slf4j
 @Service
@@ -20,8 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class CaffeineRecommendationService {
 
     private final AiServerClient aiServerClient;
-    private final UserRepository userRepository;
-    private final UserCaffeineInfoRepository userCaffeineInfoRepository;
 
     public float getPredictedCaffeineLimitByRule(User user, int caffeineSensitivity) {
         // [RULE 기반] 사용자 상태정보를 바탕으로 하루 최대 카페인 허용량 예측
@@ -32,11 +30,10 @@ public class CaffeineRecommendationService {
 
         PredictCaffeineLimitByRuleRequest request = PredictCaffeineLimitByRuleRequest.builder()
                 .userId(user.getId().toString())
-                .modelHint("rule")  // 명시적으로 rule 기반임을 전달
                 .gender(healthInfo.getGender())
                 .age(healthInfo.getAge())
                 .weight(healthInfo.getWeight())
-                .height((int) healthInfo.getHeight())
+                .height(healthInfo.getHeight())
                 .isSmoker(healthInfo.getSmoking() ? 1 : 0)
                 .takeHormonalContraceptive(healthInfo.getTakingBirthPill() ? 1 : 0)
                 .caffeineSensitivity(caffeineSensitivity)
@@ -52,6 +49,10 @@ public class CaffeineRecommendationService {
             throw new CustomApiException(ErrorStatus.AI_SERVER_ERROR);
         }
 
-        return response.getData().getMaxCaffeineMg();
+        float result = response.getData().getMaxCaffeineMg();
+        log.info("[AI 서버 호출 성공] 최대 허용 카페인량을 성공적으로 예측하였습니다.");
+        log.info("예측 최대 허용 카페인량: {}", result);
+
+        return result;
     }
 }


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] dto의 삭제된 필드를 빌더 패턴으로 지정해주는 코드 삭제 

## 🛠 변경사항
- CaffeineRecommendationService 내 getPredictedCaffeineLimitByRule 메서드 수정
- 요청 바디 빌드하는 부분 수정

## 💬 리뷰 요구사항
