### PR TITLE
✏️Chore: 음료 등록 관련 수정

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/drink/service/DrinkService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/drink/service/DrinkService.java
@@ -18,7 +18,7 @@ public class DrinkService {
 
     public DrinkSizeNutrition findDrinkSizeNutritionByIdAndSize(Long drinkSizeNutritionId, DrinkSize size){
         DrinkSizeNutrition target = drinkSizeNutritionRepository.findByIdAndSize(drinkSizeNutritionId, size)
-            .orElseThrow(() -> new CustomApiException(ErrorStatus.DRINK_NOT_FOUND));
+            .orElseThrow(() -> new CustomApiException(ErrorStatus.DRINK_SIZE_NOT_FOUND));
 
         return target;
     }

--- a/src/main/java/com/ktb/cafeboo/domain/report/service/DailyStatisticsService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/report/service/DailyStatisticsService.java
@@ -100,11 +100,11 @@ public class DailyStatisticsService {
 
         PredictCanIntakeCaffeineResponse response = aiServerClient.predictCanIntakeCaffeine(request);
 
-        String message = "권장량의 " + (statistics.getTotalCaffeineMg() / user.getCaffeinInfo().getDailyCaffeineLimitMg()) * 100 + "%를 섭취 중이에요.";
+        String message = "권장량의 " + (int)((statistics.getTotalCaffeineMg() / user.getCaffeinInfo().getDailyCaffeineLimitMg()) * 100) + "%를 섭취 중이에요.";
 
         if(Objects.equals(response.getStatus(), "success")){
             if(Objects.equals(response.getData().getCaffeineStatus(), "N")){
-                message += " 지금 카페인을 추가로 섭취하면 수면에 영향을 줄 수 있어요.";
+                message += " 카페인을 추가로 섭취하면 수면에 영향을 줄 수 있어요.";
             }
             else if (Objects.equals(response.getData().getCaffeineStatus(), "Y")){
                 message += " 카페인을 추가로 섭취해도 수면에 영향이 없어요.";

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/ErrorStatus.java
@@ -41,6 +41,7 @@ public enum ErrorStatus implements BaseCode {
 
     // 음료 관련 오류
     DRINK_NOT_FOUND(404, "DRINK_NOT_FOUND", "음료 정보를 찾을 수 없습니다."),
+    DRINK_SIZE_NOT_FOUND(404, "DRINK_SIZE_NOT_FOUND", "음료 정보를 찾을 수 없습니다."),
 
     // 외부 시스템 관련 오류
     AI_SERVER_ERROR(502, "AI_SERVER_ERROR", "AI 서버와의 통신 중 오류가 발생했습니다."),


### PR DESCRIPTION
디버깅용 에러 추가: 기존에는 음료 정보, 음료 사이즈별 정보가 없을 때 모두 DRINK_NOT_FOUND를 return. 음료 정보, 음료 사이즈 중 어떤게 문제가 되는지 확인하기 위해 DRINK_SIZE_NOT_FOUND 에러 추가.

FE에서 봤을 때 권장량의 n% 섭취 중 문구에서 소수점 5자리까지 나오는 것으로 확인. (int) 캐스팅을 통해 정수형으로 직관적으로 보일 수 있도록 수정

# 📌 Pull Request

## ✨ 작업한 내용
- [x] 디버깅용 ErrorStatus 추가

## 🛠 변경사항
- 디버깅용 ErrorStatus DRINK_SIZE_NOT_FOUND 추가

## 💬 리뷰 요구사항
- x
