### PR TITLE
🐛fix: 회원탈퇴 비즈니스 로직 수정 및 리팩토링

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/user/model/User.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/model/User.java
@@ -52,13 +52,13 @@ public class User extends BaseEntity {
     @ColumnDefault("0")
     private int coffeeBean;
 
-    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private UserHealthInfo healthInfo;
 
-    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private UserCaffeinInfo caffeinInfo;
 
-    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private UserAlarmSetting alarmSetting;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -103,21 +103,5 @@ public class User extends BaseEntity {
     public void setFavoriteDrinks(List<UserFavoriteDrinkType> favorites) {
         this.favoriteDrinks.clear(); // 기존 관계 제거
         this.favoriteDrinks.addAll(favorites);
-    }
-
-    public void withdraw() {
-        if (this.healthInfo != null) {
-            this.healthInfo.delete();
-        }
-        if (this.caffeinInfo != null) {
-            this.caffeinInfo.delete();
-        }
-        if (this.alarmSetting != null) {
-            this.alarmSetting.delete();
-        }
-        if (this.favoriteDrinks != null) {
-            this.favoriteDrinks.clear();
-        }
-        this.delete();
     }
 }

--- a/src/main/java/com/ktb/cafeboo/domain/user/service/UserService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/service/UserService.java
@@ -69,7 +69,21 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomApiException(ErrorStatus.USER_NOT_FOUND));
 
-        user.withdraw();
+        if (user.getHealthInfo() != null) {
+            user.getHealthInfo().delete();
+        }
+        if (user.getCaffeinInfo() != null) {
+            user.getCaffeinInfo().delete();
+        }
+        if (user.getAlarmSetting() != null) {
+            user.getAlarmSetting().delete();
+        }
+        if (user.getFavoriteDrinks() != null) {
+            user.getFavoriteDrinks().clear();
+        }
+        user.setRefreshToken(null);
+        user.delete();
+        userRepository.save(user);
     }
 
 }


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] 회원탈퇴 시 데이터베이스에 저장된 리프레시 토큰 삭제
- [x] 도메인에 있던 회원탈퇴 로직 서비스로 이동

## 🛠 변경사항
- UserService내 logout 메서드 수정
- User 엔티티 withdraw 메서드 삭제

## 💬 리뷰 요구사항

## 🔍 테스트 방법(선택)
- postman과 로컬 데이터베이스로 회원탈퇴 검증
