### PR TITLE
🐛Fix: 유저 마이페이지에서 정보 수정 시 카페인 한계치 값 변경됨에 따른 일일 통계 AI 메시지 내용 수정

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/report/service/DailyReportService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/report/service/DailyReportService.java
@@ -64,17 +64,17 @@ public class DailyReportService {
 
         return DailyCaffeineReportResponse.builder()
             .nickname(user.getNickname())
-            .dailyCaffeineLimit(400F)
+            .dailyCaffeineLimit(user.getCaffeinInfo().getDailyCaffeineLimitMg())
             .dailyCaffeineIntakeMg(dailyStatistics.getTotalCaffeineMg())
-            .dailyCaffeineIntakeRate(calculateIntakeRate(dailyStatistics.getTotalCaffeineMg()))
+            .dailyCaffeineIntakeRate(calculateIntakeRate(dailyStatistics.getTotalCaffeineMg(), user.getCaffeinInfo().getDailyCaffeineLimitMg()))
             .intakeGuide(dailyStatistics.getAiMessage())
             .sleepSensitiveThreshold(100F)
             .caffeineByHour(createHourlyCaffeineInfo(residuals, currentDateTime))
             .build();
     }
 
-    private int calculateIntakeRate(float dailyTotal) {
-        return (int) ((dailyTotal / 400) * 100);
+    private int calculateIntakeRate(float dailyTotal, float userDailyLimit) {
+        return (int) ((dailyTotal / userDailyLimit) * 100);
     }
 
     private List<HourlyCaffeineInfo> createHourlyCaffeineInfo(

--- a/src/main/java/com/ktb/cafeboo/domain/user/service/UserCaffeineInfoService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/service/UserCaffeineInfoService.java
@@ -3,6 +3,7 @@ package com.ktb.cafeboo.domain.user.service;
 import com.ktb.cafeboo.domain.drink.model.DrinkType;
 import com.ktb.cafeboo.domain.drink.repository.DrinkTypeRepository;
 import com.ktb.cafeboo.domain.recommend.service.CaffeineRecommendationService;
+import com.ktb.cafeboo.domain.report.service.DailyStatisticsService;
 import com.ktb.cafeboo.domain.user.dto.*;
 import com.ktb.cafeboo.domain.user.mapper.UserCaffeineInfoMapper;
 import com.ktb.cafeboo.domain.user.model.User;
@@ -12,6 +13,7 @@ import com.ktb.cafeboo.domain.user.repository.UserCaffeineInfoRepository;
 import com.ktb.cafeboo.domain.user.repository.UserRepository;
 import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
 import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -31,6 +33,7 @@ public class UserCaffeineInfoService {
     private final UserCaffeineInfoRepository userCaffeineInfoRepository;
     private final DrinkTypeRepository drinkTypeRepository;
     private final CaffeineRecommendationService caffeineRecommendationService;
+    private final DailyStatisticsService dailyStatisticsService;
 
     @Transactional
     public UserCaffeineInfoCreateResponse create(Long userId, UserCaffeineInfoCreateRequest request) {
@@ -101,6 +104,9 @@ public class UserCaffeineInfoService {
             try {
                 float predictedLimit = caffeineRecommendationService.getPredictedCaffeineLimitByRule(user, entity.getCaffeineSensitivity());
                 entity.setDailyCaffeineLimitMg(predictedLimit);
+
+                // 유저 카페인 관련 내용 수정 후, 바뀐 카페인 한계치에 따른 내용 일일 통계 데이터에 반영
+                dailyStatisticsService.updateDailyStatisticsAfterUpdateUserInfo(user, LocalDate.now());
             } catch (Exception e) {
                 log.warn("[AI 서버 호출 실패] 기존 최대 허용 카페인량 유지. userId: {}", userId);
                 // 값 유지: set 하지 않음


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] 유저 마이페이지에서 정보 수정 시 카페인 한계치 값 변경됨에 따른 일일 통계 AI 메시지 내용 수정
- [x] 일일 통계 반환 시 더미 데이터가 아닌 유저 개인의 카페인 한계치 반환하도록 수정

## 🛠 변경사항
- UserCaffeineInfoService에서 카페인 관련 수치 변동 발생 시, 일일 통계 부분의 AI 메시지에도 바뀐 카페인 관련 수치를 바탕으로 메시지를 생성해 반영하도록 수정 진행했습니다. 
- [x] 일일 리포트 반환 시 더미 데이터가 아닌 유저 개인의 카페인 한계치 반환하도록 수정했습니다. 

## 💬 리뷰 요구사항
- UserCaffeineInfoService 변경 내역 한 번 확인해주세요.
