### PR TITLE
🐛Fix: 섭취 내역 삭제/수정 시 카페인 잔존량 관련 계산 로직 변경

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/caffeinediary/service/CaffeineResidualService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/caffeinediary/service/CaffeineResidualService.java
@@ -48,8 +48,7 @@ public class CaffeineResidualService {
             // 해당 시점이 이전 섭취 시간과 새로운 섭취 시간 사이에 있는 경우에만 처리
             if (residualDateTime.isAfter(previousIntakeTime) || residualDateTime.isEqual(previousIntakeTime)) {
                 // 이전 섭취로 인한 잔존량 계산
-                double hoursSincePreviousIntake = ChronoUnit.HOURS.between(previousIntakeTime,
-                    residualDateTime);
+                double hoursSincePreviousIntake = 0;
                 double previousResidualAmount =
                     previousCaffeineAmount * Math.exp(-k * hoursSincePreviousIntake);
 
@@ -61,6 +60,8 @@ public class CaffeineResidualService {
                 updatedAmount = Math.max(0, updatedAmount);
 
                 residual.setResidueAmountMg(updatedAmount);
+
+                hoursSincePreviousIntake += 1;
             }
         }
 
@@ -137,7 +138,8 @@ public class CaffeineResidualService {
         Map<String, CaffeineResidual> residualMap = residuals.stream()
             .collect(Collectors.toMap(
                 r -> r.getTargetDate().toLocalDate().toString() + "-" + r.getHour(),
-                Function.identity()
+                Function.identity(),
+                (r1, r2) -> r2  // 중복된 경우 나중 값으로 덮어쓰기
             ));
 
         // 3. 35시간 구간의 모든 시간 포인트 생성 및 매핑

--- a/src/main/java/com/ktb/cafeboo/domain/user/service/UserHealthInfoService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/service/UserHealthInfoService.java
@@ -26,7 +26,7 @@ public class UserHealthInfoService {
     private final UserHealthInfoRepository userHealthInfoRepository;
     private final CaffeineRecommendationService caffeineRecommendationService;
     private final DailyStatisticsService dailyStatisticsService;
-    
+
     @Transactional
     public UserHealthInfoCreateResponse create(Long userId, UserHealthInfoCreateRequest request) {
         User user = userRepository.findById(userId)


### PR DESCRIPTION
섭취 내역 삭제/수정 시 카페인 잔존량 관련 계산 로직 변경

# 📌 Pull Request

## ✨ 작업한 내용
- [x] 섭취 내역 삭제/수정 시 카페인 잔존량 관련 계산 로직 변경

## 🛠 변경사항
- 섭취 내역 삭제/수정 시 카페인 잔존량 관련 계산 로직 변경

## 💬 리뷰 요구사항
- X

## 🔍 테스트 방법(선택)
- 반영 후 배포 환경에서 DataGrip을 활용해 수동 테스트 할 예정
