### PR TITLE
✨feat: 소셜 로그인 연동 상태 저장 및 연결 해제 기능 구현

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/auth/controller/AuthController.java
@@ -20,6 +20,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.io.IOException;
 import java.net.URI;
 
 @Slf4j
@@ -78,9 +79,9 @@ public class AuthController {
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<Void> logout(
+    public void logout(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            HttpServletResponse response) {
+            HttpServletResponse response) throws IOException {
 
         Long userId = userDetails.getUserId();
         authService.logout(userId);
@@ -95,6 +96,9 @@ public class AuthController {
 
         response.addHeader("Set-Cookie", deleteCookie.toString());
 
-        return ResponseEntity.noContent().build(); // 204 No Content
+        String kakaoLogoutUrl = kakaoOauthService.buildKakaoLogoutUrl();
+        response.sendRedirect(kakaoLogoutUrl);
+
+        //return ResponseEntity.noContent().build(); // 204 No Content
     }
 }

--- a/src/main/java/com/ktb/cafeboo/domain/auth/model/OauthToken.java
+++ b/src/main/java/com/ktb/cafeboo/domain/auth/model/OauthToken.java
@@ -1,0 +1,53 @@
+package com.ktb.cafeboo.domain.auth.model;
+
+import com.ktb.cafeboo.domain.user.model.User;
+import com.ktb.cafeboo.global.BaseEntity;
+import com.ktb.cafeboo.global.enums.LoginType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "oauth_tokens")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OauthToken extends BaseEntity {
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private LoginType provider; // KAKAO, GOOGLE 등
+
+    @Column(name = "access_token", nullable = false, length = 2000)
+    private String accessToken;
+
+    @Column(name = "refresh_token", length = 2000)
+    private String refreshToken;
+
+    @Column(name = "expires_at")
+    private LocalDateTime expiresAt;
+
+    public static OauthToken of(User user, String accessToken, String refreshToken, LoginType provider, long expiresInSec) {
+        return new OauthToken(user, provider, accessToken, refreshToken, LocalDateTime.now().plusSeconds(expiresInSec));
+    }
+
+    private OauthToken(User user, LoginType provider, String accessToken, String refreshToken, LocalDateTime expiresAt) {
+        this.user = user;
+        this.provider = provider;
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+        this.expiresAt = expiresAt;
+    }
+
+    public void update(String accessToken, String refreshToken, long expiresInSec) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+        this.expiresAt = LocalDateTime.now().plusSeconds(expiresInSec);
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/domain/auth/repository/OauthTokenRepository.java
+++ b/src/main/java/com/ktb/cafeboo/domain/auth/repository/OauthTokenRepository.java
@@ -1,0 +1,13 @@
+package com.ktb.cafeboo.domain.auth.repository;
+
+import com.ktb.cafeboo.domain.auth.model.OauthToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface OauthTokenRepository extends JpaRepository<OauthToken, Long> {
+
+    Optional<OauthToken> findByUserId(Long userId);
+
+    void deleteByUserId(Long userId);
+}

--- a/src/main/java/com/ktb/cafeboo/domain/user/controller/UserController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.ktb.cafeboo.domain.user.controller;
 
+import com.ktb.cafeboo.domain.auth.service.KakaoOauthService;
 import com.ktb.cafeboo.domain.user.dto.*;
 import com.ktb.cafeboo.domain.user.service.UserAlarmSettingService;
 import com.ktb.cafeboo.domain.user.service.UserCaffeineInfoService;
@@ -25,6 +26,7 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
     private final UserService userService;
+    private final KakaoOauthService kakaoOauthService;
     private final UserHealthInfoService userHealthInfoService;
     private final UserCaffeineInfoService userCaffeineInfoService;
     private final UserAlarmSettingService userAlarmSettingService;
@@ -164,6 +166,7 @@ public class UserController {
     ) {
         AuthChecker.checkOwnership(userId, userDetails.getUserId());
 
+        kakaoOauthService.disconnectKakaoAccount(userId);
         userService.deleteUser(userId);
 
         // refreshToken 쿠키 삭제

--- a/src/main/java/com/ktb/cafeboo/domain/user/service/UserService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.ktb.cafeboo.domain.user.service;
 
+import com.ktb.cafeboo.domain.auth.repository.OauthTokenRepository;
 import com.ktb.cafeboo.domain.user.dto.EmailDuplicationResponse;
 import com.ktb.cafeboo.domain.user.dto.UserProfileResponse;
 import com.ktb.cafeboo.domain.user.model.User;
@@ -14,6 +15,8 @@ import org.springframework.transaction.annotation.Transactional;
 @AllArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
+    private final OauthTokenRepository oauthTokenRepository;
+
     /**
      * 새로운 유저를 저장합니다.
      *
@@ -82,8 +85,9 @@ public class UserService {
             user.getFavoriteDrinks().clear();
         }
         user.setRefreshToken(null);
+        oauthTokenRepository.deleteByUserId(userId);
+
         user.delete();
         userRepository.save(user);
     }
-
 }

--- a/src/main/java/com/ktb/cafeboo/global/infra/kakao/client/KakaoUserClient.java
+++ b/src/main/java/com/ktb/cafeboo/global/infra/kakao/client/KakaoUserClient.java
@@ -20,4 +20,14 @@ public class KakaoUserClient {
                 .bodyToMono(KakaoUserResponse.class)
                 .block();
     }
+
+    public void unlinkUser(String accessToken) {
+        kakaoApiWebClient.post()
+                .uri("/v1/user/unlink")
+                .header("Authorization", "Bearer " + accessToken)
+                .header("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+                .retrieve()
+                .bodyToMono(Void.class)
+                .block();
+    }
 }

--- a/src/main/java/com/ktb/cafeboo/global/security/JwtProvider.java
+++ b/src/main/java/com/ktb/cafeboo/global/security/JwtProvider.java
@@ -6,11 +6,13 @@ import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.exceptions.TokenExpiredException;
 import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
 import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.Date;
 
+@Slf4j
 @Component
 public class JwtProvider {
 
@@ -29,11 +31,13 @@ public class JwtProvider {
     }
 
     private String createToken(String userId, String loginType, String role, long validityInMillis) {
+        Date now = new Date();
         return JWT.create()
-                .withSubject(String.valueOf(userId))
+                .withSubject(userId)
                 .withClaim("loginType", loginType)
                 .withClaim("role", role)
-                .withExpiresAt(new Date(System.currentTimeMillis() + validityInMillis))
+                .withIssuedAt(now)
+                .withExpiresAt(new Date(now.getTime() + validityInMillis))
                 .sign(Algorithm.HMAC256(SECRET_KEY));
     }
 


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] 소셜 연동 상태를 관리하기 위한 OauthToken 엔티티 및 리포지토리 추가
- [x] 카카오 로그인 시 accessToken 및 refreshToken 저장 로직 구현
- [x] 카카오 로그아웃 URL 생성 및 응답 수정 (303 See Other)
- [x] 회원 탈퇴 시 카카오 인증 서버에 연동 끊기 요청 (unlink)

## 🛠 변경사항
- `UserService`, `AuthController`, `KakaoOauthService` 등 주요 서비스/컨트롤러 로직 변경
- `OauthToken` 엔티티, 레포지토리 추가
- `KakaoUserClient` 를 통한 unlink 호출 메서드 추가

## 💬 리뷰 요구사항
- unlinkKakao() 예외 처리를 현재는 단순 호출 후 삭제하는 구조인데, 실패 시 어떻게 처리할지에 대한 의견도 주시면 감사하겠습니다

## 🔍 테스트 방법(선택)
- Postman을 통해 로그인 → 로그아웃 → 회원 탈퇴 전체 흐름 테스트
- 쿠키 삭제 여부 확인 (Set-Cookie: refreshToken=; Max-Age=0)
- 카카오 계정 연동 해제 여부 확인 (https://developers.kakao.com/console/app → 사용자 목록)


Fixes #59