### PR TITLE
Fix: 로그아웃 요청시, 리다이렉션 응답으로 인한 CORS오류 수정

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/auth/controller/AuthController.java
@@ -79,11 +79,12 @@ public class AuthController {
     }
 
     @PostMapping("/logout")
-    public void logout(
+    public ResponseEntity<ApiResponse<Void>> logout(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            HttpServletResponse response) throws IOException {
+            HttpServletResponse response) {
 
         Long userId = userDetails.getUserId();
+        // kakaoOauthService.logoutFromKakao(userId);
         authService.logout(userId);
 
         ResponseCookie deleteCookie = ResponseCookie.from("refreshToken", "")
@@ -96,9 +97,6 @@ public class AuthController {
 
         response.addHeader("Set-Cookie", deleteCookie.toString());
 
-        String kakaoLogoutUrl = kakaoOauthService.buildKakaoLogoutUrl();
-        response.sendRedirect(kakaoLogoutUrl);
-
-        //return ResponseEntity.noContent().build(); // 204 No Content
+        return ResponseEntity.noContent().build(); // 204 No Content
     }
 }

--- a/src/main/java/com/ktb/cafeboo/domain/auth/service/KakaoOauthService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/auth/service/KakaoOauthService.java
@@ -126,12 +126,11 @@ public class KakaoOauthService {
                 .build();
     }
 
-    public String buildKakaoLogoutUrl() {
-        return UriComponentsBuilder.fromHttpUrl("https://kauth.kakao.com/oauth/logout")
-                .queryParam("client_id", clientId)
-                .queryParam("logout_redirect_uri", redirectUri)
-                .build()
-                .toUriString();
+    public void logoutFromKakao(Long userId) {
+        oauthTokenRepository.findByUserId(userId)
+                .ifPresent(oauthToken -> {
+                    kakaoUserClient.logout(oauthToken.getAccessToken());
+                });
     }
 
     public void disconnectKakaoAccount(Long userId) {

--- a/src/main/java/com/ktb/cafeboo/global/infra/kakao/client/KakaoUserClient.java
+++ b/src/main/java/com/ktb/cafeboo/global/infra/kakao/client/KakaoUserClient.java
@@ -21,6 +21,16 @@ public class KakaoUserClient {
                 .block();
     }
 
+    public void logout(String accessToken) {
+        kakaoApiWebClient.post()
+                .uri("/v1/user/logout")
+                .header("Authorization", "Bearer " + accessToken)
+                .header("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+                .retrieve()
+                .bodyToMono(Void.class)
+                .block();
+    }
+
     public void unlinkUser(String accessToken) {
         kakaoApiWebClient.post()
                 .uri("/v1/user/unlink")


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] 카카오 로그아웃 URL 반환 방식 제거 및 서버 직접 호출 방식으로 변경
- [x] 서버에서 직접 카카오 로그아웃 API를 호출하도록 책임 이전
- [x] 프론트는 리디렉션 없이 자체 로그아웃 처리 결과만 수신

## 🛠 변경사항
- 카카오 인증 서버에 로그아웃 요청하는 메서드 추가
- 컨트롤러에서 응답 방식 수정
    - 기존: 303 See Other 응답 + Location 헤더로 로그아웃 URL 전달
    - 변경: 204 No Content 응답으로 자체 로그아웃 처리 완료만 전달

## 💬 리뷰 요구사항
- 찾아보면서 인증 로직을 조금 더 깊이 설계해야하는 지점을 발견하였습니다
(카카오 인증 서버 토큰의 재발급 등)
- 우선은 배포를 위해 오류가 나지 않도록 설정해두었고, 고도화는 따로 진행하겠습니다.

## 🔍 테스트 방법(선택)
- Postman으로 정상 반환

Fixes #78 