### PR TITLE
카카오 인증 통신 로직 고도화: AccessToken 자동 갱신 및 로그아웃/회원탈퇴 연동 처리

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/auth/controller/AuthController.java
@@ -84,7 +84,7 @@ public class AuthController {
             HttpServletResponse response) {
 
         Long userId = userDetails.getUserId();
-        // kakaoOauthService.logoutFromKakao(userId);
+        kakaoOauthService.logoutFromKakao(userId);
         authService.logout(userId);
 
         ResponseCookie deleteCookie = ResponseCookie.from("refreshToken", "")

--- a/src/main/java/com/ktb/cafeboo/domain/auth/model/OauthToken.java
+++ b/src/main/java/com/ktb/cafeboo/domain/auth/model/OauthToken.java
@@ -45,9 +45,14 @@ public class OauthToken extends BaseEntity {
         this.expiresAt = expiresAt;
     }
 
-    public void update(String accessToken, String refreshToken, long expiresInSec) {
+    public void update(String accessToken, String refreshToken, Long expiresInSec) {
         this.accessToken = accessToken;
-        this.refreshToken = refreshToken;
-        this.expiresAt = LocalDateTime.now().plusSeconds(expiresInSec);
+        if (refreshToken != null) {
+            this.refreshToken = refreshToken;
+        }
+
+        if (expiresInSec != null) {
+            this.expiresAt = LocalDateTime.now().plusSeconds(expiresInSec);
+        }
     }
 }

--- a/src/main/java/com/ktb/cafeboo/domain/auth/model/OauthToken.java
+++ b/src/main/java/com/ktb/cafeboo/domain/auth/model/OauthToken.java
@@ -24,10 +24,10 @@ public class OauthToken extends BaseEntity {
     @Column(nullable = false)
     private LoginType provider; // KAKAO, GOOGLE 등
 
-    @Column(name = "access_token", nullable = false, length = 2000)
+    @Column(name = "access_token", nullable = false, length = 128)
     private String accessToken;
 
-    @Column(name = "refresh_token", length = 2000)
+    @Column(name = "refresh_token", length = 128)
     private String refreshToken;
 
     @Column(name = "expires_at")

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/ErrorStatus.java
@@ -15,13 +15,17 @@ public enum ErrorStatus implements BaseCode {
     NOT_FOUND(404, "NOT_FOUND", "요청한 리소스를 찾을 수 없습니다."),
     INTERNAL_SERVER_ERROR(500, "INTERNAL_ERROR", "요청을 처리하는 도중 서버에서 문제가 발생했습니다."),
 
-    // 인증 관련 오류
+    // 인증 관련 오류 (서버 자체)
     UNSUPPORTED_SOCIAL_LOGIN_TYPE(400, "UNSUPPORTED_SOCIAL_LOGIN_TYPE", "지원하지 않는 소셜 로그인 타입입니다."),
     ACCESS_TOKEN_INVALID(401, "ACCESS_TOKEN_INVALID", "유효한 인증 정보가 필요합니다. 토큰을 확인해주세요."),
     ACCESS_TOKEN_EXPIRED(401, "ACCESS_TOKEN_EXPIRED", "인증 토큰이 만료되었습니다. 토큰을 재발급 받아주세요."),
     REFRESH_TOKEN_INVALID(401, "REFRESH_TOKEN_INVALID", "리프레시 토큰이 유효하지 않습니다."),
     REFRESH_TOKEN_EXPIRED(401, "REFRESH_TOKEN_EXPIRED", "리프레시 토큰이 만료되었습니다."),
     REFRESH_TOKEN_MISMATCH(401, "REFRESH_TOKEN_MISMATCH", "리프레시 토큰이 일치하지 않습니다."),
+
+    // 인증 관련 오류 (OAuth)
+    OAUTH_TOKEN_NOT_FOUND(404, "OAUTH_TOKEN_NOT_FOUND", "해당 유저의 OAuth 토큰 정보가 존재하지 않습니다."),
+    KAKAO_TOKEN_REFRESH_FAILED(500, "KAKAO_TOKEN_REFRESH_FAILED", "카카오 토큰 갱신에 실패했습니다. 다시 로그인해주세요."),
 
     // 유저 관련 오류
     USER_NOT_FOUND(404, "USER_NOT_FOUND", "사용자를 찾을 수 없습니다."),

--- a/src/main/java/com/ktb/cafeboo/global/infra/kakao/client/KakaoTokenClient.java
+++ b/src/main/java/com/ktb/cafeboo/global/infra/kakao/client/KakaoTokenClient.java
@@ -24,4 +24,16 @@ public class KakaoTokenClient {
                 .bodyToMono(KakaoTokenResponse.class)
                 .block();
     }
+
+    public KakaoTokenResponse refreshAccessToken(String refreshToken, String clientId) {
+        return kakaoWebClient.post()
+                .uri("/oauth/token")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .bodyValue("grant_type=refresh_token"
+                        + "&client_id=" + clientId
+                        + "&refresh_token=" + refreshToken)
+                .retrieve()
+                .bodyToMono(KakaoTokenResponse.class)
+                .block();
+    }
 }

--- a/src/main/java/com/ktb/cafeboo/global/infra/kakao/dto/KakaoTokenResponse.java
+++ b/src/main/java/com/ktb/cafeboo/global/infra/kakao/dto/KakaoTokenResponse.java
@@ -12,7 +12,7 @@ public class KakaoTokenResponse {
     private String refreshToken;
 
     @JsonProperty("expires_in")
-    private int expiresIn;
+    private Long expiresIn;
 
     @JsonProperty("token_type")
     private String tokenType;


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] 카카오 AccessToken 유효 시간(약 6시간)의 제약을 고려하여, RefreshToken을 활용한 자동 갱신 로직을 추가
- [x] 로그아웃 및 회원탈퇴 요청 시 accessToken이 만료된 경우, 서버에서 토큰을 재발급받고 카카오 인증 서버에 다시 요청하는 구조로 고도화

## 🛠 변경사항
- `KakaoTokenClient`에 `accessToken` 재발급 메서드 추가
- `KakaoOauthService`에 자동 재발급 + 재시도 유틸 메서드 추가 및 적용
- `ErrorStatus`에 OAuth 관련 예외 코드 추가
- 카카오 인증 토큰 길이(64)에 맞춰 JPA 컬럼 길이(128) 설정 수정

## 💬 리뷰 요구사항
- 예외 케이스를 핸들링하는 방식에 대해 부족한 점이 있다면 의견부탁드립니다.

## 🔍 테스트 방법(선택)
Postman을 통해 진행하였습니다
- 유효한 accessToken으로 로그아웃 및 회원탈퇴 → 정상 작동
- accessToken이 만료된 상태에서 로그아웃/회원탈퇴 요청 → 자동 재발급 후 성공
- refreshToken까지 만료된 상태 
→ 커스텀 예외(`KAKAO_TOKEN_REFRESH_FAILED`) 발생 및 재로그인 유도

fixes #93 