### PR TITLE
Fix: JWT 인증 실패 시 응답 바디 포함한 401 반환 및 필터 체인 중단

### DIFF
--- a/src/main/java/com/ktb/cafeboo/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ktb/cafeboo/global/security/JwtAuthenticationFilter.java
@@ -55,6 +55,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
             } catch (CustomApiException e) {
                 logger.warn("[JWT 인증 실패] " + e.getErrorCode().getCode() + ": " + e.getMessage());
+                SecurityContextHolder.clearContext();
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.setContentType("application/json;charset=UTF-8");
+                response.getWriter().write(String.format("""
+                    {
+                        "code": "%s",
+                        "message": "%s"
+                    }
+                    """, e.getErrorCode().getCode(), e.getErrorCode().getMessage()));
+                return;
             }
         }
         filterChain.doFilter(request, response);


### PR DESCRIPTION
- JwtAuthenticationFilter 내에서 토큰 유효성 검사 실패 시 CustomApiException을 catch
- 인증 실패 시 SecurityContextHolder 초기화 및 직접 JSON 응답 작성
- 인증 실패 후 filterChain.doFilter() 호출 방지하여 불필요한 필터 흐름 차단

# 📌 Pull Request

## ✨ 작업한 내용
- [x] `JwtAuthenticationFilter`에서 토큰 유효성 검사 실패 시, 클라이언트에 JSON 형태의 에러 응답을 반환하도록 개선
- [x] 기존에 예외 발생 시 로그만 출력하고 filterChain.doFilter()를 계속 호출하여, 불명확한 403 응답이 내려가는 문제 해결

## 🛠 변경사항
- CustomApiException을 catch한 뒤 다음 처리 수행:
    - SecurityContextHolder.clearContext() 호출로 인증 정보 초기화
    - response.setStatus(HttpServletResponse.SC_UNAUTHORIZED)로 401 반환
    - response.getWriter().write(...)로 code, message 포함한 JSON 응답 작성
- 인증 성공한 경우에만 filterChain.doFilter() 호출되도록 분기 구조 정리

## 💬 리뷰 요구사항

## 🔍 테스트 방법(선택)
- Postman으로 테스트
