### PR TITLE
🐛Fix: AI 콜백 호출에 대한 403 오류 수정

### DIFF
--- a/src/main/java/com/ktb/cafeboo/global/config/SecurityConfig.java
+++ b/src/main/java/com/ktb/cafeboo/global/config/SecurityConfig.java
@@ -29,7 +29,8 @@ public class SecurityConfig {
             .authorizeHttpRequests(authorize -> authorize
                 .requestMatchers(
                     "/api/v1/auth/**",
-                    "/api/v1/users/email"
+                    "/api/v1/users/email",
+                    "/api/v1/reports/weekly/ai_callback"
                 ).permitAll()
                 .anyRequest().authenticated()
             )


### PR DESCRIPTION
AI 주간 리포트 생성 기능을 테스트 하는 과정에서 AI 서버로 요청을 보내고 받는 것 까지는 제대로 동작하는 것을 확인했습니다.

하지만 AI 서버에서 비동기로 리포트 생성 완료 후 콜백을 통해 BE의 엔드포인트 호출 시 403 Forbidden 에러가 발생합니다.

해당 부분을 방지하기 위해 SecurityConfig에서 AI 콜백 부분에 대해서 Authorization이 요구되지 않도록 수정 진행합니다.

# 📌 Pull Request

## ✨ 작업한 내용
- [x] SecurityConfig 수정

## 🛠 변경사항
- AI 서버에서 비동기 리포트 생성 완료 후 호출하게 되는 BE 엔드포인트의 Authorization 헤더 필수 여부를 수정했습니다.

## 💬 리뷰 요구사항
- X

