### PR TITLE
✨Feat: 로컬 요청 분기처리

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/auth/controller/AuthController.java
@@ -10,6 +10,7 @@ import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
 import com.ktb.cafeboo.global.apiPayload.code.status.SuccessStatus;
 import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
 import com.ktb.cafeboo.global.security.userdetails.CustomUserDetails;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -49,9 +50,10 @@ public class AuthController {
     @PostMapping("/kakao")
     public ResponseEntity<ApiResponse<LoginResponse>> kakaoLogin(
             @RequestBody KakaoLoginRequest request,
+            HttpServletRequest httpRequest,
             HttpServletResponse response) {
 
-        LoginResponse loginResponse = kakaoOauthService.login(request.code());
+        LoginResponse loginResponse = kakaoOauthService.login(request.code(), httpRequest);
 
         ResponseCookie cookie = ResponseCookie.from("refreshToken", loginResponse.refreshToken())
                 .httpOnly(true)


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- redirect url을 origin에 따라 분기처리

## 🛠 변경사항
- HttpServletRequest 을 같이 인자로 받아서 header 의 origin으로 도메인 요청인지 localhost 요청인지 파악 후 분기처리함

## 💬 리뷰 요구사항
- dev 환경 내에서 qa 완료했습니다.

## 🔍 테스트 방법(선택)
@leenaheun 
로컬에서 작업 시 `VITE_API_BASE_URL`은 dev용 도메인으로 변경 후 authApi.redirect_uri 을 로컬호스트로 변경하시면 로컬에서도 정상 작동합니다. 그리고 로그인 시 `StrictMode` 로 인해 로컬 환경에서 2번 로그인이 진행되어 500에러가 발생하나, 정상 로그인되며 이후 로직에도 문제없이 작동되니 무시하시거나 `StrictMode` 를 비활성화 하면 정상 작동합니다.

로컬 프론트에서 접속 테스트해보시고 정상작동 확인되면 merge 하겠습니다! 
