### PR TITLE
[FEAT] 토큰 블랙리스트 기능 도입

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/auth/service/AuthService.java
@@ -5,6 +5,7 @@ import com.ktb.cafeboo.domain.user.model.User;
 import com.ktb.cafeboo.domain.user.repository.UserRepository;
 import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
 import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
+import com.ktb.cafeboo.global.enums.TokenBlacklistReason;
 import com.ktb.cafeboo.global.security.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -28,7 +29,7 @@ public class AuthService {
             throw new CustomApiException(ErrorStatus.REFRESH_TOKEN_MISMATCH);
         }
 
-        tokenBlacklistService.addToBlacklist(accessToken);
+        tokenBlacklistService.addToBlacklist(accessToken, userId, TokenBlacklistReason.REFRESH);
 
         String newAccessToken = jwtProvider.createAccessToken(
                 user.getId().toString(),
@@ -47,7 +48,7 @@ public class AuthService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomApiException(ErrorStatus.USER_NOT_FOUND));
 
-        tokenBlacklistService.addToBlacklist(accessToken);
+        tokenBlacklistService.addToBlacklist(accessToken, userId.toString(), TokenBlacklistReason.LOGOUT);
 
         user.updateRefreshToken(null);
         userRepository.save(user);

--- a/src/main/java/com/ktb/cafeboo/domain/auth/service/TokenBlacklistService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/auth/service/TokenBlacklistService.java
@@ -1,0 +1,33 @@
+package com.ktb.cafeboo.domain.auth.service;
+
+import com.ktb.cafeboo.global.security.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class TokenBlacklistService {
+
+    private final StringRedisTemplate redisTemplate;
+    private final JwtProvider jwtProvider;
+
+    private static final String PREFIX = "blacklist:";
+
+    public void addToBlacklist(String accessToken) {
+        long remainingMillis = jwtProvider.getRemainingExpiration(accessToken);
+
+        redisTemplate.opsForValue().set(
+                PREFIX + accessToken,
+                "logout",
+                remainingMillis,
+                TimeUnit.MILLISECONDS
+        );
+    }
+
+    public boolean isBlacklisted(String accessToken) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(PREFIX + accessToken));
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/domain/auth/service/TokenBlacklistService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/auth/service/TokenBlacklistService.java
@@ -1,5 +1,6 @@
 package com.ktb.cafeboo.domain.auth.service;
 
+import com.ktb.cafeboo.global.enums.TokenBlacklistReason;
 import com.ktb.cafeboo.global.security.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -16,12 +17,13 @@ public class TokenBlacklistService {
 
     private static final String PREFIX = "blacklist:";
 
-    public void addToBlacklist(String accessToken) {
+    public void addToBlacklist(String accessToken, String userId, TokenBlacklistReason reason) {
         long remainingMillis = jwtProvider.getRemainingExpiration(accessToken);
+        String value = reason.formatWithUserId(userId);
 
         redisTemplate.opsForValue().set(
                 PREFIX + accessToken,
-                "logout",
+                value,
                 remainingMillis,
                 TimeUnit.MILLISECONDS
         );

--- a/src/main/java/com/ktb/cafeboo/domain/user/controller/UserController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/controller/UserController.java
@@ -161,13 +161,16 @@ public class UserController {
     @DeleteMapping("/{userId}")
     public ResponseEntity<Void> deleteUser(
             @PathVariable Long userId,
+            @RequestHeader("Authorization") String authHeader,
             @AuthenticationPrincipal CustomUserDetails userDetails,
             HttpServletResponse response
     ) {
         AuthChecker.checkOwnership(userId, userDetails.getUserId());
 
+        String accessToken = authHeader.replace("Bearer ", "");
+
         kakaoOauthService.disconnectKakaoAccount(userId);
-        userService.deleteUser(userId);
+        userService.deleteUser(accessToken, userId);
 
         // refreshToken 쿠키 삭제
         ResponseCookie deleteCookie = ResponseCookie.from("refreshToken", "")
@@ -182,5 +185,4 @@ public class UserController {
 
         return ResponseEntity.noContent().build();  // 204 No Content
     }
-
 }

--- a/src/main/java/com/ktb/cafeboo/domain/user/service/UserService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/service/UserService.java
@@ -8,6 +8,7 @@ import com.ktb.cafeboo.domain.user.model.User;
 import com.ktb.cafeboo.domain.user.repository.UserRepository;
 import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
 import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
+import com.ktb.cafeboo.global.enums.TokenBlacklistReason;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -95,7 +96,7 @@ public class UserService {
         userRepository.save(user);
 
         try {
-            tokenBlacklistService.addToBlacklist(accessToken);
+            tokenBlacklistService.addToBlacklist(accessToken, userId.toString(), TokenBlacklistReason.WITHDRAWAL);
         } catch (Exception e) {
             log.warn("accessToken 블랙리스트 등록 실패: {}", e.getMessage());
         }

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/ErrorStatus.java
@@ -19,6 +19,7 @@ public enum ErrorStatus implements BaseCode {
     UNSUPPORTED_SOCIAL_LOGIN_TYPE(400, "UNSUPPORTED_SOCIAL_LOGIN_TYPE", "지원하지 않는 소셜 로그인 타입입니다."),
     ACCESS_TOKEN_INVALID(401, "ACCESS_TOKEN_INVALID", "유효한 인증 정보가 필요합니다. 토큰을 확인해주세요."),
     ACCESS_TOKEN_EXPIRED(401, "ACCESS_TOKEN_EXPIRED", "인증 토큰이 만료되었습니다. 토큰을 재발급 받아주세요."),
+    ACCESS_TOKEN_BLACKLISTED(401, "ACCESS_TOKEN_BLACKLISTED", "해당 토큰은 더 이상 유효하지 않습니다. 다시 로그인해 주세요."),
     REFRESH_TOKEN_INVALID(401, "REFRESH_TOKEN_INVALID", "리프레시 토큰이 유효하지 않습니다."),
     REFRESH_TOKEN_EXPIRED(401, "REFRESH_TOKEN_EXPIRED", "리프레시 토큰이 만료되었습니다."),
     REFRESH_TOKEN_MISMATCH(401, "REFRESH_TOKEN_MISMATCH", "리프레시 토큰이 일치하지 않습니다."),

--- a/src/main/java/com/ktb/cafeboo/global/config/SecurityConfig.java
+++ b/src/main/java/com/ktb/cafeboo/global/config/SecurityConfig.java
@@ -28,7 +28,8 @@ public class SecurityConfig {
             .csrf(csrf -> csrf.disable())
             .authorizeHttpRequests(authorize -> authorize
                 .requestMatchers(
-                    "/api/v1/auth/**",
+                    "/api/v1/auth/oauth",
+                    "/api/v1/auth/kakao",
                     "/api/v1/users/email"
                 ).permitAll()
                 .anyRequest().authenticated()

--- a/src/main/java/com/ktb/cafeboo/global/enums/TokenBlacklistReason.java
+++ b/src/main/java/com/ktb/cafeboo/global/enums/TokenBlacklistReason.java
@@ -1,0 +1,12 @@
+package com.ktb.cafeboo.global.enums;
+
+public enum TokenBlacklistReason {
+    LOGOUT,
+    REFRESH,
+    WITHDRAWAL,
+    BAN;
+
+    public String formatWithUserId(String userId) {
+        return this.name().toLowerCase() + ":" + userId;
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ktb/cafeboo/global/security/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package com.ktb.cafeboo.global.security;
 
+import com.ktb.cafeboo.domain.auth.service.TokenBlacklistService;
 import com.ktb.cafeboo.domain.user.model.User;
 import com.ktb.cafeboo.domain.user.repository.UserRepository;
 import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
@@ -20,7 +21,7 @@ import java.io.IOException;
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
-
+    private final TokenBlacklistService tokenBlacklistService;
     private final JwtProvider jwtProvider;
     private final UserRepository userRepository;
 
@@ -39,6 +40,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
                 if (userIdStr == null || !userIdStr.matches("\\d+")) {
                     throw new CustomApiException(ErrorStatus.ACCESS_TOKEN_INVALID);
+                }
+
+                // 토큰 블랙리스트 검증
+                if (tokenBlacklistService.isBlacklisted(accessToken)) {
+                    throw new CustomApiException(ErrorStatus.ACCESS_TOKEN_BLACKLISTED);
                 }
 
                 Long userIdLong = Long.parseLong(userIdStr);

--- a/src/main/java/com/ktb/cafeboo/global/security/JwtProvider.java
+++ b/src/main/java/com/ktb/cafeboo/global/security/JwtProvider.java
@@ -25,8 +25,6 @@ public class JwtProvider {
     private final long accessTokenValidity = 24 * 60 * 60 * 1000;  // 60분
     private final long refreshTokenValidity = 14 * 24 * 60 * 60 * 1000;  // 14일
 
-    private final TokenBlacklistService tokenBlacklistService;
-
     public String createAccessToken(String userId, String loginType, String role) {
         return createToken(userId, loginType, role, accessTokenValidity);
     }
@@ -47,11 +45,6 @@ public class JwtProvider {
     }
 
     public String validateAccessToken(String token) {
-        // 토큰 블랙리스트 검증
-        if (tokenBlacklistService.isBlacklisted(token)) {
-            throw new CustomApiException(ErrorStatus.ACCESS_TOKEN_BLACKLISTED);
-        }
-
         try {
             String subject = JWT.require(Algorithm.HMAC256(SECRET_KEY))
                     .build()

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -30,6 +30,10 @@ spring.security.oauth2.client.provider.kakao.user-name-attribute=id
 # AI
 ai.server.base-url: http://localhost:8000
 
+# Redis
+spring.data.redis.host=localhost
+spring.data.redis.port=6379
+
 # JWT
 jwt.secret=${JWT_SECRET}
 


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] JWT 무효화를 위해 Redis 기반의 토큰 블랙리스트 기능을 도입
- [x] 사용자가 AccessToken을 재발급, 로그아웃, 회원 탈퇴할 경우, 해당 토큰을 블랙리스트에 등록하여 서버에서 즉시 차단
- [x] 이를 통해 유효기간이 남은 토큰이라도 서버에서 인증을 거부할 수 있도록 보안 수준 강화


## 🛠 변경사항
- `TokenBlacklistService` 클래스 생성 및 Redis 저장소 연동
    - key: "blacklist:<accessToken>"
    - value: "logout:{userId}", "refresh:{userId}" 형태로 저장
    - TTL은 토큰의 남은 유효기간 기반 설정

- `BlacklistReason` enum 도입 (LOGOUT, REFRESH 등)

- 인증 필터에서 블랙리스트 토큰 존재 여부 확인 후 `401 Unauthorized` 처리 로직 추가


## 💬 리뷰 요구사항

## 🔍 테스트 방법(선택)
**- Redis: 만료된 토큰(`Key`) 저장 확인**

![image (9)](https://github.com/user-attachments/assets/3c0ea580-38c4-4020-8665-0081780bf7b2)

**- `Value` 는 {사유:유저아이디} 형태로 저장**

<img width="782" alt="image (10)" src="https://github.com/user-attachments/assets/581432db-3508-4a35-b4b5-00fff8748483" />
추후 토큰의 만료 사유 파악에 유리

**- 블랙리스트에 저장된 토큰 사용 시, 응답** 

<img width="782" alt="image (11)" src="https://github.com/user-attachments/assets/9ee67ded-2886-45de-b497-01aec8a0e1d1" />

Fixes: #86 