### PR TITLE
FEAT: 채팅 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.data:spring-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/ChatController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/ChatController.java
@@ -1,6 +1,7 @@
 package com.ktb.cafeboo.domain.coffeechat.controller;
 
 import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChat;
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatMember;
 import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatMessage;
 import com.ktb.cafeboo.domain.user.model.User;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -31,6 +32,7 @@ public class ChatController {
     private final SimpMessagingTemplate messagingTemplate; // 메시지 브로커로 메시지를 라우팅하는 역할
     private final RedisTemplate<String, Object> redisTemplate; // RedisTemplate 주입
     private StreamOperations<String, Object, Object> streamOperations; // StreamOperations 선언
+    private final ChatService chatService;
 
     @PostConstruct
     private void init() {
@@ -44,11 +46,11 @@ public class ChatController {
         log.info("[ChatController.handleCoffeeChatMessage] - handleCoffeeChatMessage 호출");
 
         // 클라이언트에서 보낸 메시지 로그
-        User sender = chatMessage.getSender();
+        CoffeeChatMember sender = chatMessage.getSender();
         CoffeeChat coffeeChat = chatMessage.getChat();
 
         log.info("[ChatController.handleCoffeeChatMessage] - 유저 {}로부터 커피챗 {}에 보내는 메시지를 받았습니다: {}",
-            sender.getId(), roomId,
+            sender.getId(), coffeeChat.getId(),
             chatMessage.getContent());
 
         String sessionId = headerAccessor.getSessionId();

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/ChatController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/ChatController.java
@@ -1,20 +1,22 @@
 package com.ktb.cafeboo.domain.coffeechat.controller;
 
-import com.ktb.cafeboo.domain.coffeechat.model.Message;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.ktb.cafeboo.domain.coffeechat.dto.JoinRoomRequest;
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeechatMessage;
+import com.ktb.cafeboo.domain.coffeechat.service.ChatService;
+import com.ktb.cafeboo.global.security.userdetails.CustomUserDetails;
 import jakarta.annotation.PostConstruct;
-import java.util.HashMap;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.connection.stream.MapRecord;
-import org.springframework.data.redis.connection.stream.RecordId;
-import org.springframework.data.redis.connection.stream.StreamRecords;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StreamOperations;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 
@@ -27,54 +29,60 @@ public class ChatController {
     private final RedisTemplate<String, Object> redisTemplate; // RedisTemplate 주입
     private StreamOperations<String, Object, Object> streamOperations; // StreamOperations 선언
 
+    private final ChatService chatService;
+
     @PostConstruct
     private void init() {
         this.streamOperations = redisTemplate.opsForStream();
     }
 
-    // 클라이언트에서 /app/chatrooms/{roomId}로 메시지를 보내면 이 메서드가 처리
+    // 클라이언트에서 /chatrooms/{roomId}로 메시지를 보내면 이 메서드가 처리
     @MessageMapping("/chatrooms/{roomId}")
-    public void handleCoffeeChatMessage(@DestinationVariable String roomId, @Payload Message chatMessage, SimpMessageHeaderAccessor headerAccessor) {
+    public void handleCoffeeChatMessage(@DestinationVariable String roomId, @Payload CoffeechatMessage chatMessage, SimpMessageHeaderAccessor headerAccessor) {
         // 클라이언트에서 보낸 메시지 로그
-        log.info("[ChatController.handleCoffeeChatMessage] - 유저 {}로부터 커피챗 {}에 보내는 메시지를 받았습니다: {}",
-            chatMessage.getUserId(), roomId,
-            chatMessage.getContent());
+        log.info("[ChatController.handleCoffeeChatMessage] - handleCoffeeChatMessage 호출");
 
-        String coffeeChatStreamKey = "coffeechat:" + roomId + ":stream";
+        String sessionId = headerAccessor.getSessionId();
+        if (sessionId == null) {
+            log.warn("Received message for room {} without a valid session ID. Message content: {}", roomId, chatMessage.getContent());
+            return; // 유효한 세션 ID가 없으면 STOMP 연결이 활성화되지 않을 것이기에 메시지 처리 중단
+        }
 
-        // ChatMessage 객체를 Map<String, String>으로 변환
-        Map<String, String> messageMap = new HashMap<>();
-        messageMap.put("userId", chatMessage.getUserId());
-        messageMap.put("roomId", chatMessage.getRoomId());
-        messageMap.put("content", chatMessage.getContent());
-        messageMap.put("type", chatMessage.getType().name()); // Enum은 String으로 변환
-        //messageMap.put("timestamp", String.valueOf(chatMessage.getTimestamp())); // long은 String으로 변환
+        try{
+            chatService.handleNewMessage(roomId, chatMessage);
+        }
+        catch (JsonProcessingException e){
+            log.error("[ChatController.handleCoffeeChatMessage] - 메시지 직렬화 실패 오류. roomId: {}, {}", roomId, e.getMessage());
+            messagingTemplate.convertAndSendToUser(headerAccessor.getSessionId(), "/queue/errors", "메시지 전송 실패: 유효하지 않은 메시지 형태.");
+        }
+        catch (Exception e) {
+            log.error("[ChatController.handleCoffeeChatMessage] - 메시지 전송 실패");
+            messagingTemplate.convertAndSendToUser(headerAccessor.getSessionId(), "/queue/errors", "메시지 전송 실패: 서버 오류.");
+        }
 
-        // MapRecord를 생성하여 Stream에 추가
-        MapRecord<String, String, String> record = StreamRecords.mapBacked(messageMap)
-            .withStreamKey(coffeeChatStreamKey);
-        RecordId recordId = streamOperations.add(record);
-        System.out.println(
-            "[ChatController.handleCoffeeChatMessage] - recordId " + recordId + "를 가지는 "
-                + coffeeChatStreamKey + "메시지가 스트림에 등록되었습니다.");
+//before, 작동 되는 거 확인하면 삭제
+//        String coffeeChatStreamKey = "coffeechat:" + roomId + ":stream";
+//
+//        // ChatMessage 객체를 Map<String, String>으로 변환
+//        Map<String, String> messageMap = new HashMap<>();
+//        messageMap.put("userId", chatMessage.getUserId());
+//        messageMap.put("roomId", chatMessage.getRoomId());
+//        messageMap.put("content", chatMessage.getContent());
+//        messageMap.put("type", chatMessage.getType().name()); // Enum은 String으로 변환
+//        //messageMap.put("timestamp", String.valueOf(chatMessage.getTimestamp())); // long은 String으로 변환
+//
+//        // MapRecord를 생성하여 Stream에 추가
+//        MapRecord<String, String, String> record = StreamRecords.mapBacked(messageMap)
+//            .withStreamKey(coffeeChatStreamKey);
+//        RecordId recordId = streamOperations.add(record);
+//        System.out.println(
+//            "[ChatController.handleCoffeeChatMessage] - recordId " + recordId + "를 가지는 "
+//                + coffeeChatStreamKey + "메시지가 스트림에 등록되었습니다.");
+//
+//        // 브로커를 통해 해당 채팅방을 구독한 모든 클라이언트에게 메시지 브로드캐스팅
+//        // Destination: /topic/chatrooms/{roomId}
+//        messagingTemplate.convertAndSend("/topic/chatrooms/" + roomId, chatMessage);
 
-        // 브로커를 통해 해당 채팅방을 구독한 모든 클라이언트에게 메시지 브로드캐스팅
-        // Destination: /topic/chatrooms/{roomId}
-        messagingTemplate.convertAndSend("/topic/chatrooms/" + roomId, chatMessage);
+
     }
-
-    // WebSocket/STOMP 연결 시 호출 (옵션)
-    // @EventListener
-    // public void handleWebSocketConnectListener(SessionConnectedEvent event) {
-    //     SimpMessageHeaderAccessor headers = SimpMessageHeaderAccessor.wrap(event.getMessage());
-    //     System.out.println("WebSocket Connected: " + headers.getSessionId() + " by " + headers.getUser().getName());
-    //     // 사용자 로그인 정보 등을 활용하여 초기 데이터 전송 가능
-    // }
-
-    // WebSocket/STOMP 연결 해제 시 호출 (옵션)
-    // @EventListener
-    // public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
-    //     SimpMessageHeaderAccessor headers = SimpMessageHeaderAccessor.wrap(event.getMessage());
-    //     System.out.println("WebSocket Disconnected: " + headers.getSessionId());
-    // }
 }

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/ChatController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/ChatController.java
@@ -1,10 +1,9 @@
 package com.ktb.cafeboo.domain.coffeechat.controller;
 
 import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChat;
-import com.ktb.cafeboo.domain.coffeechat.model.Message;
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatMessage;
 import com.ktb.cafeboo.domain.user.model.User;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.ktb.cafeboo.domain.coffeechat.model.CoffeechatMessage;
 import com.ktb.cafeboo.domain.coffeechat.service.ChatService;
 import com.ktb.cafeboo.global.security.userdetails.CustomUserDetails;
 import jakarta.annotation.PostConstruct;
@@ -40,7 +39,10 @@ public class ChatController {
 
     // 클라이언트에서 /chatrooms/{roomId}로 메시지를 보내면 이 메서드가 처리
     @MessageMapping("/chatrooms/{roomId}")
-    public void handleCoffeeChatMessage(@DestinationVariable String roomId, @Payload CoffeechatMessage chatMessage, SimpMessageHeaderAccessor headerAccessor) {
+    public void handleCoffeeChatMessage(@DestinationVariable String roomId, @Payload CoffeeChatMessage chatMessage, SimpMessageHeaderAccessor headerAccessor) {
+
+        log.info("[ChatController.handleCoffeeChatMessage] - handleCoffeeChatMessage 호출");
+
         // 클라이언트에서 보낸 메시지 로그
         User sender = chatMessage.getSender();
         CoffeeChat coffeeChat = chatMessage.getChat();
@@ -48,7 +50,6 @@ public class ChatController {
         log.info("[ChatController.handleCoffeeChatMessage] - 유저 {}로부터 커피챗 {}에 보내는 메시지를 받았습니다: {}",
             sender.getId(), roomId,
             chatMessage.getContent());
-        log.info("[ChatController.handleCoffeeChatMessage] - handleCoffeeChatMessage 호출");
 
         String sessionId = headerAccessor.getSessionId();
         if (sessionId == null) {

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatController.java
@@ -1,7 +1,7 @@
 package com.ktb.cafeboo.domain.coffeechat.controller;
 
 
-import com.ktb.cafeboo.domain.coffeechat.model.Message;
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeechatMessage;
 import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChat;
 import com.ktb.cafeboo.domain.coffeechat.repository.CoffeeChatRepository;
 import com.ktb.cafeboo.global.enums.MessageType;
@@ -53,7 +53,7 @@ public class CoffeeChatController {
 
     // 특정 채팅방의 이전 메시지 이력 조회 (Redis Stream에서 가져옴)
     @GetMapping("/{roomId}/messages")
-    public ResponseEntity<List<Message>> getChatRoomMessages(@PathVariable String roomId,
+    public ResponseEntity<List<CoffeechatMessage>> getChatRoomMessages(@PathVariable String roomId,
         @RequestParam(defaultValue = "0-0") String startId,
         @RequestParam(defaultValue = "100") long count) {
         String chatRoomStreamKey = "coffeechat:" + roomId + ":stream";
@@ -65,12 +65,12 @@ public class CoffeeChatController {
             StreamOffset.create(chatRoomStreamKey, ReadOffset.from(startId)) // 시작 오프셋
         );
 //
-        List<Message> chatMessages = records.stream()
+        List<CoffeechatMessage> chatMessages = records.stream()
             .map(record -> {
                 // MapRecord의 payload는 Map<Object, Object> 형태로 반환될 수 있음
                 // 이를 ChatMessage 객체로 다시 매핑합니다.
                 Map<Object, Object> rawData = record.getValue();
-                return new Message(
+                return new CoffeechatMessage(
                     (String) rawData.get("senderId"),
                     (String) rawData.get("roomId"),
                     (String) rawData.get("content"),

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatController.java
@@ -1,12 +1,5 @@
 package com.ktb.cafeboo.domain.coffeechat.controller;
 
-
-import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatMessage;
-import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChat;
-import com.ktb.cafeboo.domain.coffeechat.repository.CoffeeChatRepository;
-import com.ktb.cafeboo.domain.coffeechat.service.ChatService;
-import com.ktb.cafeboo.global.security.userdetails.CustomUserDetails;
-import java.util.List;
 import com.ktb.cafeboo.domain.coffeechat.dto.*;
 import com.ktb.cafeboo.domain.coffeechat.service.CoffeeChatMessageService;
 import com.ktb.cafeboo.domain.coffeechat.service.CoffeeChatService;
@@ -25,74 +18,14 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/v1/coffee-chats")
 @RequiredArgsConstructor
 public class CoffeeChatController {
-    private final CoffeeChatRepository chatRoomRepository;
-    private final ChatService chatService;
-
-    // 모든 채팅방 목록 조회
-    @GetMapping
-    public ResponseEntity<Collection<CoffeeChat>> getAllChatRooms() {
-        return ResponseEntity.ok(chatRoomRepository.findAllRooms());
-    }
-
-    // 특정 채팅방 정보 조회
-    @GetMapping("/{roomId}")
-    public ResponseEntity<CoffeeChat> getChatRoomById(@PathVariable String roomId) {
-        CoffeeChat room = chatRoomRepository.findRoomById(roomId);
-        if (room != null) {
-            return ResponseEntity.ok(room);
-        }
-        return ResponseEntity.notFound().build();
-    }
 
     private final CoffeeChatService coffeeChatService;
     private final CoffeeChatMessageService coffeeChatMessageService;
 
-    @PostMapping("/{roomId}/member")
-    public ResponseEntity<String> joinCoffeechat(@PathVariable String roomId, @AuthenticationPrincipal CustomUserDetails userDetails
-    ){
-        if (userDetails == null) {
-            log.warn("인증되지 않은 사용자가 CoffeeChat {} 에 가입을 시도했습니다.", roomId);
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("인증이 필요합니다.");
-        }
-
-        Long userId = userDetails.getUserId();
-
-        log.info("[CoffeeChatController.joinCoffeechat] - User {}가 CoffeeChat {}에 가입 시도.\n", userId, roomId);
-        try {
-            // ChatService의 startListeningToRoom() 호출
-            chatService.startListeningToRoom(roomId, userId);
-            log.info("User {} successfully started listening to room {}", userId, roomId);
-            return ResponseEntity.ok("Successfully joined chat room " + roomId);
-        } catch (Exception e) {
-            log.error("Failed to join chat room {} for user {}: {}", roomId, userId, e.getMessage(), e);
-            // 클라이언트에게 오류 응답 (HTTP)
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Failed to join chat room: " + e.getMessage());
-        }
-    }
-
-    @GetMapping("/{roomId}/members/{userId}")
-    public ResponseEntity<Boolean> isUserJoinedRoom(@PathVariable String roomId, @PathVariable String userId) {
-        boolean isJoined = chatService.isUserJoinedRoom(roomId, userId);
-        log.info("Checking if user {} is joined to room {}: {}", userId, roomId, isJoined);
-        return ResponseEntity.ok(isJoined);
-    }
-
-    // 특정 채팅방의 이전 메시지 이력 조회 (Redis Stream에서 가져옴)
-    @GetMapping("/{roomId}/messages")
-    public ResponseEntity<List<CoffeechatMessage>> getChatRoomMessages(@PathVariable String roomId,
-        @RequestParam(defaultValue = "+") String startId,
-        @RequestParam(defaultValue = "100") long count) {
-        log.info("[CoffeeChatController.getChatRoomMessages] - startId: {}, count: {}\n", startId, count);
-        List<CoffeechatMessage> chatMessages = chatService.getChatRoomMessages(roomId, startId, count);
-
-        return ResponseEntity.ok(chatMessages);
-    }
-
-    // 새로운 채팅방 생성 (예: POST /api/chatrooms?name=새로운방이름)
     @PostMapping
     public ResponseEntity<ApiResponse<CoffeeChatCreateResponse>> createCoffeeChat(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestBody CoffeeChatCreateRequest request
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        @RequestBody CoffeeChatCreateRequest request
     ) {
         Long userId = userDetails.getUserId();
         log.info("[POST /api/v1/coffee-chats] userId: {} 커피챗 생성 요청 수신", userId);
@@ -100,14 +33,14 @@ public class CoffeeChatController {
         CoffeeChatCreateResponse response = coffeeChatService.create(userId, request);
 
         return ResponseEntity
-                .status(HttpStatus.CREATED)
-                .body(ApiResponse.of(SuccessStatus.COFFEECHAT_CREATE_SUCCESS, response));
+            .status(HttpStatus.CREATED)
+            .body(ApiResponse.of(SuccessStatus.COFFEECHAT_CREATE_SUCCESS, response));
     }
 
     @GetMapping
     public ResponseEntity<ApiResponse<CoffeeChatListResponse>> getCoffeeChatList(
-            @RequestParam("status") String status,
-            @AuthenticationPrincipal CustomUserDetails userDetails
+        @RequestParam("status") String status,
+        @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         Long userId = userDetails.getUserId();
         log.info("[GET /api/v1/coffee-chats?status={}] 커피챗 목록 조회 요청 수신 - userId: {}", status, userId);
@@ -118,8 +51,8 @@ public class CoffeeChatController {
 
     @GetMapping("/{coffeechatId}")
     public ResponseEntity<ApiResponse<CoffeeChatDetailResponse>> getCoffeeChatDetail(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
-            @PathVariable Long coffeechatId
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        @PathVariable Long coffeechatId
     ) {
         CoffeeChatDetailResponse response = coffeeChatService.getDetail(coffeechatId, userDetails.getUserId());
         return ResponseEntity.ok(ApiResponse.of(SuccessStatus.COFFEECHAT_LOAD_SUCCESS, response));
@@ -127,24 +60,24 @@ public class CoffeeChatController {
 
     @PostMapping("/{coffeechatId}/member")
     public ResponseEntity<ApiResponse<CoffeeChatJoinResponse>> joinCoffeeChat(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
-            @PathVariable Long coffeechatId,
-            @RequestBody CoffeeChatJoinRequest request
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        @PathVariable Long coffeechatId,
+        @RequestBody CoffeeChatJoinRequest request
     ) {
         CoffeeChatJoinResponse response = coffeeChatService.join(
-                userDetails.getUserId(),
-                coffeechatId,
-                request
+            userDetails.getUserId(),
+            coffeechatId,
+            request
         );
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(ApiResponse.of(SuccessStatus.COFFEECHAT_JOIN_SUCCESS, response));
+            .body(ApiResponse.of(SuccessStatus.COFFEECHAT_JOIN_SUCCESS, response));
     }
 
     @DeleteMapping("/{coffeechatId}/member/{memberId}")
     public ResponseEntity<Void> leaveChat(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
-            @PathVariable Long coffeechatId,
-            @PathVariable Long memberId
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        @PathVariable Long coffeechatId,
+        @PathVariable Long memberId
     ) {
         coffeeChatService.leaveChat(coffeechatId, memberId, userDetails.getUserId());
         return ResponseEntity.noContent().build();
@@ -152,8 +85,8 @@ public class CoffeeChatController {
 
     @DeleteMapping("/{coffeechatId}")
     public ResponseEntity<Void> deleteCoffeeChat(
-            @PathVariable Long coffeechatId,
-            @AuthenticationPrincipal CustomUserDetails userDetails
+        @PathVariable Long coffeechatId,
+        @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         Long userId = userDetails.getUserId();
         log.info("[DELETE /api/v1/coffee-chats/{}] userId: {} 커피챗 삭제 요청 수신", coffeechatId, userId);
@@ -164,21 +97,21 @@ public class CoffeeChatController {
 
     @GetMapping("/{coffeechatId}/messages")
     public ResponseEntity<ApiResponse<CoffeeChatMessagesResponse>> getMessages(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
-            @PathVariable Long coffeechatId,
-            @RequestParam String cursor,
-            @RequestParam(defaultValue = "20") int limit,
-            @RequestParam(defaultValue = "desc") String order
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        @PathVariable Long coffeechatId,
+        @RequestParam String cursor,
+        @RequestParam(defaultValue = "20") int limit,
+        @RequestParam(defaultValue = "desc") String order
     ) {
         log.info("[CoffeeChatMessageController.getMessages] 메시지 조회 요청 - userId={}, coffeechatId={}, cursor={}, limit={}, order={}",
-                userDetails.getUserId(), coffeechatId, cursor, limit, order);
+            userDetails.getUserId(), coffeechatId, cursor, limit, order);
 
         CoffeeChatMessagesResponse response = coffeeChatMessageService.getMessages(
-                userDetails.getUserId(),
-                coffeechatId,
-                cursor,
-                limit,
-                order
+            userDetails.getUserId(),
+            coffeechatId,
+            cursor,
+            limit,
+            order
         );
 
         return ResponseEntity.ok(ApiResponse.of(SuccessStatus.COFFEECHAT_MESSAGES_LOAD_SUCCESS, response));

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatController.java
@@ -6,11 +6,13 @@ import com.ktb.cafeboo.domain.coffeechat.model.CoffeechatMessage;
 import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChat;
 import com.ktb.cafeboo.domain.coffeechat.repository.CoffeeChatRepository;
 import com.ktb.cafeboo.domain.coffeechat.service.ChatService;
+import com.ktb.cafeboo.global.security.userdetails.CustomUserDetails;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Collection;
@@ -40,16 +42,14 @@ public class CoffeeChatController {
     }
 
     @PostMapping("/{roomId}/member")
-    public ResponseEntity<String> joinCoffeechat(@PathVariable String roomId /*@AuthenticationPrincipal CustomUserDetails userDetails*/
-        , @RequestBody JoinRoomRequest request
+    public ResponseEntity<String> joinCoffeechat(@PathVariable String roomId, @AuthenticationPrincipal CustomUserDetails userDetails
     ){
-//        if (userDetails == null) {
-//            log.warn("인증되지 않은 사용자가 CoffeeChat {} 에 가입을 시도했습니다.", roomId);
-//            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("인증이 필요합니다.");
-//        }
+        if (userDetails == null) {
+            log.warn("인증되지 않은 사용자가 CoffeeChat {} 에 가입을 시도했습니다.", roomId);
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("인증이 필요합니다.");
+        }
 
-        //userDetails.getUserId();
-        String userId = request.getUserId();
+        Long userId = userDetails.getUserId();
 
         log.info("[CoffeeChatController.joinCoffeechat] - User {}가 CoffeeChat {}에 가입 시도.\n", userId, roomId);
         try {

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChatMessage.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChatMessage.java
@@ -1,21 +1,42 @@
 package com.ktb.cafeboo.domain.coffeechat.model;
 
+import com.ktb.cafeboo.domain.user.model.User;
 import com.ktb.cafeboo.global.BaseEntity;
 import com.ktb.cafeboo.global.enums.MessageType;
-import jakarta.persistence.Entity;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import jakarta.persistence.*;
+import lombok.*;
 
 @Entity
 @Getter
-@Setter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class CoffeechatMessage extends BaseEntity {
-    private String userId;  //테스트용, erd의 Messages 테이블의 user_id. 이후에는 BaseEntity의 id로 대체
-    private String roomId;  //테스트용, erd의 Messages 테이블의 id. 이후에는 CoffeChat Entity의 id로 대체
+public class CoffeeChatMessage extends BaseEntity {
+
+    @Column(name = "message_uuid", nullable = false, unique = true, length = 36)
+    private String messageUuid; // 클라이언트가 생성한 UUID 메시지 ID
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_id", nullable = false)
+    private CoffeeChat chat;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private CoffeeChatMember sender;
+
+    @Column(name = "content", nullable = false, length = 300)
     private String content;
-    private MessageType type; //erd 추가 요망
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, length = 10)
+    private MessageType type;
+
+    public static CoffeeChatMessage of(CoffeeChat chat, CoffeeChatMember sender, String content, MessageType type) {
+        return CoffeeChatMessage.builder()
+            .chat(chat)
+            .sender(sender)
+            .content(content)
+            .type(type)
+            .build();
+    }
 }

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChatMessage.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChatMessage.java
@@ -1,42 +1,21 @@
 package com.ktb.cafeboo.domain.coffeechat.model;
 
-import com.ktb.cafeboo.domain.user.model.User;
 import com.ktb.cafeboo.global.BaseEntity;
 import com.ktb.cafeboo.global.enums.MessageType;
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Entity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Getter
-@Builder
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class CoffeeChatMessage extends BaseEntity {
-
-    @Column(name = "message_uuid", nullable = false, unique = true, length = 36)
-    private String messageUuid; // 클라이언트가 생성한 UUID 메시지 ID
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "chat_id", nullable = false)
-    private CoffeeChat chat;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
-    private CoffeeChatMember sender;
-
-    @Column(name = "content", nullable = false, length = 300)
+public class CoffeechatMessage extends BaseEntity {
+    private String userId;  //테스트용, erd의 Messages 테이블의 user_id. 이후에는 BaseEntity의 id로 대체
+    private String roomId;  //테스트용, erd의 Messages 테이블의 id. 이후에는 CoffeChat Entity의 id로 대체
     private String content;
-
-    @Enumerated(EnumType.STRING)
-    @Column(name = "type", nullable = false, length = 10)
-    private MessageType type;
-
-    public static CoffeeChatMessage of(CoffeeChat chat, CoffeeChatMember sender, String content, MessageType type) {
-        return CoffeeChatMessage.builder()
-                .chat(chat)
-                .sender(sender)
-                .content(content)
-                .type(type)
-                .build();
-    }
+    private MessageType type; //erd 추가 요망
 }

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeechatMessage.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeechatMessage.java
@@ -1,21 +1,42 @@
 package com.ktb.cafeboo.domain.coffeechat.model;
 
+import com.ktb.cafeboo.domain.user.model.User;
 import com.ktb.cafeboo.global.BaseEntity;
 import com.ktb.cafeboo.global.enums.MessageType;
-import jakarta.persistence.Entity;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import jakarta.persistence.*;
+import lombok.*;
 
 @Entity
 @Getter
-@Setter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class CoffeechatMessage extends BaseEntity {
-    private String userId;  //테스트용, erd의 Messages 테이블의 user_id. 이후에는 BaseEntity의 id로 대체
-    private String roomId;  //테스트용, erd의 Messages 테이블의 id. 이후에는 CoffeChat Entity의 id로 대체
+public class CoffeeChatMessage extends BaseEntity {
+
+    @Column(name = "message_uuid", nullable = false, unique = true, length = 36)
+    private String messageUuid; // 클라이언트가 생성한 UUID 메시지 ID
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_id", nullable = false)
+    private CoffeeChat chat;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private CoffeeChatMember sender;
+
+    @Column(name = "content", nullable = false, length = 300)
     private String content;
-    private MessageType type; //erd 추가 요망
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, length = 10)
+    private MessageType type;
+
+    public static CoffeeChatMessage of(CoffeeChat chat, CoffeeChatMember sender, String content, MessageType type) {
+        return CoffeeChatMessage.builder()
+            .chat(chat)
+            .sender(sender)
+            .content(content)
+            .type(type)
+            .build();
+    }
 }

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeechatMessage.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeechatMessage.java
@@ -13,7 +13,7 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class Message extends BaseEntity {
+public class CoffeechatMessage extends BaseEntity {
     private String userId;  //테스트용, erd의 Messages 테이블의 user_id. 이후에는 BaseEntity의 id로 대체
     private String roomId;  //테스트용, erd의 Messages 테이블의 id. 이후에는 CoffeChat Entity의 id로 대체
     private String content;

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/ChatService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/ChatService.java
@@ -1,0 +1,246 @@
+package com.ktb.cafeboo.domain.coffeechat.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ktb.cafeboo.domain.coffeechat.repository.CoffeeChatRepository;
+import com.ktb.cafeboo.global.config.RedisConfig;
+import com.ktb.cafeboo.global.enums.MessageType;
+import com.ktb.cafeboo.global.infra.redis.stream.listener.RedisStreamListener;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeechatMessage;
+import org.springframework.data.redis.connection.Limit;
+import org.springframework.data.domain.Range;
+import org.springframework.data.redis.connection.stream.Consumer;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.ReadOffset;
+import org.springframework.data.redis.connection.stream.RecordId;
+import org.springframework.data.redis.connection.stream.StreamOffset;
+import org.springframework.data.redis.core.StreamOperations;
+import org.springframework.data.redis.stream.StreamMessageListenerContainer.StreamReadRequest;
+import org.springframework.data.redis.stream.Subscription;
+import org.springframework.data.redis.connection.stream.ObjectRecord;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.stream.StreamMessageListenerContainer;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ChatService {
+
+    private final CoffeeChatRepository chatRoomRepository;
+    private StreamOperations<String, Object, Object> streamOperations; // `Object` 대신 `String, String`으로 변경할 수도 있음
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final SimpMessagingTemplate messagingTemplate;
+    private final ObjectMapper objectMapper;
+    private final StreamMessageListenerContainer<String, ObjectRecord<String, CoffeechatMessage>> streamMessageListenerContainer;
+    private final RedisStreamListener redisStreamListener;
+    private final RedisConfig redisConfig;
+
+    private static final String CHAT_STREAM_PREFIX = "coffeechat:room:";
+    private static final String CHAT_CONSUMER_GROUP_PREFIX = "coffeechat:group:";
+    private static final String ROOM_MEMBERS_KEY_PREFIX = "coffeechat:members:";
+
+    // 각 채팅방에 대한 활성 구독을 관리 (Subscription 객체)
+    private final Map<String, Subscription> activeRoomSubscriptions = new ConcurrentHashMap<>();
+
+    // @Scheduled 메서드를 위한 별도의 스케줄러 스레드 풀 (이전과 동일)
+    private final ExecutorService pendingMessageProcessor = Executors.newSingleThreadExecutor();
+
+    @PostConstruct
+    public void setupPendingMessageProcessor(){
+        pendingMessageProcessor.submit(this::processPendingMessageScheduler);
+    }
+
+    @PostConstruct // 서비스 계층에서 스트림 관련 로직을 초기화하는 것은 자연스럽습니다.
+    public void init() {
+        this.streamOperations = redisTemplate.opsForStream();
+    }
+
+    @PreDestroy
+    public void destroy() {
+        activeRoomSubscriptions.forEach((roomId, subscription) -> {
+            subscription.cancel();
+            log.info("[ChatService.destroy] - 채팅방 {}에 대한 Redis Stream의 구독을 취소했습니다.", roomId);
+        });
+        activeRoomSubscriptions.clear();
+        log.info("[ChatService.destroy] - 모든 활성 채팅방에 대한 Redis Stream의 구독을 취소했습니다.");
+
+        // Pending Message를 처리하는 scheduler 종료
+        pendingMessageProcessor.shutdown();
+        try {
+            if (!pendingMessageProcessor.awaitTermination(5, TimeUnit.SECONDS)) {
+                pendingMessageProcessor.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            pendingMessageProcessor.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+        log.info("[ChatService.destroy] - Pending Message를 처리하는 scheduler 종료");
+    }
+
+    /**
+     * 새로운 message를 Redis Stream에 등록
+     * @param message
+     */
+    public void handleNewMessage(String roomId, CoffeechatMessage message) throws Exception{
+        String streamKey = CHAT_STREAM_PREFIX + roomId;
+        Map<String, String> messageMap = new HashMap<>();
+
+        try{
+            System.out.println("[ChatService.handleNewMessage] - " + message.getUserId());
+            System.out.println("[ChatService.handleNewMessage] - " + message.getRoomId());
+            System.out.println("[ChatService.handleNewMessage] - " + message.getContent());
+            System.out.println("[ChatService.handleNewMessage] - " + message.getType().name());
+
+            messageMap.put("userId", message.getUserId());
+            messageMap.put("roomId", message.getRoomId());
+            messageMap.put("content", message.getContent());
+            messageMap.put("type", message.getType().name());
+            RecordId recordId = redisTemplate.opsForStream().add(streamKey, messageMap);
+            log.info("[ChatService.handleNewMessage] - Stream {}에 추가된 메시지: {}", streamKey, recordId.getValue());
+
+            messagingTemplate.convertAndSend("/topic/chatrooms/" + roomId, message);
+        }
+        //메시지 직렬화 오류. 순환 참조가 있거나, ObjectMapper가 처리할 수 없는 커스텀 객체가 필드로 포함된 경우
+        catch (Exception e){
+            log.error("[ChatService.handleNewMessage] - 메시지 전송 오류. roomId: {}, message: {}", message.getRoomId(), e.getMessage(), e);
+            throw e;
+        }
+    }
+
+    /**
+     * 채팅방마다 Redis Stream의 listener를 설정
+     */
+    public void startListeningToRoom(String roomId, String userId){
+        String streamKey = CHAT_STREAM_PREFIX + roomId;
+        String consumerGroupName = CHAT_CONSUMER_GROUP_PREFIX + userId; // 사용자 ID를 컨슈머 그룹으로 사용
+        String consumerName = redisConfig.getConsumerName();
+        log.info("[ChatService.startListeningToRoom] - streamKey: {}, consumerGroupName: {}, consumerName: {}", streamKey, consumerGroupName, consumerName);
+
+        // 이미 구독 중인 방인지 확인 (방별로 하나의 구독만 유지), 예외 처리 진행하지 않을 시 동일 메시지를 여러 번 처리하게 되므로 비효율적
+        if (activeRoomSubscriptions.containsKey(roomId)) {
+            log.info("[ChatService.startListeningToRoom] - 커피챗 {} 에 대응하는 Stream Listener가 이미 존재합니다.", roomId);
+            return;
+        }
+
+        try{
+            redisTemplate.opsForStream().createGroup(streamKey, consumerGroupName);
+            log.info("[ChatService.startListeningToRoom] - Stream {}에 Consumer group {}가 생성되었습니다.", streamKey, consumerGroupName);
+        }
+        catch (Exception e) {
+            if (e.getMessage() != null && e.getMessage().contains("BUSYGROUP Consumer Group name already exists")) {
+                log.info("Consumer group {} already exists for stream {}", consumerGroupName, streamKey);
+            } else {
+                log.error("Error creating consumer group {}: {}", consumerGroupName, e.getMessage());
+                return; // 그룹 생성 실패 시 리스너 시작 안함
+            }
+        }
+
+        // 2. ✨ StreamReadRequest를 사용하여 리스너 등록 방식 변경
+        StreamReadRequest<String> readRequest = StreamReadRequest.builder(
+                StreamOffset.create(streamKey, ReadOffset.lastConsumed())) // 해당 그룹의 마지막으로 소비한 오프셋부터 읽음
+            .consumer(Consumer.from(consumerGroupName, consumerName)) // 컨슈머 그룹과 컨슈머 이름
+            .autoAcknowledge(true) // onMessage() 성공 시 자동 ACK. 메시지 처리 실패 시 재처리를 위해 이 줄을 제거할 수 있음
+            .build();
+
+        // StreamMessageListenerContainer에 리스너 등록
+        // 이 Subscription이 XREADGROUP BLOCK 명령을 내부적으로 처리합니다.
+        Subscription subscription = streamMessageListenerContainer.register(
+            readRequest, // ✨ StreamReadRequest 객체 전달
+            redisStreamListener // 메시지 도착 시 onMessage()가 호출될 리스너 인스턴스
+        );
+
+        activeRoomSubscriptions.put(roomId, subscription);
+        log.info("Stream listener registered for chat room {} with group {} and consumer {}", roomId, consumerGroupName, consumerName);
+    }
+
+    /**
+     * 특정 방에 사용자가 가입되어 있는지 확인합니다.
+     * @param roomId 채팅방 ID
+     * @param userId 사용자 ID
+     * @return 가입되어 있으면 true, 아니면 false
+     */
+    public boolean isUserJoinedRoom(String roomId, String userId) {
+        String roomMembersKey = ROOM_MEMBERS_KEY_PREFIX + roomId;
+
+        // 1. Redis Set에 사용자 추가 (이미 있으면 추가되지 않음 - 멱등성)
+        // 이 부분은 사용자가 "영구적으로" 이 방의 멤버임을 나타냅니다.
+        Long addedCount = redisTemplate.opsForSet().add(roomMembersKey, userId);
+
+        if (addedCount != null && addedCount > 0) {
+            log.info("User {} newly added to active members of room {}.", userId, roomId);
+            return false;
+        } else {
+            log.info("User {} is already an active member of room {}.", userId, roomId);
+            // 이미 멤버인 경우, Redis Stream Consumer Group 관련 로직을 다시 수행하지 않고 바로 반환
+            // (컨슈머 그룹 생성/초기화는 한번만 하면 되므로)
+            // 하지만, 필요하다면 여기에 STOMP 세션 재연결 등 추가 로직을 넣을 수 있습니다.
+            return true;
+        }
+    }
+
+    // ✨ 기존 CoffeeChatController에 있던 getChatRoomMessages 로직을 여기로 이동
+    public List<CoffeechatMessage> getChatRoomMessages(String roomId, String startId, long count) {
+        String chatRoomStreamKey = "coffeechat:room:" + roomId;
+
+        if (count <= 0) {
+            log.info("Requested count is {} for room {}. Returning empty list.", count, roomId);
+            return Collections.emptyList();
+        }
+
+        log.info("Fetching messages for room {} from ID {} with count {} (reverse order).", roomId, startId, count);
+
+        // streamOperations는 이제 이 서비스 클래스 내부에서 초기화되어 사용 가능합니다.
+        List<MapRecord<String, Object, Object>> records = streamOperations.reverseRange(
+            chatRoomStreamKey,
+            Range.of(
+                Range.Bound.inclusive("+"),
+                Range.Bound.inclusive("-")
+            ),
+            Limit.limit().count((int) count)
+        );
+        Collections.reverse(records);
+        log.info("[ChatService] - records count: {}", records.size());
+
+        List<CoffeechatMessage> chatMessages = records.stream()
+            .map(record -> {
+                // MapRecord의 payload는 Map<Object, Object> 형태로 반환될 수 있음
+                // 이를 ChatMessage 객체로 다시 매핑합니다.
+                Map<Object, Object> rawData = record.getValue();
+                return new CoffeechatMessage(
+                    (String) rawData.get("userId"),
+                    (String) rawData.get("roomId"),
+                    (String) rawData.get("content"),
+                    MessageType.valueOf((String) rawData.get("type"))
+                );
+            })
+            .collect(Collectors.toList());
+
+        return chatMessages;
+    }
+
+    /**
+     * 메시지 전송 과정에서 문제가 생겨 ACK 되지 않은 상태인 pending 메시지 처리 메서드
+     */
+    @Scheduled(fixedDelay = 300000) // 5분 마다 실행
+    @Async
+    public void processPendingMessageScheduler(){
+        log.info("[ChatService.processPendingMessageScheduler] - PENDING 상태의 메서지 처리 진행...");
+
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/ChatService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/ChatService.java
@@ -126,7 +126,7 @@ public class ChatService {
     /**
      * 채팅방마다 Redis Stream의 listener를 설정
      */
-    public void startListeningToRoom(String roomId, String userId){
+    public void startListeningToRoom(String roomId, Long userId){
         String streamKey = CHAT_STREAM_PREFIX + roomId;
         String consumerGroupName = CHAT_CONSUMER_GROUP_PREFIX + userId; // 사용자 ID를 컨슈머 그룹으로 사용
         String consumerName = redisConfig.getConsumerName();

--- a/src/main/java/com/ktb/cafeboo/global/config/SecurityConfig.java
+++ b/src/main/java/com/ktb/cafeboo/global/config/SecurityConfig.java
@@ -43,7 +43,8 @@ public class SecurityConfig {
             new AntPathRequestMatcher("/favicon.ico"),
             new AntPathRequestMatcher("/webjars/**"), // SockJS, STOMP.js가 webjars를 통해 제공된다면 필요// 웹소켓 엔드포인트
             new AntPathRequestMatcher("/api/chat/**"),
-            new AntPathRequestMatcher("/api/chatrooms/**")
+            new AntPathRequestMatcher("/api/chatrooms/**"),
+            new AntPathRequestMatcher("/chatrooms/{roomId}/member") // 테스트용
         );
 
         http


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] Redis Stream을 이용한 메시징 기능 구현
- [x] 그에 따른 서비스 로직 구현

## 🛠 변경사항
- 채팅방 별로 Redis Stream의 listener 설정
Redis Stream의 경우 consumer group (listener) 단위로 작업을 나눠서 처리하도록 할 수 있음. 이 때, 각 채팅방에 여러 consumer group이 할당되는 경우, 동일한 메시지를 여러 번 처리하게 되므로 비효율적임.

이러한 부분을 방지하기 위해 각 채팅방 별로 하나의 listener만 설정되도록 구현을 진행.

- isUserJoinedRoom() 메서드 추가
채팅방에 입장하는 경우는 두 가지 대표 케이스가 존재.
  i. 신규 가입
 ii. 이미 가입한 사람이 재입장

이 때, 각 유저는 입장을 하며 해당 채팅방에 대해 subscribe를 진행하게 되는데 이미 가입한 사람이 재입장하는 경우에는 이 과정이 불필요함.

따라서, 신규 가입인지 재입장인지를 판별하기 위해 해당 메서드를 추가.

- NOACK 상태의 메시지를 처리하는 스케쥴러 및 pendingMessageProcessor 추가
네트워크 오류, 서버 오류 등이 발생 시 Redis Stream에는 메시지가 전달되었지만 ACK되지 않을 가능성이 존재함. NOACK 상태의 메시지는 자원을 불필요하게 차지하는 상태이므로 이를 해소시킬 수 있는 로직이 필요.

따라서, 일정 주기로 NOACK (= PENDING) 상태의 메시지를 처리하는 PendingMessageProcessor를 스케쥴러를 통해 실행하도록 하는 기능을 추가.

## 💬 리뷰 요구사항
- 현재 채팅방과 같은 데이터의 경우 DB 상에 저장하는 부분이 미구현 상태입니다. 채팅의 경우 서버가 실행되는 동안에는 Redis 상에 저장되는 것을 확인했지만 재부팅을 하는 경우 인메모리 DB인 Redis의 특성 상 내역이 날아가는 상황입니다. 
- 채팅방에 재입장 시, 현재의 로컬 구현에서는 읽지 않은 메시지의 수 만큼만 채팅 화면에 메시지를 불러오게 됩니다. 이 부분은 임의로 구현했기에 대화 후에 수정이 진행되어야 할 거 같습니다.

## 🔍 테스트 방법(선택)
- 로컬 환경에서 테스트
