### PR TITLE
[FEAT] 카카오 프로필 이미지 연동 및 S3 업로드 기능 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
@@ -42,9 +43,11 @@ dependencies {
 	//prometheus
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'io.micrometer:micrometer-registry-prometheus'
-
-	implementation 'org.springframework.boot:spring-boot-starter'
 	implementation 'io.micrometer:micrometer-core'
+
+	// s3
+	implementation platform("software.amazon.awssdk:bom:2.25.0")
+	implementation "software.amazon.awssdk:s3"
 
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/com/ktb/cafeboo/domain/auth/service/KakaoOauthService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/auth/service/KakaoOauthService.java
@@ -87,9 +87,9 @@ public class KakaoOauthService {
         boolean requiresOnboarding = !userService.hasCompletedOnboarding(user);
 
         if (requiresOnboarding) {
-            log.info("[KakaoOauthService.login] 신규 사용자 가입 - userId={}", user.getId());
+            log.info("[KakaoOauthService.login] 온보딩 필요 - userId={}", user.getId());
         } else {
-            log.info("[KakaoOauthService.login] 기존 사용자 로그인 - userId={}", user.getId());
+            log.info("[KakaoOauthService.login] 온보딩 완료 - userId={}", user.getId());
         }
 
         String accessToken = generateAccessToken(user);
@@ -151,66 +151,35 @@ public class KakaoOauthService {
         }
     }
 
-    private KakaoTokenResponse getKakaoToken(String code) {
-        return kakaoTokenClient.getToken(code, clientId, redirectUri, grantType);
-    }
-
-    private KakaoUserResponse getKakaoUserInfo(String accessToken) {
-        return kakaoUserClient.getUserInfo(accessToken);
-    }
-
     private User getOrCreateUser(KakaoUserResponse kakaoUser) {
+        String kakaoImageUrl = kakaoUser.getKakaoAccount().getProfile().getProfileImageUrl();
+
         return userRepository.findByOauthIdAndLoginType(kakaoUser.getId(), LoginType.KAKAO)
                 .map(user -> {
-                    // 기존 유저인데 profileImageUrl이 비어있다면
+                    // 기존 유저인데 프로필 이미지가 없는 경우
                     if (user.getProfileImageUrl() == null) {
-                        String kakaoImageUrl = kakaoUser.getKakaoAccount().getProfile().getProfileImageUrl();
-                        log.info("kakaoImageUrl={}", kakaoImageUrl);
+                        String profileImageUrl = (kakaoImageUrl != null && !kakaoImageUrl.isBlank())
+                                ? fetchKakaoProfileImage(kakaoImageUrl)
+                                : s3Uploader.getDefaultProfileImageUrl();
 
-                        String profileImageUrl;
-
-                        if (kakaoImageUrl != null && !kakaoImageUrl.isBlank()) {
-                            try (InputStream is = new URL(kakaoImageUrl).openStream()) {
-                                long contentLength = is.available();
-                                String contentType = URLConnection.guessContentTypeFromStream(is);
-                                profileImageUrl = s3Uploader.uploadProfileImage(is, contentLength, contentType);
-                            } catch (IOException e) {
-                                profileImageUrl = s3Uploader.getDefaultProfileImageUrl();
-                            }
-                        } else {
-                            profileImageUrl = s3Uploader.getDefaultProfileImageUrl();
-                        }
                         user.updateProfileImage(profileImageUrl);
                         userRepository.save(user);
                     }
-
                     return user;
                 })
                 .orElseGet(() -> {
-                    String kakaoImageUrl = kakaoUser.getKakaoAccount().getProfile().getProfileImageUrl();
-                    String profileImageUrl;
+                    String profileImageUrl = (kakaoImageUrl != null && !kakaoImageUrl.isBlank())
+                            ? fetchKakaoProfileImage(kakaoImageUrl)
+                            : s3Uploader.getDefaultProfileImageUrl();
 
-                    if (kakaoImageUrl != null && !kakaoImageUrl.isBlank()) {
-                        try (InputStream is = new URL(kakaoImageUrl).openStream()) {
-                            long contentLength = is.available();
-                            String contentType = URLConnection.guessContentTypeFromStream(is);
-                            profileImageUrl = s3Uploader.uploadProfileImage(is, contentLength, contentType);
-                        } catch (IOException e) {
-                            profileImageUrl = s3Uploader.getDefaultProfileImageUrl();
-                        }
-                    } else {
-                        profileImageUrl = s3Uploader.getDefaultProfileImageUrl();
-                    }
-                    log.info("kakaoImageUrl={}", kakaoImageUrl);
-                    log.info("profileImageUrl={}", profileImageUrl);
                     User newUser = User.fromKakao(kakaoUser, profileImageUrl);
-
                     User savedUser = userRepository.save(newUser);
+
                     userAlarmSettingService.create(
                             savedUser.getId(),
                             new UserAlarmSettingCreateRequest(false, false, false)
                     );
-                    return newUser;
+                    return savedUser;
                 });
     }
 
@@ -263,4 +232,21 @@ public class KakaoOauthService {
             action.accept(newAccessToken);
         }
     }
+
+    private String fetchKakaoProfileImage(String imageUrl) {
+        try {
+            URL url = new URL(imageUrl);
+            URLConnection connection = url.openConnection();
+            long contentLength = connection.getContentLengthLong(); // 더 정확함
+            String contentType = connection.getContentType(); // 직접 추출
+
+            try (InputStream is = connection.getInputStream()) {
+                return s3Uploader.uploadProfileImage(is, contentLength, contentType);
+            }
+        } catch (IOException e) {
+            log.warn("[fetchKakaoProfileImage] 카카오 이미지 업로드 실패: {}", e.getMessage());
+            return s3Uploader.getDefaultProfileImageUrl();
+        }
+    }
+
 }

--- a/src/main/java/com/ktb/cafeboo/domain/user/model/User.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/model/User.java
@@ -37,6 +37,9 @@ public class User extends BaseEntity {
     @Column(nullable = false, length = 10)
     private String nickname;
 
+    @Column
+    private String profileImageUrl;
+
     @Column(nullable = true, length = 512)
     private String refreshToken;
 
@@ -84,7 +87,7 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<YearlyReport> yearlyReports = new ArrayList<>();
 
-    public static User fromKakao(KakaoUserResponse kakaoUser) {
+    public static User fromKakao(KakaoUserResponse kakaoUser, String profileImageUrl) {
         User user = new User();
         user.setOauthId(kakaoUser.getId());
         user.setLoginType(LoginType.KAKAO);
@@ -93,6 +96,7 @@ public class User extends BaseEntity {
         user.setRole(UserRole.USER);
         user.setDarkMode(false);
         user.setCoffeeBean(0);
+        user.setProfileImageUrl(profileImageUrl);
         return user;
     }
 
@@ -103,5 +107,11 @@ public class User extends BaseEntity {
     public void setFavoriteDrinks(List<UserFavoriteDrinkType> favorites) {
         this.favoriteDrinks.clear(); // 기존 관계 제거
         this.favoriteDrinks.addAll(favorites);
+    }
+
+    public void updateProfileImage(String profileImageUrl) {
+        if (this.profileImageUrl == null) {
+            this.profileImageUrl = profileImageUrl;
+        }
     }
 }

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/ErrorStatus.java
@@ -50,6 +50,7 @@ public enum ErrorStatus implements BaseCode {
 
     // 외부 시스템 관련 오류
     AI_SERVER_ERROR(502, "AI_SERVER_ERROR", "AI 서버와의 통신 중 오류가 발생했습니다."),
+    S3_REVIEW_IMAGE_UPLOAD_FAILED(500, "S3_REVIEW_IMAGE_UPLOAD_FAILED", "S3에 후기 이미지를 업로드하는 데 실패했습니다."),
 
     //리포트 관련 오류
     REPORT_NOT_FOUND(404, "REPORT_NOT_FOUND", "리포트 정보를 찾을 수 없습니다."),

--- a/src/main/java/com/ktb/cafeboo/global/config/S3Config.java
+++ b/src/main/java/com/ktb/cafeboo/global/config/S3Config.java
@@ -1,0 +1,42 @@
+package com.ktb.cafeboo.global.config;
+
+import com.ktb.cafeboo.global.infra.s3.S3Properties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+@EnableConfigurationProperties(S3Properties.class)
+public class S3Config {
+
+    @Bean
+    public S3Client s3Client(S3Properties s3Properties) {
+        return S3Client.builder()
+                .region(Region.of(s3Properties.getRegion()))
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(
+                                        s3Properties.getAccessKey(),
+                                        s3Properties.getSecretKey()
+                                )
+                        )
+                )
+                .build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner(S3Properties properties) {
+        return S3Presigner.builder()
+                .region(Region.of(properties.getRegion()))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(properties.getAccessKey(), properties.getSecretKey())
+                ))
+                .build();
+    }
+
+}

--- a/src/main/java/com/ktb/cafeboo/global/infra/s3/S3Properties.java
+++ b/src/main/java/com/ktb/cafeboo/global/infra/s3/S3Properties.java
@@ -1,0 +1,39 @@
+package com.ktb.cafeboo.global.infra.s3;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "cloud.aws")
+public record S3Properties(
+        S3 s3,
+        Credentials credentials,
+        Region region
+) {
+
+    public record S3(String bucket, String dir, String defaultProfileImageUrl) {}
+    public record Credentials(String accessKey, String secretKey) {}
+    public record Region(String staticRegion) {}
+
+    public String getAccessKey() {
+        return credentials.accessKey();
+    }
+
+    public String getSecretKey() {
+        return credentials.secretKey();
+    }
+
+    public String getRegion() {
+        return region.staticRegion();
+    }
+
+    public String getBucket() {
+        return s3.bucket();
+    }
+
+    public String getDir() {
+        return s3.dir();
+    }
+
+    public String getDefaultProfileImageUrl() {
+        return s3.defaultProfileImageUrl();
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/global/infra/s3/S3Uploader.java
+++ b/src/main/java/com/ktb/cafeboo/global/infra/s3/S3Uploader.java
@@ -81,8 +81,12 @@ public class S3Uploader {
         return s3Presigner.presignGetObject(presignRequest).url().toString();
     }
 
-
     private String generatePublicUrl(String key) {
         return String.format("https://%s.s3.amazonaws.com/%s", s3Properties.getBucket(), key);
     }
+
+    public String getDefaultProfileImageUrl() {
+        return s3Properties.getDefaultProfileImageUrl();
+    }
+
 }

--- a/src/main/java/com/ktb/cafeboo/global/infra/s3/S3Uploader.java
+++ b/src/main/java/com/ktb/cafeboo/global/infra/s3/S3Uploader.java
@@ -1,0 +1,88 @@
+package com.ktb.cafeboo.global.infra.s3;
+
+import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
+import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+
+import java.io.InputStream;
+import java.time.Duration;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class S3Uploader {
+
+    private final S3Client s3Client;
+    private final S3Presigner s3Presigner;
+    private final S3Properties s3Properties;
+
+    public String uploadProfileImage(InputStream inputStream, long contentLength, String contentType) {
+        String fileName = String.format("%s/profile-images/%s", s3Properties.getDir(), UUID.randomUUID());
+        try {
+            PutObjectRequest request = PutObjectRequest.builder()
+                    .bucket(s3Properties.getBucket())
+                    .key(fileName)
+                    .contentType(contentType)
+                    .acl("public-read")
+                    .build();
+
+            s3Client.putObject(request, RequestBody.fromInputStream(inputStream, contentLength));
+
+            String uploadedUrl = generatePublicUrl(fileName);
+            log.info("[S3Uploader.uploadProfileImageOrDefault] 업로드 성공: {}", uploadedUrl);
+            return uploadedUrl;
+        } catch (Exception e) {
+            log.warn("[S3Uploader.uploadProfileImageOrDefault] 업로드 실패, 기본 이미지 사용: {}", e.getMessage());
+            return s3Properties.getDefaultProfileImageUrl();
+        }
+    }
+
+    public String uploadReviewImage(InputStream inputStream, long contentLength, String contentType) {
+        String fileName = String.format("%s/review-images/%s", s3Properties.getDir(), UUID.randomUUID());
+        try {
+            PutObjectRequest request = PutObjectRequest.builder()
+                    .bucket(s3Properties.getBucket())
+                    .key(fileName)
+                    .contentType(contentType)
+                    .acl("public-read")
+                    .build();
+
+            s3Client.putObject(request, RequestBody.fromInputStream(inputStream, contentLength));
+
+            String uploadedUrl = generatePublicUrl(fileName);
+            log.info("[S3Uploader.uploadReviewImage] 업로드 성공: {}", uploadedUrl);
+            return uploadedUrl;
+        } catch (Exception e) {
+            log.error("[S3Uploader.uploadReviewImage] 업로드 실패", e);
+            throw new CustomApiException(ErrorStatus.S3_REVIEW_IMAGE_UPLOAD_FAILED);
+        }
+    }
+
+    public String generatePresignedUrl(String fileName, Duration duration) {
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                .bucket(s3Properties.getBucket())
+                .key(fileName)
+                .build();
+
+        GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                .signatureDuration(duration)
+                .getObjectRequest(getObjectRequest)
+                .build();
+
+        return s3Presigner.presignGetObject(presignRequest).url().toString();
+    }
+
+
+    private String generatePublicUrl(String key) {
+        return String.format("https://%s.s3.amazonaws.com/%s", s3Properties.getBucket(), key);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,7 +12,7 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 # JPA
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.format_sql=false
 spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
 
 # oauth
@@ -47,7 +47,7 @@ management.endpoint.health.show-details=always
 # S3
 cloud.aws.s3.bucket=${AWS_S3_BUCKET}
 cloud.aws.s3.dir=${AWS_S3_PROFILE_DIR:cafeboo}
-cloud.aws.s3.default-profile-url=https://your-cdn.com/defaults/profile.png
-cloud.aws.credentials.access-key=${AWS_ACCESS_KEY}
-cloud.aws.credentials.secret-key=${AWS_SECRET_KEY}
-cloud.aws.region.static=ap-northeast-2
+cloud.aws.s3.defaultProfileImageUrl=https://your-cdn.com/defaults/profile.png
+cloud.aws.credentials.accessKey=${AWS_ACCESS_KEY}
+cloud.aws.credentials.secretKey=${AWS_SECRET_KEY}
+cloud.aws.region.static-region=ap-northeast-2

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -47,7 +47,7 @@ management.endpoint.health.show-details=always
 # S3
 cloud.aws.s3.bucket=${AWS_S3_BUCKET}
 cloud.aws.s3.dir=${AWS_S3_PROFILE_DIR:cafeboo}
-cloud.aws.s3.defaultProfileImageUrl=${DEFAULT_PROFILE_IMAGE_URL:https://your-cdn.com/defaults/profile.png}
+cloud.aws.s3.defaultProfileImageUrl=${DEFAULT_PROFILE_IMAGE_URL:https://cafeboo-s3.s3.ap-northeast-2.amazonaws.com/defaults/default-profile.png}
 cloud.aws.credentials.accessKey=${AWS_ACCESS_KEY}
 cloud.aws.credentials.secretKey=${AWS_SECRET_KEY}
 cloud.aws.region.static-region=ap-northeast-2

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -47,6 +47,7 @@ management.endpoint.health.show-details=always
 # S3
 cloud.aws.s3.bucket=${AWS_S3_BUCKET}
 cloud.aws.s3.dir=${AWS_S3_PROFILE_DIR:cafeboo}
+# TODO: ?? ??? ??? ??? ?, ?? URL? ??
 cloud.aws.s3.defaultProfileImageUrl=https://your-cdn.com/defaults/profile.png
 cloud.aws.credentials.accessKey=${AWS_ACCESS_KEY}
 cloud.aws.credentials.secretKey=${AWS_SECRET_KEY}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -43,3 +43,11 @@ logging.level.com.example.cafeboo=DEBUG
 # Health Check, Monitoring
 management.endpoints.web.exposure.include=health,prometheus
 management.endpoint.health.show-details=always
+
+# S3
+cloud.aws.s3.bucket=${AWS_S3_BUCKET}
+cloud.aws.s3.dir=${AWS_S3_PROFILE_DIR:cafeboo}
+cloud.aws.s3.default-profile-url=https://your-cdn.com/defaults/profile.png
+cloud.aws.credentials.access-key=${AWS_ACCESS_KEY}
+cloud.aws.credentials.secret-key=${AWS_SECRET_KEY}
+cloud.aws.region.static=ap-northeast-2

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -47,8 +47,7 @@ management.endpoint.health.show-details=always
 # S3
 cloud.aws.s3.bucket=${AWS_S3_BUCKET}
 cloud.aws.s3.dir=${AWS_S3_PROFILE_DIR:cafeboo}
-# TODO: ?? ??? ??? ??? ?, ?? URL? ??
-cloud.aws.s3.defaultProfileImageUrl=https://your-cdn.com/defaults/profile.png
+cloud.aws.s3.defaultProfileImageUrl=${DEFAULT_PROFILE_IMAGE_URL:https://your-cdn.com/defaults/profile.png}
 cloud.aws.credentials.accessKey=${AWS_ACCESS_KEY}
 cloud.aws.credentials.secretKey=${AWS_SECRET_KEY}
 cloud.aws.region.static-region=ap-northeast-2

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -47,7 +47,7 @@ management.endpoint.health.show-details=always
 # S3
 cloud.aws.s3.bucket=${AWS_S3_BUCKET}
 cloud.aws.s3.dir=${AWS_S3_PROFILE_DIR:cafeboo}
-cloud.aws.s3.defaultProfileImageUrl=${DEFAULT_PROFILE_IMAGE_URL:https://cafeboo-s3.s3.ap-northeast-2.amazonaws.com/defaults/default-profile.png}
+cloud.aws.s3.defaultProfileImageUrl=${DEFAULT_PROFILE_IMAGE_URL:https://cafeboo-s3.s3.ap-northeast-2.amazonaws.com/cafeboo/defaults/default-profile.png}
 cloud.aws.credentials.accessKey=${AWS_ACCESS_KEY}
 cloud.aws.credentials.secretKey=${AWS_SECRET_KEY}
 cloud.aws.region.static-region=ap-northeast-2


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] 카카오 소셜 로그인 시, 카카오 프로필 이미지 연동 기능 구현
- [x] S3 이미지 저장 로직 구현

## 🛠 변경사항
- `S3Uploader`: AWS S3 이미지 업로드 공통 클래스 구현
- `KakaoOauthService`: 내부에서 카카오 프로필 이미지 업로드 및 저장 로직 추가
    - 회원가입 시, 이미지 새로 저장
    - 기존 회원은 이미지 URL이 null인 경우만 업데이트되도록 조건 분기

## 💬 리뷰 요구사항
- S3 upload 공통 메서드 사용에 대해 궁금한 사항이 있으면 말씀해주세요

## 🔍 테스트 방법(선택)
- AWS 이미지 폴더 구성

**cafeboo/**
├── **defaults/**
 │   └── default-profile.png
├── **profile-uploads/**
└── **review-uploads/**
    

<img width="718" alt="image" src="https://github.com/user-attachments/assets/56e654fb-c5b7-448a-8dcb-c141156ccf48" />


fixes: #135 