### PR TITLE
[FEAT] 커피챗 생성 및 참여 관련 API 구현

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/ChatController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/ChatController.java
@@ -1,6 +1,8 @@
 package com.ktb.cafeboo.domain.coffeechat.controller;
 
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChat;
 import com.ktb.cafeboo.domain.coffeechat.model.Message;
+import com.ktb.cafeboo.domain.user.model.User;
 import jakarta.annotation.PostConstruct;
 import java.util.HashMap;
 import java.util.Map;
@@ -36,16 +38,19 @@ public class ChatController {
     @MessageMapping("/chatrooms/{roomId}")
     public void handleCoffeeChatMessage(@DestinationVariable String roomId, @Payload Message chatMessage, SimpMessageHeaderAccessor headerAccessor) {
         // 클라이언트에서 보낸 메시지 로그
+        User sender = chatMessage.getSender();
+        CoffeeChat coffeeChat = chatMessage.getChat();
+
         log.info("[ChatController.handleCoffeeChatMessage] - 유저 {}로부터 커피챗 {}에 보내는 메시지를 받았습니다: {}",
-            chatMessage.getUserId(), roomId,
+            sender.getId(), roomId,
             chatMessage.getContent());
 
         String coffeeChatStreamKey = "coffeechat:" + roomId + ":stream";
 
         // ChatMessage 객체를 Map<String, String>으로 변환
         Map<String, String> messageMap = new HashMap<>();
-        messageMap.put("userId", chatMessage.getUserId());
-        messageMap.put("roomId", chatMessage.getRoomId());
+        messageMap.put("userId", sender.getId().toString());
+        messageMap.put("roomId", coffeeChat.getId().toString());
         messageMap.put("content", chatMessage.getContent());
         messageMap.put("type", chatMessage.getType().name()); // Enum은 String으로 변환
         //messageMap.put("timestamp", String.valueOf(chatMessage.getTimestamp())); // long은 String으로 변환

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatController.java
@@ -1,91 +1,91 @@
 package com.ktb.cafeboo.domain.coffeechat.controller;
 
-
-import com.ktb.cafeboo.domain.coffeechat.model.Message;
-import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChat;
-import com.ktb.cafeboo.domain.coffeechat.repository.CoffeeChatRepository;
-import com.ktb.cafeboo.global.enums.MessageType;
-import jakarta.annotation.PostConstruct;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
+import com.ktb.cafeboo.domain.coffeechat.dto.*;
+import com.ktb.cafeboo.domain.coffeechat.service.CoffeeChatService;
+import com.ktb.cafeboo.global.apiPayload.ApiResponse;
+import com.ktb.cafeboo.global.apiPayload.code.status.SuccessStatus;
+import com.ktb.cafeboo.global.security.userdetails.CustomUserDetails;
+import com.ktb.cafeboo.global.util.AuthChecker;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.connection.stream.MapRecord;
-import org.springframework.data.redis.connection.stream.ReadOffset;
-import org.springframework.data.redis.connection.stream.StreamOffset;
-import org.springframework.data.redis.connection.stream.StreamReadOptions;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.StreamOperations;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Collection;
-
+@Slf4j
 @RestController
-@RequestMapping("/api/chatrooms")
-@RequiredArgsConstructor// HTTP 엔드포인트
+@RequestMapping("/api/v1/coffee-chats")
+@RequiredArgsConstructor
 public class CoffeeChatController {
 
-    private final CoffeeChatRepository chatRoomRepository;
-    private final RedisTemplate<String, Object> redisTemplate; // `Object` 대신 `String`으로 변경할 수도 있음
-    private StreamOperations<String, Object, Object> streamOperations; // `Object` 대신 `String, String`으로 변경할 수도 있음
+    private final CoffeeChatService coffeeChatService;
 
-    @PostConstruct
-    public void init (){
-        this.streamOperations = redisTemplate.opsForStream();
-    }
-
-    // 모든 채팅방 목록 조회
-    @GetMapping
-    public ResponseEntity<Collection<CoffeeChat>> getAllChatRooms() {
-        return ResponseEntity.ok(chatRoomRepository.findAllRooms());
-    }
-
-    // 특정 채팅방 정보 조회
-    @GetMapping("/{roomId}")
-    public ResponseEntity<CoffeeChat> getChatRoomById(@PathVariable String roomId) {
-        CoffeeChat room = chatRoomRepository.findRoomById(roomId);
-        if (room != null) {
-            return ResponseEntity.ok(room);
-        }
-        return ResponseEntity.notFound().build();
-    }
-
-    // 특정 채팅방의 이전 메시지 이력 조회 (Redis Stream에서 가져옴)
-    @GetMapping("/{roomId}/messages")
-    public ResponseEntity<List<Message>> getChatRoomMessages(@PathVariable String roomId,
-        @RequestParam(defaultValue = "0-0") String startId,
-        @RequestParam(defaultValue = "100") long count) {
-        String chatRoomStreamKey = "coffeechat:" + roomId + ":stream";
-
-
-        // MapRecord를 읽도록 명시적으로 지정
-        List<MapRecord<String, Object, Object>> records = streamOperations.read(
-            StreamReadOptions.empty().count(count), // 메시지 개수 제한 옵션
-            StreamOffset.create(chatRoomStreamKey, ReadOffset.from(startId)) // 시작 오프셋
-        );
-//
-        List<Message> chatMessages = records.stream()
-            .map(record -> {
-                // MapRecord의 payload는 Map<Object, Object> 형태로 반환될 수 있음
-                // 이를 ChatMessage 객체로 다시 매핑합니다.
-                Map<Object, Object> rawData = record.getValue();
-                return new Message(
-                    (String) rawData.get("senderId"),
-                    (String) rawData.get("roomId"),
-                    (String) rawData.get("content"),
-                    MessageType.valueOf((String) rawData.get("type"))
-                );
-            })
-            .collect(Collectors.toList());
-
-        return ResponseEntity.ok(chatMessages);
-    }
-
-    // 새로운 채팅방 생성 (예: POST /api/chatrooms?name=새로운방이름)
     @PostMapping
-    public ResponseEntity<CoffeeChat> createChatRoom(@RequestParam String name) {
-        CoffeeChat newRoom = chatRoomRepository.createChatRoom(name);
-        return ResponseEntity.status(201).body(newRoom);
+    public ResponseEntity<ApiResponse<CoffeeChatCreateResponse>> createCoffeeChat(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody CoffeeChatCreateRequest request
+    ) {
+        Long userId = userDetails.getUserId();
+        log.info("[POST /api/v1/coffee-chats] userId: {} 커피챗 생성 요청 수신", userId);
+
+        CoffeeChatCreateResponse response = coffeeChatService.create(userId, request);
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.of(SuccessStatus.COFFEECHAT_CREATE_SUCCESS, response));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<CoffeeChatListResponse>> getCoffeeChatList(
+            @RequestParam("status") String status,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUserId();
+        log.info("[GET /api/v1/coffee-chats?status={}] 커피챗 목록 조회 요청 수신 - userId: {}", status, userId);
+
+        CoffeeChatListResponse response = coffeeChatService.getCoffeeChatsByStatus(userId, status);
+        return ResponseEntity.ok(ApiResponse.of(SuccessStatus.COFFEECHAT_LIST_LOAD_SUCCESS, response));
+    }
+
+    @GetMapping("/{coffeechatId}")
+    public ApiResponse<CoffeeChatDetailResponse> getCoffeeChatDetail(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long coffeechatId
+    ) {
+        CoffeeChatDetailResponse response = coffeeChatService.getDetail(coffeechatId, userDetails.getUserId());
+        return ApiResponse.of(SuccessStatus.COFFEECHAT_LOAD_SUCCESS, response);
+    }
+
+    @PostMapping("/{coffeechatId}/member")
+    public ResponseEntity<ApiResponse<CoffeeChatJoinResponse>> joinCoffeeChat(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long coffeechatId
+    ) {
+        CoffeeChatJoinResponse response = coffeeChatService.join(userDetails.getUserId(), coffeechatId);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.of(SuccessStatus.COFFEECHAT_JOIN_SUCCESS, response));
+    }
+
+    @DeleteMapping("/{coffeechatId}/member/{memberId}")
+    public ResponseEntity<Void> leaveChat(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long coffeechatId,
+            @PathVariable Long memberId
+    ) {
+        coffeeChatService.leaveChat(coffeechatId, memberId, userDetails.getUserId());
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{coffeechatId}")
+    public ResponseEntity<Void> deleteCoffeeChat(
+            @PathVariable Long coffeechatId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUserId();
+        log.info("[DELETE /api/v1/coffee-chats/{}] userId: {} 커피챗 삭제 요청 수신", coffeechatId, userId);
+
+        coffeeChatService.delete(coffeechatId, userId);
+        return ResponseEntity.noContent().build(); // 204 No Content
     }
 }

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatController.java
@@ -5,7 +5,6 @@ import com.ktb.cafeboo.domain.coffeechat.service.CoffeeChatService;
 import com.ktb.cafeboo.global.apiPayload.ApiResponse;
 import com.ktb.cafeboo.global.apiPayload.code.status.SuccessStatus;
 import com.ktb.cafeboo.global.security.userdetails.CustomUserDetails;
-import com.ktb.cafeboo.global.util.AuthChecker;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -60,9 +59,14 @@ public class CoffeeChatController {
     @PostMapping("/{coffeechatId}/member")
     public ResponseEntity<ApiResponse<CoffeeChatJoinResponse>> joinCoffeeChat(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @PathVariable Long coffeechatId
+            @PathVariable Long coffeechatId,
+            @RequestBody CoffeeChatJoinRequest request
     ) {
-        CoffeeChatJoinResponse response = coffeeChatService.join(userDetails.getUserId(), coffeechatId);
+        CoffeeChatJoinResponse response = coffeeChatService.join(
+                userDetails.getUserId(),
+                coffeechatId,
+                request
+        );
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.of(SuccessStatus.COFFEECHAT_JOIN_SUCCESS, response));
     }

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatController.java
@@ -1,6 +1,7 @@
 package com.ktb.cafeboo.domain.coffeechat.controller;
 
 import com.ktb.cafeboo.domain.coffeechat.dto.*;
+import com.ktb.cafeboo.domain.coffeechat.service.CoffeeChatMessageService;
 import com.ktb.cafeboo.domain.coffeechat.service.CoffeeChatService;
 import com.ktb.cafeboo.global.apiPayload.ApiResponse;
 import com.ktb.cafeboo.global.apiPayload.code.status.SuccessStatus;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.*;
 public class CoffeeChatController {
 
     private final CoffeeChatService coffeeChatService;
+    private final CoffeeChatMessageService coffeeChatMessageService;
 
     @PostMapping
     public ResponseEntity<ApiResponse<CoffeeChatCreateResponse>> createCoffeeChat(
@@ -48,12 +50,12 @@ public class CoffeeChatController {
     }
 
     @GetMapping("/{coffeechatId}")
-    public ApiResponse<CoffeeChatDetailResponse> getCoffeeChatDetail(
+    public ResponseEntity<ApiResponse<CoffeeChatDetailResponse>> getCoffeeChatDetail(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long coffeechatId
     ) {
         CoffeeChatDetailResponse response = coffeeChatService.getDetail(coffeechatId, userDetails.getUserId());
-        return ApiResponse.of(SuccessStatus.COFFEECHAT_LOAD_SUCCESS, response);
+        return ResponseEntity.ok(ApiResponse.of(SuccessStatus.COFFEECHAT_LOAD_SUCCESS, response));
     }
 
     @PostMapping("/{coffeechatId}/member")
@@ -91,5 +93,27 @@ public class CoffeeChatController {
 
         coffeeChatService.delete(coffeechatId, userId);
         return ResponseEntity.noContent().build(); // 204 No Content
+    }
+
+    @GetMapping("/{coffeechatId}/messages")
+    public ResponseEntity<ApiResponse<CoffeeChatMessagesResponse>> getMessages(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long coffeechatId,
+            @RequestParam String cursor,
+            @RequestParam(defaultValue = "20") int limit,
+            @RequestParam(defaultValue = "desc") String order
+    ) {
+        log.info("[CoffeeChatMessageController.getMessages] 메시지 조회 요청 - userId={}, coffeechatId={}, cursor={}, limit={}, order={}",
+                userDetails.getUserId(), coffeechatId, cursor, limit, order);
+
+        CoffeeChatMessagesResponse response = coffeeChatMessageService.getMessages(
+                userDetails.getUserId(),
+                coffeechatId,
+                cursor,
+                limit,
+                order
+        );
+
+        return ResponseEntity.ok(ApiResponse.of(SuccessStatus.COFFEECHAT_MESSAGES_LOAD_SUCCESS, response));
     }
 }

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatCreateRequest.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatCreateRequest.java
@@ -1,5 +1,7 @@
 package com.ktb.cafeboo.domain.coffeechat.dto;
 
+import com.ktb.cafeboo.domain.coffeechat.dto.common.LocationDto;
+
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
@@ -11,5 +13,5 @@ public record CoffeeChatCreateRequest(
         LocalTime time,
         int memberCount,
         List<String> tags,
-        Location location
+        LocationDto location
 ) {}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatCreateRequest.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatCreateRequest.java
@@ -1,0 +1,15 @@
+package com.ktb.cafeboo.domain.coffeechat.dto;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+public record CoffeeChatCreateRequest(
+        String title,
+        String content,
+        LocalDate date,
+        LocalTime time,
+        int memberCount,
+        List<String> tags,
+        Location location
+) {}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatCreateRequest.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatCreateRequest.java
@@ -1,6 +1,7 @@
 package com.ktb.cafeboo.domain.coffeechat.dto;
 
 import com.ktb.cafeboo.domain.coffeechat.dto.common.LocationDto;
+import com.ktb.cafeboo.global.enums.ProfileImageType;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -13,5 +14,7 @@ public record CoffeeChatCreateRequest(
         LocalTime time,
         int memberCount,
         List<String> tags,
-        LocationDto location
+        LocationDto location,
+        String chatNickname,
+        ProfileImageType profileImageType
 ) {}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatCreateResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatCreateResponse.java
@@ -1,0 +1,5 @@
+package com.ktb.cafeboo.domain.coffeechat.dto;
+
+public record CoffeeChatCreateResponse(
+        Long coffechatId
+) {}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatDetailResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatDetailResponse.java
@@ -1,0 +1,55 @@
+package com.ktb.cafeboo.domain.coffeechat.dto;
+
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChat;
+
+import java.util.List;
+
+public record CoffeeChatDetailResponse(
+        Long coffechatId,
+        String title,
+        String content,
+        String time,
+        int maxMemberCount,
+        int currentMemberCount,
+        List<String> tags,
+        Location location,
+        Writer writer,
+        Boolean isJoined
+) {
+    public record Location(
+            String address,
+            double latitude,
+            double longitude,
+            String kakaoPlaceUrl
+    ) {}
+
+    public record Writer(
+            String name,
+            String profileImageUrl
+    ) {}
+
+    public static CoffeeChatDetailResponse from(CoffeeChat chat, Long userId) {
+
+        return new CoffeeChatDetailResponse(
+                chat.getId(),
+                chat.getName(),
+                chat.getContent(),
+                chat.getMeetingTime().toLocalTime().toString(),
+                chat.getMaxMemberCount(),
+                chat.getCurrentMemberCount(),
+                chat.getTagNames(),
+                new Location(
+                        chat.getAddress(),
+                        chat.getLatitude().doubleValue(),
+                        chat.getLongitude().doubleValue(),
+                        chat.getKakaoPlaceUrl()
+                ),
+                new Writer(
+                        chat.getWriter().getNickname(),
+                        chat.getWriter().getProfileImageUrl()
+                ),
+                chat.isJoinedBy(userId)
+        );
+    }
+
+}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatDetailResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatDetailResponse.java
@@ -1,5 +1,7 @@
 package com.ktb.cafeboo.domain.coffeechat.dto;
 
+import com.ktb.cafeboo.domain.coffeechat.dto.common.LocationDto;
+import com.ktb.cafeboo.domain.coffeechat.dto.common.WriterDto;
 import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChat;
 
 import java.util.List;
@@ -12,22 +14,10 @@ public record CoffeeChatDetailResponse(
         int maxMemberCount,
         int currentMemberCount,
         List<String> tags,
-        Location location,
-        Writer writer,
+        LocationDto location,
+        WriterDto writer,
         Boolean isJoined
 ) {
-    public record Location(
-            String address,
-            double latitude,
-            double longitude,
-            String kakaoPlaceUrl
-    ) {}
-
-    public record Writer(
-            String name,
-            String profileImageUrl
-    ) {}
-
     public static CoffeeChatDetailResponse from(CoffeeChat chat, Long userId) {
 
         return new CoffeeChatDetailResponse(
@@ -38,18 +28,17 @@ public record CoffeeChatDetailResponse(
                 chat.getMaxMemberCount(),
                 chat.getCurrentMemberCount(),
                 chat.getTagNames(),
-                new Location(
+                new LocationDto(
                         chat.getAddress(),
-                        chat.getLatitude().doubleValue(),
-                        chat.getLongitude().doubleValue(),
+                        chat.getLatitude(),
+                        chat.getLongitude(),
                         chat.getKakaoPlaceUrl()
                 ),
-                new Writer(
+                new WriterDto(
                         chat.getWriter().getNickname(),
                         chat.getWriter().getProfileImageUrl()
                 ),
                 chat.isJoinedBy(userId)
         );
     }
-
 }

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatJoinRequest.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatJoinRequest.java
@@ -1,0 +1,8 @@
+package com.ktb.cafeboo.domain.coffeechat.dto;
+
+import com.ktb.cafeboo.global.enums.ProfileImageType;
+
+public record CoffeeChatJoinRequest(
+        String chatNickname,
+        ProfileImageType profileImageType
+) {}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatJoinResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatJoinResponse.java
@@ -1,0 +1,9 @@
+package com.ktb.cafeboo.domain.coffeechat.dto;
+
+public record CoffeeChatJoinResponse(
+        Long memberId
+) {
+    public static CoffeeChatJoinResponse from(Long memberId) {
+        return new CoffeeChatJoinResponse(memberId);
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatListResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatListResponse.java
@@ -1,5 +1,7 @@
 package com.ktb.cafeboo.domain.coffeechat.dto;
 
+import com.ktb.cafeboo.domain.coffeechat.dto.common.WriterDto;
+
 import java.util.List;
 
 public record CoffeeChatListResponse(
@@ -14,7 +16,7 @@ public record CoffeeChatListResponse(
             int currentMemberCount,
             List<String> tags,
             String address,
-            Writer writer,
+            WriterDto writer,
 
             // 조건부 필드
             Boolean isJoined,
@@ -33,13 +35,14 @@ public record CoffeeChatListResponse(
                     chat.getCurrentMemberCount(),
                     chat.getTagNames(),
                     chat.getAddress(),
-                    new Writer(chat.getWriter().getNickname(), chat.getWriter().getProfileImageUrl()),
+                    new WriterDto(
+                            chat.getWriter().getNickname(),
+                            chat.getWriter().getProfileImageUrl()
+                    ),
                     isJoined,
                     isReviewed
             );
         }
-
-        public record Writer(String name, String profileImageUrl) {}
     }
 }
 

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatListResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatListResponse.java
@@ -1,0 +1,45 @@
+package com.ktb.cafeboo.domain.coffeechat.dto;
+
+import java.util.List;
+
+public record CoffeeChatListResponse(
+        String filter,
+        List<CoffeeChatSummary> coffeechats
+) {
+    public record CoffeeChatSummary(
+            Long coffechatId,
+            String title,
+            String time,
+            int maxMemberCount,
+            int currentMemberCount,
+            List<String> tags,
+            String address,
+            Writer writer,
+
+            // 조건부 필드
+            Boolean isJoined,
+            Boolean isReviewed
+    ) {
+        public static CoffeeChatSummary of(
+                com.ktb.cafeboo.domain.coffeechat.model.CoffeeChat chat,
+                boolean isJoined,
+                boolean isReviewed
+        ) {
+            return new CoffeeChatSummary(
+                    chat.getId(),
+                    chat.getName(),
+                    chat.getMeetingTime().toLocalTime().toString(),
+                    chat.getMaxMemberCount(),
+                    chat.getCurrentMemberCount(),
+                    chat.getTagNames(),
+                    chat.getAddress(),
+                    new Writer(chat.getWriter().getNickname(), chat.getWriter().getProfileImageUrl()),
+                    isJoined,
+                    isReviewed
+            );
+        }
+
+        public record Writer(String name, String profileImageUrl) {}
+    }
+}
+

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatMessagesResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatMessagesResponse.java
@@ -1,0 +1,14 @@
+package com.ktb.cafeboo.domain.coffeechat.dto;
+
+import com.ktb.cafeboo.domain.coffeechat.dto.common.MessageDto;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record CoffeeChatMessagesResponse(
+        Long coffeechatId,
+        List<MessageDto> messages,
+        String nextCursor,
+        boolean hasNext
+) {}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/Location.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/Location.java
@@ -1,0 +1,10 @@
+package com.ktb.cafeboo.domain.coffeechat.dto;
+
+import java.math.BigDecimal;
+
+public record Location(
+        String address,
+        BigDecimal latitude,
+        BigDecimal longitude,
+        String kakaoPlaceUrl
+) {}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/common/LocationDto.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/common/LocationDto.java
@@ -1,8 +1,8 @@
-package com.ktb.cafeboo.domain.coffeechat.dto;
+package com.ktb.cafeboo.domain.coffeechat.dto.common;
 
 import java.math.BigDecimal;
 
-public record Location(
+public record LocationDto(
         String address,
         BigDecimal latitude,
         BigDecimal longitude,

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/common/MessageDto.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/common/MessageDto.java
@@ -1,0 +1,10 @@
+package com.ktb.cafeboo.domain.coffeechat.dto.common;
+
+import java.time.LocalDateTime;
+
+public record MessageDto(
+        String messageId,
+        SenderDto sender,
+        String content,
+        LocalDateTime sentAt
+) {}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/common/SenderDto.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/common/SenderDto.java
@@ -1,7 +1,7 @@
 package com.ktb.cafeboo.domain.coffeechat.dto.common;
 
 public record SenderDto(
-        String userId,
-        String nickname,
+        Long memberId,
+        String chatNickname,
         String profileImageUrl
 ) {}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/common/SenderDto.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/common/SenderDto.java
@@ -1,0 +1,7 @@
+package com.ktb.cafeboo.domain.coffeechat.dto.common;
+
+public record SenderDto(
+        String userId,
+        String nickname,
+        String profileImageUrl
+) {}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/common/WriterDto.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/common/WriterDto.java
@@ -1,0 +1,6 @@
+package com.ktb.cafeboo.domain.coffeechat.dto.common;
+
+public record WriterDto(
+        String nickname,
+        String profileImageUrl
+) {}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChat.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChat.java
@@ -1,25 +1,72 @@
 package com.ktb.cafeboo.domain.coffeechat.model;
 
+import com.ktb.cafeboo.domain.user.model.User;
 import com.ktb.cafeboo.global.BaseEntity;
-import jakarta.persistence.Entity;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.NoArgsConstructor;
-import lombok.AllArgsConstructor;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.Where;
 
-//@Entity
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
 @Getter
-@Setter
-@NoArgsConstructor
+@Builder
 @AllArgsConstructor
-public class CoffeeChat { // 이후에 extends BaseEntity 추가 요망
-    private String id; //테스트용 id, 후에 extends BaseEntity 추가될 시 삭제
-    private String name; // 채팅방 이름 (예: "자유 채팅방", "스터디 그룹")
-    // private List<String> participants; // 참여자 목록 (필요시 추가)
-//    private int maxMemberCount;
-//    private int currentMemberCount;
-//    private String address;
-//    private float latitude;
-//    private float longitude;
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "coffee_chats")
+@Where(clause = "deleted_at IS NULL")
+public class CoffeeChat extends BaseEntity {
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User writer;
+
+    @Column(name = "name", nullable = false)
+    private String name; // 채팅방 이름 (예: "자유 채팅방", "스터디 그룹")
+
+    @Column(name = "meeting_time", nullable = false)
+    private LocalDateTime meetingTime;
+
+    @Column(name = "max_member_count", nullable = false)
+    private int maxMemberCount;
+
+    @Column(name = "current_member_count", nullable = false)
+    private int currentMemberCount;
+
+    @Column(name = "address", nullable = false, length = 255)
+    private String address;
+
+    @Column(name = "latitude", precision = 10, scale = 7)
+    private BigDecimal latitude;
+
+    @Column(name = "longitude", precision = 10, scale = 7)
+    private BigDecimal longitude;
+
+    @Column(name = "kakao_place_url", columnDefinition = "TEXT")
+    private String kakaoPlaceUrl;
+
+    public static CoffeeChat of(
+            User writer,
+            String name,
+            LocalDateTime meetingTime,
+            int maxMemberCount,
+            int currentMemberCount,
+            String address,
+            BigDecimal latitude,
+            BigDecimal longitude,
+            String kakaoPlaceUrl
+    ) {
+        return CoffeeChat.builder()
+                .writer(writer)
+                .name(name)
+                .meetingTime(meetingTime)
+                .maxMemberCount(maxMemberCount)
+                .currentMemberCount(currentMemberCount)
+                .address(address)
+                .latitude(latitude)
+                .longitude(longitude)
+                .kakaoPlaceUrl(kakaoPlaceUrl)
+                .build();
+    }
 }

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChat.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChat.java
@@ -61,7 +61,7 @@ public class CoffeeChat extends BaseEntity {
     private List<CoffeeChatMember> members = new ArrayList<>();
 
     @OneToMany(mappedBy = "coffeeChat", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Message> messages = new ArrayList<>();
+    private List<CoffeeChatMessage> messages = new ArrayList<>();
 
     @OneToMany(mappedBy = "coffeeChat", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<CoffeeChatReview> reviews = new ArrayList<>();

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChatMember.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChatMember.java
@@ -32,7 +32,6 @@ public class CoffeeChatMember extends BaseEntity {
     @Column(name = "profile_image_type", nullable = false, length = 10)
     private ProfileImageType profileImageType;
 
-
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false, length = 10)
     private CoffeeChatMemberStatus status;

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChatMember.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChatMember.java
@@ -31,11 +31,11 @@ public class CoffeeChatMember extends BaseEntity {
     @Column(name = "is_evaluated", nullable = false)
     private boolean isEvaluated;
 
-    public static CoffeeChatMember of(CoffeeChat chat, User user, CoffeeChatMemberStatus status) {
+    public static CoffeeChatMember of(CoffeeChat chat, User user) {
         return CoffeeChatMember.builder()
                 .coffeeChat(chat)
                 .user(user)
-                .status(status)
+                .status(CoffeeChatMemberStatus.JOINED)
                 .isEvaluated(false)
                 .build();
     }

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChatMember.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChatMember.java
@@ -3,6 +3,7 @@ package com.ktb.cafeboo.domain.coffeechat.model;
 import com.ktb.cafeboo.domain.user.model.User;
 import com.ktb.cafeboo.global.BaseEntity;
 import com.ktb.cafeboo.global.enums.CoffeeChatMemberStatus;
+import com.ktb.cafeboo.global.enums.ProfileImageType;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.Where;
@@ -24,6 +25,14 @@ public class CoffeeChatMember extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    @Column(name = "chat_nickname", nullable = false, length = 20)
+    private String chatNickname;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "profile_image_type", nullable = false, length = 10)
+    private ProfileImageType profileImageType;
+
+
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false, length = 10)
     private CoffeeChatMemberStatus status;
@@ -31,10 +40,17 @@ public class CoffeeChatMember extends BaseEntity {
     @Column(name = "is_evaluated", nullable = false)
     private boolean isEvaluated;
 
-    public static CoffeeChatMember of(CoffeeChat chat, User user) {
+    public static CoffeeChatMember of(
+            CoffeeChat chat,
+            User user,
+            String chatNickname,
+            ProfileImageType profileImageType
+    ) {
         return CoffeeChatMember.builder()
                 .coffeeChat(chat)
                 .user(user)
+                .chatNickname(chatNickname)
+                .profileImageType(profileImageType)
                 .status(CoffeeChatMemberStatus.JOINED)
                 .isEvaluated(false)
                 .build();

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChatMember.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChatMember.java
@@ -1,0 +1,42 @@
+package com.ktb.cafeboo.domain.coffeechat.model;
+
+import com.ktb.cafeboo.domain.user.model.User;
+import com.ktb.cafeboo.global.BaseEntity;
+import com.ktb.cafeboo.global.enums.CoffeeChatMemberStatus;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.Where;
+
+@Entity
+@Table(name = "coffee_chat_members")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Where(clause = "deleted_at IS NULL")
+public class CoffeeChatMember extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id", nullable = false)
+    private CoffeeChat coffeeChat;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 10)
+    private CoffeeChatMemberStatus status;
+
+    @Column(name = "is_evaluated", nullable = false)
+    private boolean isEvaluated;
+
+    public static CoffeeChatMember of(CoffeeChat chat, User user, CoffeeChatMemberStatus status) {
+        return CoffeeChatMember.builder()
+                .coffeeChat(chat)
+                .user(user)
+                .status(status)
+                .isEvaluated(false)
+                .build();
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChatMessage.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChatMessage.java
@@ -11,15 +11,18 @@ import lombok.*;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class Message extends BaseEntity {
+public class CoffeeChatMessage extends BaseEntity {
+
+    @Column(name = "message_uuid", nullable = false, unique = true, length = 36)
+    private String messageUuid; // 클라이언트가 생성한 UUID 메시지 ID
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "chat_id", nullable = false)
     private CoffeeChat chat;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    private User sender;
+    @JoinColumn(name = "member_id", nullable = false)
+    private CoffeeChatMember sender;
 
     @Column(name = "content", nullable = false, length = 300)
     private String content;
@@ -28,8 +31,8 @@ public class Message extends BaseEntity {
     @Column(name = "type", nullable = false, length = 10)
     private MessageType type;
 
-    public static Message of(CoffeeChat chat, User sender, String content, MessageType type) {
-        return Message.builder()
+    public static CoffeeChatMessage of(CoffeeChat chat, CoffeeChatMember sender, String content, MessageType type) {
+        return CoffeeChatMessage.builder()
                 .chat(chat)
                 .sender(sender)
                 .content(content)

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChatReview.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChatReview.java
@@ -1,0 +1,45 @@
+package com.ktb.cafeboo.domain.coffeechat.model;
+
+import com.ktb.cafeboo.domain.user.model.User;
+import com.ktb.cafeboo.global.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.Where;
+
+@Entity
+@Table(
+    name = "coffee_chat_reviews",
+    uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"room_id", "user_id"})
+    }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Where(clause = "deleted_at IS NULL")
+public class CoffeeChatReview extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id", nullable = false)
+    private CoffeeChat coffeeChat;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User writer;
+
+    @Column(name = "content_text", nullable = false, columnDefinition = "TEXT")
+    private String contentText;
+
+    @Column(name = "content_img_url", length = 255)
+    private String contentImgUrl;
+
+    public static CoffeeChatReview of(CoffeeChat chat, User writer, String text, String imgUrl) {
+        return CoffeeChatReview.builder()
+                .coffeeChat(chat)
+                .writer(writer)
+                .contentText(text)
+                .contentImgUrl(imgUrl)
+                .build();
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChatReview.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChatReview.java
@@ -1,6 +1,5 @@
 package com.ktb.cafeboo.domain.coffeechat.model;
 
-import com.ktb.cafeboo.domain.user.model.User;
 import com.ktb.cafeboo.global.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -10,7 +9,7 @@ import org.hibernate.annotations.Where;
 @Table(
     name = "coffee_chat_reviews",
     uniqueConstraints = {
-        @UniqueConstraint(columnNames = {"room_id", "user_id"})
+        @UniqueConstraint(columnNames = {"chat_member_id"})
     }
 )
 @Getter
@@ -25,8 +24,8 @@ public class CoffeeChatReview extends BaseEntity {
     private CoffeeChat coffeeChat;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    private User writer;
+    @JoinColumn(name = "chat_member_id", nullable = false)
+    private CoffeeChatMember writer;
 
     @Column(name = "content_text", nullable = false, columnDefinition = "TEXT")
     private String contentText;
@@ -34,7 +33,7 @@ public class CoffeeChatReview extends BaseEntity {
     @Column(name = "content_img_url", length = 255)
     private String contentImgUrl;
 
-    public static CoffeeChatReview of(CoffeeChat chat, User writer, String text, String imgUrl) {
+    public static CoffeeChatReview of(CoffeeChat chat, CoffeeChatMember writer, String text, String imgUrl) {
         return CoffeeChatReview.builder()
                 .coffeeChat(chat)
                 .writer(writer)

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/Message.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/Message.java
@@ -1,21 +1,39 @@
 package com.ktb.cafeboo.domain.coffeechat.model;
 
+import com.ktb.cafeboo.domain.user.model.User;
 import com.ktb.cafeboo.global.BaseEntity;
 import com.ktb.cafeboo.global.enums.MessageType;
-import jakarta.persistence.Entity;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import jakarta.persistence.*;
+import lombok.*;
 
 @Entity
 @Getter
-@Setter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class Message extends BaseEntity {
-    private String userId;  //테스트용, erd의 Messages 테이블의 user_id. 이후에는 BaseEntity의 id로 대체
-    private String roomId;  //테스트용, erd의 Messages 테이블의 id. 이후에는 CoffeChat Entity의 id로 대체
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_id", nullable = false)
+    private CoffeeChat chat;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User sender;
+
+    @Column(name = "content", nullable = false, length = 300)
     private String content;
-    private MessageType type; //erd 추가 요망
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, length = 10)
+    private MessageType type;
+
+    public static Message of(CoffeeChat chat, User sender, String content, MessageType type) {
+        return Message.builder()
+                .chat(chat)
+                .sender(sender)
+                .content(content)
+                .type(type)
+                .build();
+    }
 }

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/repository/CoffeeChatMemberRepository.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/repository/CoffeeChatMemberRepository.java
@@ -1,0 +1,18 @@
+package com.ktb.cafeboo.domain.coffeechat.repository;
+
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChat;
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatMember;
+import com.ktb.cafeboo.domain.user.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CoffeeChatMemberRepository extends JpaRepository<CoffeeChatMember, Long> {
+
+    Optional<CoffeeChatMember> findByCoffeeChatAndUser(CoffeeChat chat, User user);
+
+    List<CoffeeChatMember> findAllByCoffeeChat(CoffeeChat chat);
+
+    boolean existsByCoffeeChatAndUser(CoffeeChat chat, User user);
+}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/repository/CoffeeChatMemberRepository.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/repository/CoffeeChatMemberRepository.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 
 public interface CoffeeChatMemberRepository extends JpaRepository<CoffeeChatMember, Long> {
 
-    Optional<CoffeeChatMember> findByCoffeeChatAndUser(CoffeeChat chat, User user);
+    Optional<CoffeeChatMember> findByCoffeeChatIdAndUserId(Long chatId, Long userId);
 
     List<CoffeeChatMember> findAllByCoffeeChat(CoffeeChat chat);
 

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/repository/CoffeeChatMemberRepository.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/repository/CoffeeChatMemberRepository.java
@@ -15,4 +15,6 @@ public interface CoffeeChatMemberRepository extends JpaRepository<CoffeeChatMemb
     List<CoffeeChatMember> findAllByCoffeeChat(CoffeeChat chat);
 
     boolean existsByCoffeeChatAndUser(CoffeeChat chat, User user);
+
+    boolean existsByCoffeeChatIdAndChatNickname(Long chatId, String chatNickname);
 }

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/repository/CoffeeChatMessageRepository.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/repository/CoffeeChatMessageRepository.java
@@ -1,0 +1,15 @@
+package com.ktb.cafeboo.domain.coffeechat.repository;
+
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CoffeeChatMessageRepository extends JpaRepository<CoffeeChatMessage, Long> {
+
+    List<CoffeeChatMessage> findByChatId(Long chatId);
+
+    List<CoffeeChatMessage> findByChatIdAndIdLessThanOrderByIdDesc(Long chatId, Long cursor, org.springframework.data.domain.Pageable pageable);
+
+    List<CoffeeChatMessage> findByChatIdAndIdGreaterThanOrderByIdAsc(Long chatId, Long cursor, org.springframework.data.domain.Pageable pageable);
+}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/repository/CoffeeChatReviewRepository.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/repository/CoffeeChatReviewRepository.java
@@ -1,0 +1,15 @@
+package com.ktb.cafeboo.domain.coffeechat.repository;
+
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChat;
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatReview;
+import com.ktb.cafeboo.domain.user.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CoffeeChatReviewRepository extends JpaRepository<CoffeeChatReview, Long> {
+
+    Optional<CoffeeChatReview> findByCoffeeChatAndWriter(CoffeeChat chat, User writer);
+
+    boolean existsByCoffeeChatAndWriter(CoffeeChat chat, User writer);
+}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/repository/MessageRepository.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/repository/MessageRepository.java
@@ -1,0 +1,12 @@
+package com.ktb.cafeboo.domain.coffeechat.repository;
+
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChat;
+import com.ktb.cafeboo.domain.coffeechat.model.Message;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MessageRepository extends JpaRepository<Message, Long> {
+
+    List<Message> findAllByChatOrderByCreatedAtAsc(CoffeeChat chat);
+}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/repository/MessageRepository.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/repository/MessageRepository.java
@@ -1,12 +1,12 @@
 package com.ktb.cafeboo.domain.coffeechat.repository;
 
 import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChat;
-import com.ktb.cafeboo.domain.coffeechat.model.Message;
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatMessage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface MessageRepository extends JpaRepository<Message, Long> {
+public interface MessageRepository extends JpaRepository<CoffeeChatMessage, Long> {
 
-    List<Message> findAllByChatOrderByCreatedAtAsc(CoffeeChat chat);
+    List<CoffeeChatMessage> findAllByChatOrderByCreatedAtAsc(CoffeeChat chat);
 }

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatMessageService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatMessageService.java
@@ -1,0 +1,111 @@
+package com.ktb.cafeboo.domain.coffeechat.service;
+
+import com.ktb.cafeboo.domain.coffeechat.dto.CoffeeChatMessagesResponse;
+import com.ktb.cafeboo.domain.coffeechat.dto.common.MessageDto;
+import com.ktb.cafeboo.domain.coffeechat.dto.common.SenderDto;
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChat;
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatMember;
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatMessage;
+import com.ktb.cafeboo.domain.coffeechat.repository.CoffeeChatMemberRepository;
+import com.ktb.cafeboo.domain.coffeechat.repository.CoffeeChatMessageRepository;
+import com.ktb.cafeboo.domain.coffeechat.repository.CoffeeChatRepository;
+import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
+import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
+import com.ktb.cafeboo.global.enums.CoffeeChatStatus;
+import com.ktb.cafeboo.global.enums.ProfileImageType;
+import com.ktb.cafeboo.global.infra.s3.S3Properties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CoffeeChatMessageService {
+
+    private final CoffeeChatRepository coffeeChatRepository;
+    private final CoffeeChatMessageRepository messageRepository;
+    private final CoffeeChatMemberRepository memberRepository;
+    private final S3Properties s3Properties;
+
+    public CoffeeChatMessagesResponse getMessages(Long userId, Long coffeechatId, String cursor, int limit, String order) {
+        log.info("[CoffeeChatMessageService.getMessages] 커피챗 메시지 조회 요청: userId={}, chatId={}, cursor={}, limit={}, order={}",
+                userId, coffeechatId, cursor, limit, order);
+
+        CoffeeChat chat = coffeeChatRepository.findById(coffeechatId)
+                .orElseThrow(() -> new CustomApiException(ErrorStatus.COFFEECHAT_NOT_FOUND));
+
+        if (!chat.getStatus().equals(CoffeeChatStatus.ACTIVE)) {
+            throw new CustomApiException(ErrorStatus.COFFEECHAT_NOT_ACTIVE);
+        }
+
+        CoffeeChatMember member = memberRepository.findByCoffeeChatIdAndUserId(coffeechatId, userId)
+                .orElseThrow(() -> new CustomApiException(ErrorStatus.COFFEECHAT_MEMBER_NOT_FOUND));
+
+        List<CoffeeChatMessage> messages = fetchMessagesByCursor(coffeechatId, cursor, limit, order);
+        boolean hasNext = messages.size() > limit;
+        if (hasNext) {
+            messages = messages.subList(0, limit);
+        }
+
+        List<MessageDto> messageDtos = messages.stream()
+                .map(m -> {
+                    CoffeeChatMember sender = m.getSender();
+                    String profileImageUrl = sender.getProfileImageType() == ProfileImageType.DEFAULT
+                            ? s3Properties.getDefaultProfileImageUrl()
+                            : sender.getUser().getProfileImageUrl();
+
+                    return new MessageDto(
+                            m.getMessageUuid(),
+                            new SenderDto(
+                                    sender.getId(),
+                                    sender.getChatNickname(),
+                                    profileImageUrl
+                            ),
+                            m.getContent(),
+                            m.getCreatedAt()
+                    );
+                })
+                .collect(Collectors.toList());
+
+        String nextCursor = hasNext ? messageDtos.get(messageDtos.size() - 1).messageId() : null;
+
+        return new CoffeeChatMessagesResponse(
+                coffeechatId,
+                messageDtos,
+                nextCursor,
+                hasNext
+        );
+    }
+
+    private List<CoffeeChatMessage> fetchMessagesByCursor(Long chatId, String cursor, int limit, String order) {
+        PageRequest pageRequest = PageRequest.of(0, limit + 1);
+
+        if (cursor == null) {
+            return messageRepository.findByChatId(chatId)
+                    .stream()
+                    .sorted(order.equalsIgnoreCase("asc")
+                            ? java.util.Comparator.comparing(CoffeeChatMessage::getId)
+                            : java.util.Comparator.comparing(CoffeeChatMessage::getId).reversed())
+                    .limit(limit + 1)
+                    .collect(Collectors.toList());
+        }
+
+        Long cursorId;
+        try {
+            cursorId = Long.parseLong(cursor);
+        } catch (NumberFormatException e) {
+            throw new CustomApiException(ErrorStatus.INVALID_CURSOR);
+        }
+
+        if (order.equalsIgnoreCase("asc")) {
+            return messageRepository.findByChatIdAndIdGreaterThanOrderByIdAsc(chatId, cursorId, pageRequest);
+        } else {
+            return messageRepository.findByChatIdAndIdLessThanOrderByIdDesc(chatId, cursorId, pageRequest);
+        }
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatService.java
@@ -4,7 +4,7 @@ import com.ktb.cafeboo.domain.coffeechat.dto.*;
 import com.ktb.cafeboo.domain.coffeechat.dto.common.LocationDto;
 import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChat;
 import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatMember;
-import com.ktb.cafeboo.domain.coffeechat.model.Message;
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatMessage;
 import com.ktb.cafeboo.domain.coffeechat.repository.CoffeeChatMemberRepository;
 import com.ktb.cafeboo.domain.coffeechat.repository.CoffeeChatRepository;
 import com.ktb.cafeboo.domain.tag.service.TagService;
@@ -183,7 +183,7 @@ public class CoffeeChatService {
             throw new CustomApiException(ErrorStatus.COFFEECHAT_NOT_ACTIVE);
         }
 
-        for (Message message : chat.getMessages()) {
+        for (CoffeeChatMessage message : chat.getMessages()) {
             message.delete();
         }
 

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatService.java
@@ -1,0 +1,172 @@
+package com.ktb.cafeboo.domain.coffeechat.service;
+
+import com.ktb.cafeboo.domain.coffeechat.dto.*;
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChat;
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatMember;
+import com.ktb.cafeboo.domain.coffeechat.model.Message;
+import com.ktb.cafeboo.domain.coffeechat.repository.CoffeeChatMemberRepository;
+import com.ktb.cafeboo.domain.coffeechat.repository.CoffeeChatRepository;
+import com.ktb.cafeboo.domain.tag.service.TagService;
+import com.ktb.cafeboo.domain.user.model.User;
+import com.ktb.cafeboo.domain.user.repository.UserRepository;
+import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
+import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
+import com.ktb.cafeboo.global.enums.CoffeeChatFilterType;
+import com.ktb.cafeboo.global.enums.CoffeeChatStatus;
+import com.ktb.cafeboo.global.util.AuthChecker;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CoffeeChatService {
+
+    private final CoffeeChatRepository coffeeChatRepository;
+    private final CoffeeChatMemberRepository coffeeChatMemberRepository;
+    private final UserRepository userRepository;
+    private final TagService tagService;
+
+    public CoffeeChatCreateResponse create(Long userId, CoffeeChatCreateRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomApiException(ErrorStatus.USER_NOT_FOUND));
+
+        LocalDateTime meetingTime = LocalDateTime.of(request.date(), request.time());
+
+        Location loc = request.location();
+
+        CoffeeChat chat = CoffeeChat.builder()
+                .writer(user)
+                .name(request.title())
+                .content(request.content())
+                .status(CoffeeChatStatus.ACTIVE)
+                .meetingTime(meetingTime)
+                .maxMemberCount(request.memberCount())
+                .currentMemberCount(1)
+                .address(loc.address())
+                .latitude(loc.latitude())
+                .longitude(loc.longitude())
+                .kakaoPlaceUrl(loc.kakaoPlaceUrl())
+                .build();
+
+        CoffeeChatMember hostMember = CoffeeChatMember.of (chat, user);
+        chat.addMember(hostMember);
+
+        CoffeeChat saved = coffeeChatRepository.save(chat);
+
+        tagService.saveTagsToCoffeeChat(saved, request.tags());
+
+        return new CoffeeChatCreateResponse(saved.getId());
+    }
+
+    @Transactional(readOnly = true)
+    public CoffeeChatListResponse getCoffeeChatsByStatus(Long userId, String status) {
+        CoffeeChatFilterType filter = CoffeeChatFilterType.from(status); // enum 파싱 및 예외처리 포함 권장
+
+        List<CoffeeChat> chats;
+
+        switch (filter) {
+            case JOINED -> chats = coffeeChatRepository.findJoinedChats(userId);
+            case COMPLETED -> chats = coffeeChatRepository.findCompletedChats(userId);
+            case ALL -> chats = coffeeChatRepository.findAllActiveChats();
+            default -> throw new CustomApiException(ErrorStatus.INVALID_COFFEECHAT_FILTER);
+        }
+
+        List<CoffeeChatListResponse.CoffeeChatSummary> summaryList = chats.stream()
+                .map(chat -> {
+                    boolean isJoined = chat.isJoinedBy(userId);
+                    boolean isReviewed = chat.isReviewedBy(userId);
+
+                    return CoffeeChatListResponse.CoffeeChatSummary.of(
+                            chat,
+                            isJoined,
+                            isReviewed
+                    );
+                })
+                .toList();
+
+        return new CoffeeChatListResponse(filter.name().toLowerCase(), summaryList);
+    }
+
+    @Transactional(readOnly = true)
+    public CoffeeChatDetailResponse getDetail(Long coffeechatId, Long userId) {
+        CoffeeChat chat = coffeeChatRepository.findById(coffeechatId)
+                .orElseThrow(() -> new CustomApiException(ErrorStatus.COFFEECHAT_NOT_FOUND));
+
+        return CoffeeChatDetailResponse.from(chat, userId);
+    }
+
+    @Transactional
+    public CoffeeChatJoinResponse join(Long userId, Long coffeechatId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomApiException(ErrorStatus.USER_NOT_FOUND));
+
+        CoffeeChat chat = coffeeChatRepository.findById(coffeechatId)
+                .orElseThrow(() -> new CustomApiException(ErrorStatus.COFFEECHAT_NOT_FOUND));
+
+        if (!chat.getStatus().equals(CoffeeChatStatus.ACTIVE)) {
+            throw new CustomApiException(ErrorStatus.COFFEECHAT_NOT_ACTIVE);
+        }
+
+        if (chat.isJoinedBy(userId)) {
+            throw new CustomApiException(ErrorStatus.COFFEECHAT_ALREADY_JOINED);
+        }
+
+        if (chat.getCurrentMemberCount() >= chat.getMaxMemberCount()) {
+            throw new CustomApiException(ErrorStatus.COFFEECHAT_CAPACITY_EXCEEDED);
+        }
+
+        CoffeeChatMember member = CoffeeChatMember.of(chat, user);
+        chat.addMember(member);
+
+        CoffeeChatMember saved = coffeeChatMemberRepository.save(member);
+        return CoffeeChatJoinResponse.from(saved.getId());
+    }
+
+    @Transactional
+    public void leaveChat(Long coffeechatId, Long memberId, Long userId) {
+        CoffeeChat chat = coffeeChatRepository.findById(coffeechatId)
+                .orElseThrow(() -> new CustomApiException(ErrorStatus.COFFEECHAT_NOT_FOUND));
+
+        CoffeeChatMember member = coffeeChatMemberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomApiException(ErrorStatus.COFFEECHAT_MEMBER_NOT_FOUND));
+
+        if (!member.getUser().getId().equals(userId)) {
+            throw new CustomApiException(ErrorStatus.ACCESS_DENIED);
+        }
+
+        // 작성자는 나갈 수 없음
+        if (chat.getWriter().getId().equals(userId)) {
+            throw new CustomApiException(ErrorStatus.CANNOT_LEAVE_CHAT_OWNER);
+        }
+
+        chat.removeMember(member);
+        coffeeChatMemberRepository.delete(member);
+
+    }
+
+    public void delete(Long coffeechatId, Long userId) {
+        CoffeeChat chat = coffeeChatRepository.findById(coffeechatId)
+                .orElseThrow(() -> new CustomApiException(ErrorStatus.COFFEECHAT_NOT_FOUND));
+
+        AuthChecker.checkOwnership(chat.getWriter().getId(), userId);
+
+        if (chat.getStatus() != CoffeeChatStatus.ACTIVE) {
+            throw new CustomApiException(ErrorStatus.COFFEECHAT_NOT_ACTIVE);
+        }
+
+        for (Message message : chat.getMessages()) {
+            message.delete();
+        }
+
+        for (CoffeeChatMember member : chat.getMembers()) {
+            member.delete();
+        }
+
+        chat.delete();
+        coffeeChatRepository.save(chat);
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/domain/tag/model/CoffeeChatTag.java
+++ b/src/main/java/com/ktb/cafeboo/domain/tag/model/CoffeeChatTag.java
@@ -1,0 +1,23 @@
+package com.ktb.cafeboo.domain.tag.model;
+
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChat;
+import com.ktb.cafeboo.global.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "coffee_chat_tags")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class CoffeeChatTag extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_id", nullable = false)
+    private CoffeeChat coffeeChat;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tag_id", nullable = false)
+    private Tag tag;
+}

--- a/src/main/java/com/ktb/cafeboo/domain/tag/model/Tag.java
+++ b/src/main/java/com/ktb/cafeboo/domain/tag/model/Tag.java
@@ -1,0 +1,23 @@
+package com.ktb.cafeboo.domain.tag.model;
+
+import com.ktb.cafeboo.global.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "tags")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Tag extends BaseEntity {
+
+    @Column(length = 10, nullable = false)
+    private String name;
+
+    @OneToMany(mappedBy = "tag", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<CoffeeChatTag> coffeeChatTags = new ArrayList<>();
+}

--- a/src/main/java/com/ktb/cafeboo/domain/tag/repository/CoffeeChatTagRepository.java
+++ b/src/main/java/com/ktb/cafeboo/domain/tag/repository/CoffeeChatTagRepository.java
@@ -1,0 +1,11 @@
+package com.ktb.cafeboo.domain.tag.repository;
+
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChat;
+import com.ktb.cafeboo.domain.tag.model.CoffeeChatTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CoffeeChatTagRepository extends JpaRepository<CoffeeChatTag, Long> {
+    List<CoffeeChatTag> findAllByCoffeeChat(CoffeeChat coffeeChat);
+}

--- a/src/main/java/com/ktb/cafeboo/domain/tag/repository/TagRepository.java
+++ b/src/main/java/com/ktb/cafeboo/domain/tag/repository/TagRepository.java
@@ -1,0 +1,10 @@
+package com.ktb.cafeboo.domain.tag.repository;
+
+import com.ktb.cafeboo.domain.tag.model.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+    Optional<Tag> findByName(String name);
+}

--- a/src/main/java/com/ktb/cafeboo/domain/tag/service/TagService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/tag/service/TagService.java
@@ -1,0 +1,33 @@
+package com.ktb.cafeboo.domain.tag.service;
+
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChat;
+import com.ktb.cafeboo.domain.tag.model.CoffeeChatTag;
+import com.ktb.cafeboo.domain.tag.model.Tag;
+import com.ktb.cafeboo.domain.tag.repository.CoffeeChatTagRepository;
+import com.ktb.cafeboo.domain.tag.repository.TagRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TagService {
+
+    private final TagRepository tagRepository;
+    private final CoffeeChatTagRepository coffeeChatTagRepository;
+
+    public void saveTagsToCoffeeChat(CoffeeChat chat, List<String> tagNames) {
+        if (tagNames == null || tagNames.isEmpty()) {
+            return;
+        }
+
+        for (String tagName : tagNames) {
+            Tag tag = tagRepository.findByName(tagName)
+                    .orElseGet(() -> tagRepository.save(Tag.builder().name(tagName).build()));
+
+            CoffeeChatTag coffeeChatTag = new CoffeeChatTag(chat, tag);
+            coffeeChatTagRepository.save(coffeeChatTag);
+        }
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/domain/user/model/User.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/model/User.java
@@ -1,6 +1,7 @@
 package com.ktb.cafeboo.domain.user.model;
 
 import com.ktb.cafeboo.domain.caffeinediary.model.*;
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChat;
 import com.ktb.cafeboo.domain.report.model.*;
 import com.ktb.cafeboo.global.infra.kakao.dto.KakaoUserResponse;
 import com.ktb.cafeboo.global.BaseEntity;
@@ -36,6 +37,9 @@ public class User extends BaseEntity {
 
     @Column(nullable = false, length = 10)
     private String nickname;
+
+    @Column
+    private String profileImageUrl;
 
     @Column(nullable = true, length = 512)
     private String refreshToken;
@@ -83,6 +87,9 @@ public class User extends BaseEntity {
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<YearlyReport> yearlyReports = new ArrayList<>();
+
+    @OneToMany(mappedBy = "writer", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<CoffeeChat> coffeeChats = new ArrayList<>();
 
     public static User fromKakao(KakaoUserResponse kakaoUser) {
         User user = new User();

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/ErrorStatus.java
@@ -64,6 +64,7 @@ public enum ErrorStatus implements BaseCode {
     INVALID_COFFEECHAT_FILTER(401, ",INVALID_COFFEECHAT_FILTER", "요청한 커피챗 필터 값이 유효하지 않습니다. 필터는 'all', 'joined', 'completed' 중 하나여야 합니다."),
     COFFEECHAT_ALREADY_JOINED(409, ",COFFEECHAT_ALREADY_JOINED", "이미 해당 커피챗에 참여한 사용자입니다."),
     COFFEECHAT_CAPACITY_EXCEEDED(409, "COFFEECHAT_CAPACITY_EXCEEDED", "해당 커피챗은 이미 정원이 초과되어 더 이상 참여할 수 없습니다."),
+    CHAT_NICKNAME_ALREADY_EXISTS(409, "CHAT_NICKNAME_ALREADY_EXISTS", "이미 사용 중인 채팅방 닉네임입니다."),
     CANNOT_LEAVE_CHAT_OWNER(400, "CANNOT_LEAVE_CHAT_OWNER", "작성자는 채팅방에서 나갈 수 없습니다.")
     ;
 

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/ErrorStatus.java
@@ -65,7 +65,8 @@ public enum ErrorStatus implements BaseCode {
     COFFEECHAT_ALREADY_JOINED(409, ",COFFEECHAT_ALREADY_JOINED", "이미 해당 커피챗에 참여한 사용자입니다."),
     COFFEECHAT_CAPACITY_EXCEEDED(409, "COFFEECHAT_CAPACITY_EXCEEDED", "해당 커피챗은 이미 정원이 초과되어 더 이상 참여할 수 없습니다."),
     CHAT_NICKNAME_ALREADY_EXISTS(409, "CHAT_NICKNAME_ALREADY_EXISTS", "이미 사용 중인 채팅방 닉네임입니다."),
-    CANNOT_LEAVE_CHAT_OWNER(400, "CANNOT_LEAVE_CHAT_OWNER", "작성자는 채팅방에서 나갈 수 없습니다.")
+    CANNOT_LEAVE_CHAT_OWNER(400, "CANNOT_LEAVE_CHAT_OWNER", "작성자는 채팅방에서 나갈 수 없습니다."),
+    INVALID_CURSOR(400, "INVALID_CURSOR", "커서 값이 유효하지 않습니다.")
     ;
 
     private final int status;

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/ErrorStatus.java
@@ -31,13 +31,10 @@ public enum ErrorStatus implements BaseCode {
     // 유저 관련 오류
     USER_NOT_FOUND(404, "USER_NOT_FOUND", "사용자를 찾을 수 없습니다."),
     ACCESS_DENIED(403, "ACCESS_DENIED", "해당 요청에 대한 권한이 없습니다."),
-
     HEALTH_PROFILE_ALREADY_EXISTS(409, "HEALTH_PROFILE_ALREADY_EXISTS", "이미 건강 정보가 등록되어 있습니다."),
     HEALTH_PROFILE_NOT_FOUND(404, "HEALTH_PROFILE_NOT_FOUND", "건강 정보가 존재하지 않습니다."),
-
     CAFFEINE_PROFILE_ALREADY_EXISTS(409, "CAFFEINE_PROFILE_ALREADY_EXISTS", "이미 카페인 정보가 등록되어 있습니다."),
     CAFFEINE_PROFILE_NOT_FOUND(404, "CAFFEINE_PROFILE_NOT_FOUND", "카페인 정보가 존재하지 않습니다."),
-
     ALARM_SETTING_ALREADY_EXISTS(409, "ALARM_SETTING_ALREADY_EXISTS", "이미 알림 설정이 존재합니다."),
     ALARM_SETTING_NOT_FOUND(404, "ALARM_SETTING_NOT_FOUND", "알림 설정 정보를 찾을 수 없습니다."),
 
@@ -59,6 +56,15 @@ public enum ErrorStatus implements BaseCode {
 
     //파라미터 관련 오류
     INVALID_PARAMETER(400, "INVALID_PARAMETER", "요청 파라미터의 올바르지 않습니다."),
+
+    // 채팅 관련 오류
+    COFFEECHAT_NOT_FOUND(404, "COFFEECHAT_NOT_FOUND", "해당 커피챗을 찾을 수 없습니다."),
+    COFFEECHAT_MEMBER_NOT_FOUND(404, "COFFEECHAT_MEMBER_NOT_FOUND", "해당 커피챗 멤버를 찾을 수 없습니다."),
+    COFFEECHAT_NOT_ACTIVE(409, "COFFEECHAT_NOT_ACTIVE", "해당 커피챗은 더 이상 유효하지 않아 요청을 처리할 수 없습니다."),
+    INVALID_COFFEECHAT_FILTER(401, ",INVALID_COFFEECHAT_FILTER", "요청한 커피챗 필터 값이 유효하지 않습니다. 필터는 'all', 'joined', 'completed' 중 하나여야 합니다."),
+    COFFEECHAT_ALREADY_JOINED(409, ",COFFEECHAT_ALREADY_JOINED", "이미 해당 커피챗에 참여한 사용자입니다."),
+    COFFEECHAT_CAPACITY_EXCEEDED(409, "COFFEECHAT_CAPACITY_EXCEEDED", "해당 커피챗은 이미 정원이 초과되어 더 이상 참여할 수 없습니다."),
+    CANNOT_LEAVE_CHAT_OWNER(400, "CANNOT_LEAVE_CHAT_OWNER", "작성자는 채팅방에서 나갈 수 없습니다.")
     ;
 
     private final int status;

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/SuccessStatus.java
@@ -57,7 +57,8 @@ public enum SuccessStatus implements BaseCode {
     COFFEECHAT_CREATE_SUCCESS(201, "COFFEECHAT_CREATE_SUCCESS", "커피챗이 성공적으로 생성되었습니다."),
     COFFEECHAT_LIST_LOAD_SUCCESS(200, "COFFEECHAT_LIST_LOAD_SUCCESS", "커피챗 목록을 성공적으로 조회했습니다."),
     COFFEECHAT_LOAD_SUCCESS(200, "COFFEECHAT_LOAD_SUCCESS", "커피챗 상세내용을 성공적으로 조회했습니다."),
-    COFFEECHAT_JOIN_SUCCESS(201, "COFFEECHAT_JOIN_SUCCESS", "커피챗에 성공적으로 참여하였습니다.")
+    COFFEECHAT_JOIN_SUCCESS(201, "COFFEECHAT_JOIN_SUCCESS", "커피챗에 성공적으로 참여하였습니다."),
+    COFFEECHAT_MESSAGES_LOAD_SUCCESS(200, "COFFEECHAT_MESSAGES_LOAD_SUCCESS", "커피챗 메시지를 성공적으로 조회했습니다.")
     ;
     private final int status;
     private final String code;

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/SuccessStatus.java
@@ -52,6 +52,12 @@ public enum SuccessStatus implements BaseCode {
 
     //AI 리포트 생성 관련 응답
     REPORT_GENERATION_SUCCESS(200, "AI_GENERATION_REPORT", "AI 리포트 생성 요청 성공"),
+
+    //커피챗 관련 응답
+    COFFEECHAT_CREATE_SUCCESS(201, "COFFEECHAT_CREATE_SUCCESS", "커피챗이 성공적으로 생성되었습니다."),
+    COFFEECHAT_LIST_LOAD_SUCCESS(200, "COFFEECHAT_LIST_LOAD_SUCCESS", "커피챗 목록을 성공적으로 조회했습니다."),
+    COFFEECHAT_LOAD_SUCCESS(200, "COFFEECHAT_LOAD_SUCCESS", "커피챗 상세내용을 성공적으로 조회했습니다."),
+    COFFEECHAT_JOIN_SUCCESS(201, "COFFEECHAT_JOIN_SUCCESS", "커피챗에 성공적으로 참여하였습니다.")
     ;
     private final int status;
     private final String code;

--- a/src/main/java/com/ktb/cafeboo/global/config/RedisConfig.java
+++ b/src/main/java/com/ktb/cafeboo/global/config/RedisConfig.java
@@ -1,6 +1,6 @@
 package com.ktb.cafeboo.global.config;
 
-import com.ktb.cafeboo.domain.coffeechat.model.Message;
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatMessage;
 import java.time.Duration;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -77,7 +77,7 @@ public class RedisConfig {
                 .batchSize(10) // 한 번에 처리할 메시지 수
                 .executor(taskExecutor) // 사용할 스레드 풀
                 .pollTimeout(Duration.ofSeconds(1)) // 메시지가 없을 때 폴링 타임아웃
-                .targetType(Message.class) // 메시지 역직렬화 대상 타입
+                .targetType(CoffeeChatMessage.class) // 메시지 역직렬화 대상 타입
                 .build();
 
         StreamMessageListenerContainer<String, ?>container = StreamMessageListenerContainer.create(connectionFactory, options);

--- a/src/main/java/com/ktb/cafeboo/global/enums/CoffeeChatFilterType.java
+++ b/src/main/java/com/ktb/cafeboo/global/enums/CoffeeChatFilterType.java
@@ -1,0 +1,19 @@
+package com.ktb.cafeboo.global.enums;
+
+import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
+import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
+
+import java.util.Arrays;
+
+public enum CoffeeChatFilterType {
+    ALL,
+    JOINED,
+    COMPLETED;
+
+    public static CoffeeChatFilterType from(String status) {
+        return Arrays.stream(values())
+                .filter(type -> type.name().equalsIgnoreCase(status))
+                .findFirst()
+                .orElseThrow(() -> new CustomApiException(ErrorStatus.INVALID_COFFEECHAT_FILTER));
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/global/enums/CoffeeChatMemberStatus.java
+++ b/src/main/java/com/ktb/cafeboo/global/enums/CoffeeChatMemberStatus.java
@@ -1,0 +1,5 @@
+package com.ktb.cafeboo.global.enums;
+
+public enum CoffeeChatMemberStatus {
+    JOINED, LEAVED, KICKED
+}

--- a/src/main/java/com/ktb/cafeboo/global/enums/CoffeeChatStatus.java
+++ b/src/main/java/com/ktb/cafeboo/global/enums/CoffeeChatStatus.java
@@ -1,0 +1,5 @@
+package com.ktb.cafeboo.global.enums;
+
+public enum CoffeeChatStatus {
+    ACTIVE, ENDED, DELETED
+}

--- a/src/main/java/com/ktb/cafeboo/global/enums/ProfileImageType.java
+++ b/src/main/java/com/ktb/cafeboo/global/enums/ProfileImageType.java
@@ -1,0 +1,5 @@
+package com.ktb.cafeboo.global.enums;
+
+public enum ProfileImageType {
+    DEFAULT, USER
+}


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] 커피챗 생성/삭제/목록 조회/상세 조회 API 구현
- [x] 커피챗 참여/나가기/대화 내역 조회 API 구현

## 🛠 변경사항
- `CoffeeChat` 및 관련 도메인 클래스 설계 및 연관관계 매핑
- `CoffeeChatController`, `CoffeeChatService`, 관련 DTO 및 Repository 로직 작성

## 💬 리뷰 요구사항
- 커피챗 참여/나가기 로직의 예외 처리 흐름 검토

## 🔍 테스트 방법(선택)
- Postman으로 진행

fixes: #140 