### PR TITLE
[FIX] accessToken 토큰 재발급 오류 수정

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/auth/controller/AuthController.java
@@ -5,6 +5,7 @@ import com.ktb.cafeboo.domain.auth.dto.LoginResponse;
 import com.ktb.cafeboo.domain.auth.dto.TokenRefreshResponse;
 import com.ktb.cafeboo.domain.auth.service.AuthService;
 import com.ktb.cafeboo.domain.auth.service.KakaoOauthService;
+import com.ktb.cafeboo.domain.auth.service.TokenBlacklistService;
 import com.ktb.cafeboo.global.apiPayload.ApiResponse;
 import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
 import com.ktb.cafeboo.global.apiPayload.code.status.SuccessStatus;
@@ -31,6 +32,7 @@ public class AuthController {
 
     private final AuthService authService;
     private final KakaoOauthService kakaoOauthService;
+    private final TokenBlacklistService tokenBlacklistService;
 
     @PostMapping("/oauth")
     public ResponseEntity<ApiResponse<String>> redirectToOauth(@RequestParam("type") String type) {

--- a/src/main/java/com/ktb/cafeboo/domain/auth/service/TokenBlacklistService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/auth/service/TokenBlacklistService.java
@@ -1,13 +1,18 @@
 package com.ktb.cafeboo.domain.auth.service;
 
+import com.auth0.jwt.exceptions.TokenExpiredException;
+import com.auth0.jwt.interfaces.DecodedJWT;
 import com.ktb.cafeboo.global.enums.TokenBlacklistReason;
 import com.ktb.cafeboo.global.security.JwtProvider;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
+import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class TokenBlacklistService {
@@ -18,7 +23,24 @@ public class TokenBlacklistService {
     private static final String PREFIX = "blacklist:";
 
     public void addToBlacklist(String accessToken, String userId, TokenBlacklistReason reason) {
-        long remainingMillis = jwtProvider.getRemainingExpiration(accessToken);
+        long remainingMillis;
+
+        try {
+            // 정상적인 유효 토큰이면 이 경로로
+            remainingMillis = jwtProvider.getRemainingExpiration(accessToken);
+        } catch (TokenExpiredException e) {
+            // 만료된 토큰도 블랙리스트 등록: decode만 수행
+            DecodedJWT decodedJWT = jwtProvider.decodeExpiredToken(accessToken);
+            Date expiresAt = decodedJWT.getExpiresAt();
+            remainingMillis = expiresAt.getTime() - System.currentTimeMillis();
+
+            if (remainingMillis <= 0) {
+                // 만료 시간이 이미 지났다면 저장하지 않음
+                log.warn("만료된 토큰이므로 블랙리스트에 저장하지 않음.");
+                return;
+            }
+        }
+
         String value = reason.formatWithUserId(userId);
 
         redisTemplate.opsForValue().set(
@@ -28,6 +50,7 @@ public class TokenBlacklistService {
                 TimeUnit.MILLISECONDS
         );
     }
+
 
     public boolean isBlacklisted(String accessToken) {
         return Boolean.TRUE.equals(redisTemplate.hasKey(PREFIX + accessToken));

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatController.java
@@ -2,6 +2,7 @@ package com.ktb.cafeboo.domain.coffeechat.controller;
 
 import com.ktb.cafeboo.domain.coffeechat.dto.*;
 import com.ktb.cafeboo.domain.coffeechat.service.CoffeeChatMessageService;
+import com.ktb.cafeboo.domain.coffeechat.service.CoffeeChatReviewService;
 import com.ktb.cafeboo.domain.coffeechat.service.CoffeeChatService;
 import com.ktb.cafeboo.global.apiPayload.ApiResponse;
 import com.ktb.cafeboo.global.apiPayload.code.status.SuccessStatus;
@@ -9,9 +10,13 @@ import com.ktb.cafeboo.global.security.userdetails.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @Slf4j
 @RestController
@@ -21,6 +26,7 @@ public class CoffeeChatController {
 
     private final CoffeeChatService coffeeChatService;
     private final CoffeeChatMessageService coffeeChatMessageService;
+    private final CoffeeChatReviewService coffeeChatReviewService;
 
     @PostMapping
     public ResponseEntity<ApiResponse<CoffeeChatCreateResponse>> createCoffeeChat(
@@ -128,5 +134,27 @@ public class CoffeeChatController {
         CoffeeChatMembersResponse response = coffeeChatService.getCoffeeChatMembers(coffeechatId);
 
         return ResponseEntity.ok(ApiResponse.of(SuccessStatus.COFFEECHAT_MEMBER_LOAD_SUCCESS, response));
+    }
+
+    @PostMapping(value = "/{coffeechatId}/reviews", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<CoffeeChatReviewCreateResponse>> createCoffeeChatReview(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long coffeechatId,
+            @RequestPart("memberId") String memberId,
+            @RequestPart("text") String text,
+            @RequestPart(value = "images", required = false) List<MultipartFile> images
+    ) {
+        Long userId = userDetails.getUserId();
+        log.info("[POST /api/v1/coffee-chats/{}/reviews] userId: {} 커피챗 후기 작성 요청 수신", coffeechatId, userId);
+
+        CoffeeChatReviewCreateRequest request = new CoffeeChatReviewCreateRequest(memberId, text, images);
+
+        CoffeeChatReviewCreateResponse response = coffeeChatReviewService.createCoffeeChatReview(
+                userId,
+                coffeechatId,
+                request
+        );
+
+        return ResponseEntity.ok(ApiResponse.of(SuccessStatus.COFFEECHAT_REVIEW_CREATE_SUCCESS, response));
     }
 }

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatController.java
@@ -116,4 +116,17 @@ public class CoffeeChatController {
 
         return ResponseEntity.ok(ApiResponse.of(SuccessStatus.COFFEECHAT_MESSAGES_LOAD_SUCCESS, response));
     }
+
+    @GetMapping("/{coffeechatId}/members")
+    public ResponseEntity<ApiResponse<CoffeeChatMembersResponse>> getCoffeeChatMembers(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long coffeechatId
+    ) {
+        Long userId = userDetails.getUserId();
+        log.info("[GET /api/v1/coffee-chats/{}/members] userId: {} 커피챗 참여자 목록 조회 요청 수신", coffeechatId, userId);
+
+        CoffeeChatMembersResponse response = coffeeChatService.getCoffeeChatMembers(coffeechatId);
+
+        return ResponseEntity.ok(ApiResponse.of(SuccessStatus.COFFEECHAT_MEMBER_LOAD_SUCCESS, response));
+    }
 }

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatController.java
@@ -73,7 +73,7 @@ public class CoffeeChatController {
             .body(ApiResponse.of(SuccessStatus.COFFEECHAT_JOIN_SUCCESS, response));
     }
 
-    @DeleteMapping("/{coffeechatId}/member/{memberId}")
+    @DeleteMapping("/{coffeechatId:\\d+}/member/{memberId:\\d+}")
     public ResponseEntity<Void> leaveChat(
         @AuthenticationPrincipal CustomUserDetails userDetails,
         @PathVariable Long coffeechatId,
@@ -83,7 +83,7 @@ public class CoffeeChatController {
         return ResponseEntity.noContent().build();
     }
 
-    @DeleteMapping("/{coffeechatId}")
+    @DeleteMapping("/{coffeechatId:\\d+}")
     public ResponseEntity<Void> deleteCoffeeChat(
         @PathVariable Long coffeechatId,
         @AuthenticationPrincipal CustomUserDetails userDetails

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatController.java
@@ -58,7 +58,7 @@ public class CoffeeChatController {
         return ResponseEntity.ok(ApiResponse.of(SuccessStatus.COFFEECHAT_LOAD_SUCCESS, response));
     }
 
-    @PostMapping("/{coffeechatId}/member")
+    @PostMapping("/{coffeechatId}/members")
     public ResponseEntity<ApiResponse<CoffeeChatJoinResponse>> joinCoffeeChat(
         @AuthenticationPrincipal CustomUserDetails userDetails,
         @PathVariable Long coffeechatId,
@@ -73,7 +73,7 @@ public class CoffeeChatController {
             .body(ApiResponse.of(SuccessStatus.COFFEECHAT_JOIN_SUCCESS, response));
     }
 
-    @DeleteMapping("/{coffeechatId:\\d+}/member/{memberId:\\d+}")
+    @DeleteMapping("/{coffeechatId:\\d+}/members/{memberId:\\d+}")
     public ResponseEntity<Void> leaveChat(
         @AuthenticationPrincipal CustomUserDetails userDetails,
         @PathVariable Long coffeechatId,

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatReviewController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatReviewController.java
@@ -1,0 +1,29 @@
+package com.ktb.cafeboo.domain.review.controller;
+
+import com.ktb.cafeboo.domain.coffeechat.dto.CoffeeChatReviewListResponse;
+import com.ktb.cafeboo.domain.coffeechat.service.CoffeeChatReviewService;
+import com.ktb.cafeboo.global.apiPayload.ApiResponse;
+import com.ktb.cafeboo.global.apiPayload.code.status.SuccessStatus;
+import com.ktb.cafeboo.global.security.userdetails.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/coffee-chats/reviews")
+@RequiredArgsConstructor
+public class CoffeeChatReviewController {
+
+    private final CoffeeChatReviewService coffeeChatReviewService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<CoffeeChatReviewListResponse>> getReviews(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(name = "status", defaultValue = "all") String status
+    ) {
+        Long userId = userDetails.getUserId();
+        CoffeeChatReviewListResponse response = coffeeChatReviewService.getCoffeeChatReviewsByStatus(userId, status);
+        return ResponseEntity.ok(ApiResponse.of(SuccessStatus.COFFEECHAT_REVIEW_LIST_LOAD_SUCCESS, response));
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatCreateResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatCreateResponse.java
@@ -1,5 +1,5 @@
 package com.ktb.cafeboo.domain.coffeechat.dto;
 
 public record CoffeeChatCreateResponse(
-        Long coffechatId
+        String coffechatId
 ) {}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatDetailResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatDetailResponse.java
@@ -3,11 +3,14 @@ package com.ktb.cafeboo.domain.coffeechat.dto;
 import com.ktb.cafeboo.domain.coffeechat.dto.common.LocationDto;
 import com.ktb.cafeboo.domain.coffeechat.dto.common.WriterDto;
 import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChat;
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatMember;
+import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
+import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
 
 import java.util.List;
 
 public record CoffeeChatDetailResponse(
-        Long coffechatId,
+        String coffechatId,
         String title,
         String content,
         String time,
@@ -19,9 +22,13 @@ public record CoffeeChatDetailResponse(
         Boolean isJoined
 ) {
     public static CoffeeChatDetailResponse from(CoffeeChat chat, Long userId) {
+        CoffeeChatMember writerMember = chat.getMembers().stream()
+                .filter(m -> m.getUser().getId().equals(chat.getWriter().getId()))
+                .findFirst()
+                .orElseThrow(() -> new CustomApiException(ErrorStatus.COFFEECHAT_MEMBER_NOT_FOUND));
 
         return new CoffeeChatDetailResponse(
-                chat.getId(),
+                chat.getId().toString(),
                 chat.getName(),
                 chat.getContent(),
                 chat.getMeetingTime().toLocalTime().toString(),
@@ -35,8 +42,9 @@ public record CoffeeChatDetailResponse(
                         chat.getKakaoPlaceUrl()
                 ),
                 new WriterDto(
-                        chat.getWriter().getNickname(),
-                        chat.getWriter().getProfileImageUrl()
+                        writerMember.getId().toString(),
+                        writerMember.getChatNickname(),
+                        writerMember.getProfileImageUrl()
                 ),
                 chat.isJoinedBy(userId)
         );

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatDetailResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatDetailResponse.java
@@ -1,7 +1,7 @@
 package com.ktb.cafeboo.domain.coffeechat.dto;
 
 import com.ktb.cafeboo.domain.coffeechat.dto.common.LocationDto;
-import com.ktb.cafeboo.domain.coffeechat.dto.common.WriterDto;
+import com.ktb.cafeboo.domain.coffeechat.dto.common.MemberDto;
 import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChat;
 import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatMember;
 import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
@@ -18,7 +18,7 @@ public record CoffeeChatDetailResponse(
         int currentMemberCount,
         List<String> tags,
         LocationDto location,
-        WriterDto writer,
+        MemberDto writer,
         Boolean isJoined
 ) {
     public static CoffeeChatDetailResponse from(CoffeeChat chat, Long userId) {
@@ -41,10 +41,11 @@ public record CoffeeChatDetailResponse(
                         chat.getLongitude(),
                         chat.getKakaoPlaceUrl()
                 ),
-                new WriterDto(
+                new MemberDto(
                         writerMember.getId().toString(),
                         writerMember.getChatNickname(),
-                        writerMember.getProfileImageUrl()
+                        writerMember.getProfileImageUrl(),
+                        writerMember.isHost()
                 ),
                 chat.isJoinedBy(userId)
         );

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatJoinResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatJoinResponse.java
@@ -1,9 +1,9 @@
 package com.ktb.cafeboo.domain.coffeechat.dto;
 
 public record CoffeeChatJoinResponse(
-        Long memberId
+        String memberId
 ) {
     public static CoffeeChatJoinResponse from(Long memberId) {
-        return new CoffeeChatJoinResponse(memberId);
+        return new CoffeeChatJoinResponse(memberId.toString());
     }
 }

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatListResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatListResponse.java
@@ -1,6 +1,9 @@
 package com.ktb.cafeboo.domain.coffeechat.dto;
 
 import com.ktb.cafeboo.domain.coffeechat.dto.common.WriterDto;
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatMember;
+import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
+import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
 
 import java.util.List;
 
@@ -9,7 +12,7 @@ public record CoffeeChatListResponse(
         List<CoffeeChatSummary> coffeechats
 ) {
     public record CoffeeChatSummary(
-            Long coffechatId,
+            String coffechatId,
             String title,
             String time,
             int maxMemberCount,
@@ -27,8 +30,13 @@ public record CoffeeChatListResponse(
                 boolean isJoined,
                 boolean isReviewed
         ) {
+            CoffeeChatMember writerMember = chat.getMembers().stream()
+                    .filter(m -> m.getUser().getId().equals(chat.getWriter().getId()))
+                    .findFirst()
+                    .orElseThrow(() -> new CustomApiException(ErrorStatus.COFFEECHAT_MEMBER_NOT_FOUND));
+
             return new CoffeeChatSummary(
-                    chat.getId(),
+                    chat.getId().toString(),
                     chat.getName(),
                     chat.getMeetingTime().toLocalTime().toString(),
                     chat.getMaxMemberCount(),
@@ -36,8 +44,9 @@ public record CoffeeChatListResponse(
                     chat.getTagNames(),
                     chat.getAddress(),
                     new WriterDto(
-                            chat.getWriter().getNickname(),
-                            chat.getWriter().getProfileImageUrl()
+                            writerMember.getId().toString(),
+                            writerMember.getChatNickname(),
+                            writerMember.getProfileImageUrl()
                     ),
                     isJoined,
                     isReviewed

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatListResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatListResponse.java
@@ -1,6 +1,6 @@
 package com.ktb.cafeboo.domain.coffeechat.dto;
 
-import com.ktb.cafeboo.domain.coffeechat.dto.common.WriterDto;
+import com.ktb.cafeboo.domain.coffeechat.dto.common.MemberDto;
 import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatMember;
 import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
 import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
@@ -19,7 +19,7 @@ public record CoffeeChatListResponse(
             int currentMemberCount,
             List<String> tags,
             String address,
-            WriterDto writer,
+            MemberDto writer,
 
             // 조건부 필드
             Boolean isJoined,
@@ -43,10 +43,11 @@ public record CoffeeChatListResponse(
                     chat.getCurrentMemberCount(),
                     chat.getTagNames(),
                     chat.getAddress(),
-                    new WriterDto(
+                    new MemberDto(
                             writerMember.getId().toString(),
                             writerMember.getChatNickname(),
-                            writerMember.getProfileImageUrl()
+                            writerMember.getProfileImageUrl(),
+                            writerMember.isHost()
                     ),
                     isJoined,
                     isReviewed

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatMembersResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatMembersResponse.java
@@ -1,0 +1,11 @@
+package com.ktb.cafeboo.domain.coffeechat.dto;
+
+import com.ktb.cafeboo.domain.coffeechat.dto.common.MemberDto;
+
+import java.util.List;
+
+public record CoffeeChatMembersResponse(
+        String coffeeChatId,
+        int totalMemberCounts,
+        List<MemberDto> members
+) {}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatMessagesResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatMessagesResponse.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 @Builder
 public record CoffeeChatMessagesResponse(
-        Long coffeechatId,
+        String coffeechatId,
         List<MessageDto> messages,
         String nextCursor,
         boolean hasNext

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatReviewCreateRequest.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatReviewCreateRequest.java
@@ -1,0 +1,11 @@
+package com.ktb.cafeboo.domain.coffeechat.dto;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public record CoffeeChatReviewCreateRequest(
+        String memberId,
+        String text,
+        List<MultipartFile> images
+) {}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatReviewCreateResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatReviewCreateResponse.java
@@ -1,0 +1,5 @@
+package com.ktb.cafeboo.domain.coffeechat.dto;
+
+public record CoffeeChatReviewCreateResponse(
+        String reviewId
+) {}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatReviewListResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatReviewListResponse.java
@@ -1,0 +1,12 @@
+package com.ktb.cafeboo.domain.coffeechat.dto;
+
+import com.ktb.cafeboo.domain.coffeechat.dto.common.CoffeeChatReviewPreviewDto;
+
+import java.util.List;
+
+public record CoffeeChatReviewListResponse(
+        String filter,
+        int totalReviewCount,
+        List<CoffeeChatReviewPreviewDto> coffeeChatReviews
+) {
+}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/common/CoffeeChatReviewPreviewDto.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/common/CoffeeChatReviewPreviewDto.java
@@ -1,0 +1,27 @@
+package com.ktb.cafeboo.domain.coffeechat.dto.common;
+
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChat;
+
+import java.util.List;
+
+public record CoffeeChatReviewPreviewDto(
+        String coffeeChatId,
+        String title,
+        List<String> tags,
+        String address,
+        int likesCount,
+        int imagesCount,
+        String previewImageUrl
+) {
+    public static CoffeeChatReviewPreviewDto from(CoffeeChat coffeeChat, int imagesCount, String previewImageUrl) {
+        return new CoffeeChatReviewPreviewDto(
+                coffeeChat.getId().toString(),
+                coffeeChat.getName(),
+                coffeeChat.getTagNames(),
+                coffeeChat.getAddress(),
+                coffeeChat.getLikesCount(),
+                imagesCount,
+                previewImageUrl
+        );
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/common/MemberDto.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/common/MemberDto.java
@@ -1,7 +1,8 @@
 package com.ktb.cafeboo.domain.coffeechat.dto.common;
 
-public record SenderDto(
+public record MemberDto(
         String memberId,
         String chatNickname,
-        String profileImageUrl
+        String profileImageUrl,
+        boolean isHost
 ) {}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/common/MessageDto.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/common/MessageDto.java
@@ -4,7 +4,7 @@ import java.time.LocalDateTime;
 
 public record MessageDto(
         String messageId,
-        SenderDto sender,
+        MemberDto sender,
         String content,
         LocalDateTime sentAt
 ) {}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/common/SenderDto.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/common/SenderDto.java
@@ -1,7 +1,7 @@
 package com.ktb.cafeboo.domain.coffeechat.dto.common;
 
 public record SenderDto(
-        Long memberId,
+        String memberId,
         String chatNickname,
         String profileImageUrl
 ) {}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/common/WriterDto.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/common/WriterDto.java
@@ -1,6 +1,7 @@
 package com.ktb.cafeboo.domain.coffeechat.dto.common;
 
 public record WriterDto(
+        String memberId,
         String nickname,
         String profileImageUrl
 ) {}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/common/WriterDto.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/common/WriterDto.java
@@ -1,7 +1,0 @@
-package com.ktb.cafeboo.domain.coffeechat.dto.common;
-
-public record WriterDto(
-        String memberId,
-        String nickname,
-        String profileImageUrl
-) {}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChat.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChat.java
@@ -73,6 +73,20 @@ public class CoffeeChat extends BaseEntity {
     @OneToMany(mappedBy = "coffeeChat", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<CoffeeChatTag> coffeeChatTags = new ArrayList<>();
 
+    @Column(name = "likes_count", nullable = false)
+    private int likesCount = 0;
+
+    @OneToMany(mappedBy = "coffeeChat", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<CoffeeChatLike> likes = new ArrayList<>();
+
+    public void increaseLikes() {
+        this.likesCount++;
+    }
+
+    public void decreaseLikes() {
+        if (this.likesCount > 0) this.likesCount--;
+    }
+
     public void addMember(CoffeeChatMember member) {
         this.members.add(member);
         this.currentMemberCount = this.members.size();

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChatLike.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChatLike.java
@@ -1,0 +1,32 @@
+package com.ktb.cafeboo.domain.coffeechat.model;
+
+import com.ktb.cafeboo.domain.user.model.User;
+import com.ktb.cafeboo.global.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "coffee_chat_likes", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id", "coffee_chat_id"})
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class CoffeeChatLike extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "coffee_chat_id", nullable = false)
+    private CoffeeChat coffeeChat;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    public static CoffeeChatLike of(CoffeeChat coffeeChat, User user) {
+        return CoffeeChatLike.builder()
+                .coffeeChat(coffeeChat)
+                .user(user)
+                .build();
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChatMember.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChatMember.java
@@ -25,6 +25,9 @@ public class CoffeeChatMember extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    @Column(name = "is_host", nullable = false)
+    private boolean isHost;
+
     @Column(name = "chat_nickname", nullable = false, length = 20)
     private String chatNickname;
 
@@ -42,7 +45,8 @@ public class CoffeeChatMember extends BaseEntity {
             CoffeeChat chat,
             User user,
             String chatNickname,
-            String profileImageUrl
+            String profileImageUrl,
+            boolean isHost
     ) {
         return CoffeeChatMember.builder()
                 .coffeeChat(chat)
@@ -51,6 +55,7 @@ public class CoffeeChatMember extends BaseEntity {
                 .profileImageUrl(profileImageUrl)
                 .status(CoffeeChatMemberStatus.JOINED)
                 .isEvaluated(false)
+                .isHost(isHost)
                 .build();
     }
 }

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChatMember.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChatMember.java
@@ -28,9 +28,8 @@ public class CoffeeChatMember extends BaseEntity {
     @Column(name = "chat_nickname", nullable = false, length = 20)
     private String chatNickname;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "profile_image_type", nullable = false, length = 10)
-    private ProfileImageType profileImageType;
+    @Column(name = "profile_image_url", nullable = false, length = 512)
+    private String profileImageUrl;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false, length = 10)
@@ -43,13 +42,13 @@ public class CoffeeChatMember extends BaseEntity {
             CoffeeChat chat,
             User user,
             String chatNickname,
-            ProfileImageType profileImageType
+            String profileImageUrl
     ) {
         return CoffeeChatMember.builder()
                 .coffeeChat(chat)
                 .user(user)
                 .chatNickname(chatNickname)
-                .profileImageType(profileImageType)
+                .profileImageUrl(profileImageUrl)
                 .status(CoffeeChatMemberStatus.JOINED)
                 .isEvaluated(false)
                 .build();

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChatReview.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChatReview.java
@@ -5,6 +5,9 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.Where;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Table(
     name = "coffee_chat_reviews",
@@ -28,17 +31,24 @@ public class CoffeeChatReview extends BaseEntity {
     private CoffeeChatMember writer;
 
     @Column(name = "content_text", nullable = false, columnDefinition = "TEXT")
-    private String contentText;
+    private String text;
 
-    @Column(name = "content_img_url", length = 255)
-    private String contentImgUrl;
+    @Builder.Default
+    @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("sortOrder ASC")
+    private List<CoffeeChatReviewImage> images = new ArrayList<>();
 
-    public static CoffeeChatReview of(CoffeeChat chat, CoffeeChatMember writer, String text, String imgUrl) {
-        return CoffeeChatReview.builder()
+    public static CoffeeChatReview of(CoffeeChat chat, CoffeeChatMember writer, String text, List<CoffeeChatReviewImage> imgUrls) {
+        CoffeeChatReview review = CoffeeChatReview.builder()
                 .coffeeChat(chat)
                 .writer(writer)
-                .contentText(text)
-                .contentImgUrl(imgUrl)
+                .text(text)
                 .build();
+
+        for (CoffeeChatReviewImage img : imgUrls) {
+            img.setReview(review);
+        }
+        review.getImages().addAll(imgUrls);
+        return review;
     }
 }

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChatReviewImage.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChatReviewImage.java
@@ -1,0 +1,36 @@
+package com.ktb.cafeboo.domain.coffeechat.model;
+
+import com.ktb.cafeboo.global.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "coffee_chat_review_images")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class CoffeeChatReviewImage extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "review_id", nullable = false)
+    private CoffeeChatReview review;
+
+    @Column(name = "image_url", length = 255, nullable = false)
+    private String imageUrl;
+
+    @Column(name = "sort_order")
+    private Integer sortOrder;
+
+    public void setReview(CoffeeChatReview review) {
+        this.review = review;
+    }
+
+    public static CoffeeChatReviewImage of(CoffeeChatReview review, String imageUrl, Integer sortOrder) {
+        return CoffeeChatReviewImage.builder()
+                .review(review)
+                .imageUrl(imageUrl)
+                .sortOrder(sortOrder)
+                .build();
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/repository/CoffeeChatMemberRepository.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/repository/CoffeeChatMemberRepository.java
@@ -1,20 +1,13 @@
 package com.ktb.cafeboo.domain.coffeechat.repository;
 
-import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChat;
 import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatMember;
-import com.ktb.cafeboo.domain.user.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface CoffeeChatMemberRepository extends JpaRepository<CoffeeChatMember, Long> {
 
     Optional<CoffeeChatMember> findByCoffeeChatIdAndUserId(Long chatId, Long userId);
-
-    List<CoffeeChatMember> findAllByCoffeeChat(CoffeeChat chat);
-
-    boolean existsByCoffeeChatAndUser(CoffeeChat chat, User user);
 
     boolean existsByCoffeeChatIdAndChatNickname(Long chatId, String chatNickname);
 }

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/repository/CoffeeChatRepository.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/repository/CoffeeChatRepository.java
@@ -3,8 +3,10 @@ package com.ktb.cafeboo.domain.coffeechat.repository;
 import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChat;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CoffeeChatRepository extends JpaRepository<CoffeeChat, Long> {
 
@@ -50,4 +52,8 @@ public interface CoffeeChatRepository extends JpaRepository<CoffeeChat, Long> {
         ORDER BY c.createdAt DESC
     """)
     List<CoffeeChat> findAllActiveChats();
+
+    // N+1 문제 방지
+    @Query("SELECT c FROM CoffeeChat c JOIN FETCH c.members m WHERE c.id = :coffeeChatId")
+    Optional<CoffeeChat> findByIdWithMembers(@Param("coffeeChatId") Long coffeeChatId);
 }

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/repository/CoffeeChatRepository.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/repository/CoffeeChatRepository.java
@@ -31,6 +31,17 @@ public interface CoffeeChatRepository extends JpaRepository<CoffeeChat, Long> {
     """)
     List<CoffeeChat> findCompletedChats(Long userId);
 
+    @Query("""
+        SELECT c FROM CoffeeChat c
+        JOIN CoffeeChatMember m ON c.id = m.coffeeChat.id
+        WHERE m.user.id = :userId
+        AND c.meetingTime < CURRENT_TIMESTAMP
+        AND c.deletedAt IS NULL
+        ORDER BY c.meetingTime DESC
+    """)
+    List<CoffeeChat> findReviewableChats(Long userId);
+
+
     // 모든 활성화된 채팅방 목록 (ALL)
     @Query("""
         SELECT c FROM CoffeeChat c

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/repository/CoffeeChatRepository.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/repository/CoffeeChatRepository.java
@@ -56,4 +56,23 @@ public interface CoffeeChatRepository extends JpaRepository<CoffeeChat, Long> {
     // N+1 문제 방지
     @Query("SELECT c FROM CoffeeChat c JOIN FETCH c.members m WHERE c.id = :coffeeChatId")
     Optional<CoffeeChat> findByIdWithMembers(@Param("coffeeChatId") Long coffeeChatId);
+
+    // 사용자가 참여했고, 후기가 있는 커피챗 목록
+    @Query("""
+        SELECT DISTINCT c FROM CoffeeChat c
+        JOIN c.members m
+        JOIN FETCH c.reviews r
+        WHERE m.user.id = :userId
+        AND r.deletedAt IS NULL
+    """)
+    List<CoffeeChat> findChatsWithReviewsByUserId(@Param("userId") Long userId);
+
+    // 후기가 하나 이상 존재하는 모든 커피챗 목록
+    @Query("""
+        SELECT DISTINCT c FROM CoffeeChat c
+        JOIN FETCH c.reviews r
+        WHERE r.deletedAt IS NULL
+    """)
+    List<CoffeeChat> findAllWithReviews();
+
 }

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/repository/CoffeeChatReviewRepository.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/repository/CoffeeChatReviewRepository.java
@@ -1,12 +1,9 @@
 package com.ktb.cafeboo.domain.coffeechat.repository;
 
-import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChat;
 import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatMember;
 import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatReview;
-import com.ktb.cafeboo.domain.user.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
 
 public interface CoffeeChatReviewRepository extends JpaRepository<CoffeeChatReview, Long> {
 

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/repository/CoffeeChatReviewRepository.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/repository/CoffeeChatReviewRepository.java
@@ -1,6 +1,7 @@
 package com.ktb.cafeboo.domain.coffeechat.repository;
 
 import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChat;
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatMember;
 import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatReview;
 import com.ktb.cafeboo.domain.user.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,7 +10,5 @@ import java.util.Optional;
 
 public interface CoffeeChatReviewRepository extends JpaRepository<CoffeeChatReview, Long> {
 
-    Optional<CoffeeChatReview> findByCoffeeChatAndWriter(CoffeeChat chat, User writer);
-
-    boolean existsByCoffeeChatAndWriter(CoffeeChat chat, User writer);
+    boolean existsByWriter(CoffeeChatMember writer);
 }

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatMessageService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatMessageService.java
@@ -2,7 +2,7 @@ package com.ktb.cafeboo.domain.coffeechat.service;
 
 import com.ktb.cafeboo.domain.coffeechat.dto.CoffeeChatMessagesResponse;
 import com.ktb.cafeboo.domain.coffeechat.dto.common.MessageDto;
-import com.ktb.cafeboo.domain.coffeechat.dto.common.SenderDto;
+import com.ktb.cafeboo.domain.coffeechat.dto.common.MemberDto;
 import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChat;
 import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatMember;
 import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatMessage;
@@ -56,10 +56,11 @@ public class CoffeeChatMessageService {
 
                     return new MessageDto(
                             m.getMessageUuid(),
-                            new SenderDto(
+                            new MemberDto(
                                     sender.getId().toString(),
                                     sender.getChatNickname(),
-                                    profileImageUrl
+                                    profileImageUrl,
+                                    sender.isHost()
                             ),
                             m.getContent(),
                             m.getCreatedAt()

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatMessageService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatMessageService.java
@@ -12,8 +12,6 @@ import com.ktb.cafeboo.domain.coffeechat.repository.CoffeeChatRepository;
 import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
 import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
 import com.ktb.cafeboo.global.enums.CoffeeChatStatus;
-import com.ktb.cafeboo.global.enums.ProfileImageType;
-import com.ktb.cafeboo.global.infra.s3.S3Properties;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -30,7 +28,6 @@ public class CoffeeChatMessageService {
     private final CoffeeChatRepository coffeeChatRepository;
     private final CoffeeChatMessageRepository messageRepository;
     private final CoffeeChatMemberRepository memberRepository;
-    private final S3Properties s3Properties;
 
     public CoffeeChatMessagesResponse getMessages(Long userId, Long coffeechatId, String cursor, int limit, String order) {
         log.info("[CoffeeChatMessageService.getMessages] 커피챗 메시지 조회 요청: userId={}, chatId={}, cursor={}, limit={}, order={}",
@@ -55,14 +52,12 @@ public class CoffeeChatMessageService {
         List<MessageDto> messageDtos = messages.stream()
                 .map(m -> {
                     CoffeeChatMember sender = m.getSender();
-                    String profileImageUrl = sender.getProfileImageType() == ProfileImageType.DEFAULT
-                            ? s3Properties.getDefaultProfileImageUrl()
-                            : sender.getUser().getProfileImageUrl();
+                    String profileImageUrl = sender.getProfileImageUrl();
 
                     return new MessageDto(
                             m.getMessageUuid(),
                             new SenderDto(
-                                    sender.getId(),
+                                    sender.getId().toString(),
                                     sender.getChatNickname(),
                                     profileImageUrl
                             ),
@@ -75,7 +70,7 @@ public class CoffeeChatMessageService {
         String nextCursor = hasNext ? messageDtos.get(messageDtos.size() - 1).messageId() : null;
 
         return new CoffeeChatMessagesResponse(
-                coffeechatId,
+                coffeechatId.toString(),
                 messageDtos,
                 nextCursor,
                 hasNext

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatReviewService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatReviewService.java
@@ -1,0 +1,101 @@
+package com.ktb.cafeboo.domain.coffeechat.service;
+
+
+import com.ktb.cafeboo.domain.coffeechat.dto.CoffeeChatReviewCreateRequest;
+import com.ktb.cafeboo.domain.coffeechat.dto.CoffeeChatReviewCreateResponse;
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChat;
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatMember;
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatReview;
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatReviewImage;
+import com.ktb.cafeboo.domain.coffeechat.repository.CoffeeChatMemberRepository;
+import com.ktb.cafeboo.domain.coffeechat.repository.CoffeeChatRepository;
+import com.ktb.cafeboo.domain.coffeechat.repository.CoffeeChatReviewRepository;
+import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
+import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
+import com.ktb.cafeboo.global.infra.s3.S3Uploader;
+import com.ktb.cafeboo.global.util.AuthChecker;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CoffeeChatReviewService {
+    private static final int MAX_IMAGE_COUNT = 3;
+
+    private final CoffeeChatRepository coffeeChatRepository;
+    private final CoffeeChatReviewRepository coffeeChatReviewRepository;
+    private final CoffeeChatMemberRepository coffeeChatMemberRepository;
+    private final S3Uploader s3Uploader;
+
+    @Transactional
+    public CoffeeChatReviewCreateResponse createCoffeeChatReview(
+            Long userId,
+            Long coffeechatId,
+            CoffeeChatReviewCreateRequest request
+    ) {
+
+        CoffeeChat coffeeChat = coffeeChatRepository.findById(coffeechatId)
+                .orElseThrow(() -> new CustomApiException(ErrorStatus.COFFEECHAT_NOT_FOUND));
+
+        CoffeeChatMember writer = coffeeChatMemberRepository.findById(Long.parseLong(request.memberId()))
+                .orElseThrow(() -> new CustomApiException(ErrorStatus.COFFEECHAT_MEMBER_NOT_FOUND));
+        AuthChecker.checkOwnership(writer.getId(), userId);
+
+        if (!writer.getCoffeeChat().getId().equals(coffeechatId)) {
+            throw new CustomApiException(ErrorStatus.MEMBER_NOT_IN_THIS_CHAT);
+        }
+
+        boolean isAlreadyReviewed = coffeeChatReviewRepository.existsByWriter(writer);
+        if (isAlreadyReviewed) {
+            throw new CustomApiException(ErrorStatus.ALREADY_REVIEWED);
+        }
+
+        LocalDateTime meetingTime = coffeeChat.getMeetingTime();
+        //LocalDateTime reviewDeadline = meetingTime.plusHours(24); 후기 작성 데드라인은 현재 없음
+        if (LocalDateTime.now().isBefore(meetingTime) ) {
+            throw new CustomApiException(ErrorStatus.INVALID_REVIEW_TIME);
+        }
+
+        // 이미지 처리
+        List<MultipartFile> files = request.images() != null ? request.images() : List.of();
+
+        if (files.size() > MAX_IMAGE_COUNT) {
+            throw new CustomApiException(ErrorStatus.INVALID_IMAGE_COUNT);
+        }
+
+        List<String> imageUrls = new ArrayList<>();
+        for (MultipartFile file : files) {
+            try (InputStream inputStream = file.getInputStream()) {
+                String url = s3Uploader.uploadReviewImage(inputStream, file.getSize(), file.getContentType());
+                imageUrls.add(url);
+            } catch (IOException e) {
+                throw new CustomApiException(ErrorStatus.S3_REVIEW_IMAGE_UPLOAD_FAILED);
+            }
+        }
+
+        List<CoffeeChatReviewImage> images = new ArrayList<>();
+        for (int i = 0; i < imageUrls.size(); i++) {
+            images.add(CoffeeChatReviewImage.of(null, imageUrls.get(i), i));
+        }
+
+        CoffeeChatReview review = CoffeeChatReview.of(
+                coffeeChat,
+                writer,
+                request.text(),
+                images
+        );
+        CoffeeChatReview savedReview = coffeeChatReviewRepository.save(review);
+
+        return new CoffeeChatReviewCreateResponse(savedReview.getId().toString());
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatReviewService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatReviewService.java
@@ -49,7 +49,7 @@ public class CoffeeChatReviewService {
 
         CoffeeChatMember writer = coffeeChatMemberRepository.findById(Long.parseLong(request.memberId()))
                 .orElseThrow(() -> new CustomApiException(ErrorStatus.COFFEECHAT_MEMBER_NOT_FOUND));
-        AuthChecker.checkOwnership(writer.getId(), userId);
+        AuthChecker.checkOwnership(writer.getUser().getId(), userId);
 
         if (!writer.getCoffeeChat().getId().equals(coffeechatId)) {
             throw new CustomApiException(ErrorStatus.MEMBER_NOT_IN_THIS_CHAT);

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatService.java
@@ -217,7 +217,7 @@ public class CoffeeChatService {
 
         List<MemberDto> memberDtos = coffeeChat.getMembers().stream()
                 .map(cm -> new MemberDto(
-                        String.valueOf(cm.getUser().getId()),
+                        String.valueOf(cm.getId()),
                         cm.getChatNickname(),
                         cm.getProfileImageUrl(),
                         cm.isHost()

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatService.java
@@ -198,8 +198,9 @@ public class CoffeeChatService {
     private List<CoffeeChat> getChatsByFilter(CoffeeChatFilterType filter, Long userId) {
         return switch (filter) {
             case JOINED -> coffeeChatRepository.findJoinedChats(userId);
-            case COMPLETED -> coffeeChatRepository.findCompletedChats(userId);
+            case ENDED -> coffeeChatRepository.findCompletedChats(userId);
             case ALL -> coffeeChatRepository.findAllActiveChats();
+            case REVIEWABLE -> coffeeChatRepository.findReviewableChats(userId);
         };
     }
 

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatService.java
@@ -68,7 +68,8 @@ public class CoffeeChatService {
                 chat,
                 user,
                 request.chatNickname(),
-                profileImageUrl
+                profileImageUrl,
+                true
         );
         chat.addMember(hostMember);
 
@@ -149,7 +150,8 @@ public class CoffeeChatService {
                 chat,
                 user,
                 request.chatNickname(),
-                profileImageUrl
+                profileImageUrl,
+                false
         );
         chat.addMember(member);
 

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/ErrorStatus.java
@@ -62,7 +62,7 @@ public enum ErrorStatus implements BaseCode {
     COFFEECHAT_NOT_FOUND(404, "COFFEECHAT_NOT_FOUND", "해당 커피챗을 찾을 수 없습니다."),
     COFFEECHAT_MEMBER_NOT_FOUND(404, "COFFEECHAT_MEMBER_NOT_FOUND", "해당 커피챗 멤버를 찾을 수 없습니다."),
     COFFEECHAT_NOT_ACTIVE(409, "COFFEECHAT_NOT_ACTIVE", "해당 커피챗은 더 이상 유효하지 않아 요청을 처리할 수 없습니다."),
-    INVALID_COFFEECHAT_FILTER(401, ",INVALID_COFFEECHAT_FILTER", "요청한 커피챗 필터 값이 유효하지 않습니다. 필터는 'all', 'joined', 'completed' 중 하나여야 합니다."),
+    INVALID_COFFEECHAT_FILTER(400, ",INVALID_COFFEECHAT_FILTER", "요청한 커피챗 필터 값이 유효하지 않습니다. 필터는 'all', 'joined', 'completed' 중 하나여야 합니다."),
     COFFEECHAT_ALREADY_JOINED(409, ",COFFEECHAT_ALREADY_JOINED", "이미 해당 커피챗에 참여한 사용자입니다."),
     COFFEECHAT_CAPACITY_EXCEEDED(409, "COFFEECHAT_CAPACITY_EXCEEDED", "해당 커피챗은 이미 정원이 초과되어 더 이상 참여할 수 없습니다."),
     CHAT_NICKNAME_ALREADY_EXISTS(409, "CHAT_NICKNAME_ALREADY_EXISTS", "이미 사용 중인 채팅방 닉네임입니다."),
@@ -73,7 +73,8 @@ public enum ErrorStatus implements BaseCode {
     INVALID_IMAGE_COUNT(400, "INVALID_IMAGE_COUNT", "이미지는 최대 3장까지만 첨부할 수 있습니다."),
     INVALID_REVIEW_TIME(400, "INVALID_REVIEW_TIME", "후기 작성이 가능한 시간이 아닙니다."),
     MEMBER_NOT_IN_THIS_CHAT(400, "MEMBER_NOT_IN_THIS_CHAT", "해당 커피챗에 속한 멤버가 아닙니다."),
-    ALREADY_REVIEWED(409, "ALREADY_REVIEWED", "이미 후기를 작성한 참여자입니다.")
+    ALREADY_REVIEWED(409, "ALREADY_REVIEWED", "이미 후기를 작성한 참여자입니다."),
+    INVALID_REVIEW_FILTER(400, "INVALID_REVIEW_FILTER", "")
     ;
 
     private final int status;

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/ErrorStatus.java
@@ -58,7 +58,7 @@ public enum ErrorStatus implements BaseCode {
     //파라미터 관련 오류
     INVALID_PARAMETER(400, "INVALID_PARAMETER", "요청 파라미터의 올바르지 않습니다."),
 
-    // 채팅 관련 오류
+    // 커피챗 관련 오류
     COFFEECHAT_NOT_FOUND(404, "COFFEECHAT_NOT_FOUND", "해당 커피챗을 찾을 수 없습니다."),
     COFFEECHAT_MEMBER_NOT_FOUND(404, "COFFEECHAT_MEMBER_NOT_FOUND", "해당 커피챗 멤버를 찾을 수 없습니다."),
     COFFEECHAT_NOT_ACTIVE(409, "COFFEECHAT_NOT_ACTIVE", "해당 커피챗은 더 이상 유효하지 않아 요청을 처리할 수 없습니다."),
@@ -67,7 +67,13 @@ public enum ErrorStatus implements BaseCode {
     COFFEECHAT_CAPACITY_EXCEEDED(409, "COFFEECHAT_CAPACITY_EXCEEDED", "해당 커피챗은 이미 정원이 초과되어 더 이상 참여할 수 없습니다."),
     CHAT_NICKNAME_ALREADY_EXISTS(409, "CHAT_NICKNAME_ALREADY_EXISTS", "이미 사용 중인 채팅방 닉네임입니다."),
     CANNOT_LEAVE_CHAT_OWNER(400, "CANNOT_LEAVE_CHAT_OWNER", "작성자는 채팅방에서 나갈 수 없습니다."),
-    INVALID_CURSOR(400, "INVALID_CURSOR", "커서 값이 유효하지 않습니다.")
+    INVALID_CURSOR(400, "INVALID_CURSOR", "커서 값이 유효하지 않습니다."),
+
+    // 커피챗 후기 관련
+    INVALID_IMAGE_COUNT(400, "INVALID_IMAGE_COUNT", "이미지는 최대 3장까지만 첨부할 수 있습니다."),
+    INVALID_REVIEW_TIME(400, "INVALID_REVIEW_TIME", "후기 작성이 가능한 시간이 아닙니다."),
+    MEMBER_NOT_IN_THIS_CHAT(400, "MEMBER_NOT_IN_THIS_CHAT", "해당 커피챗에 속한 멤버가 아닙니다."),
+    ALREADY_REVIEWED(409, "ALREADY_REVIEWED", "이미 후기를 작성한 참여자입니다.")
     ;
 
     private final int status;

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/SuccessStatus.java
@@ -59,7 +59,11 @@ public enum SuccessStatus implements BaseCode {
     COFFEECHAT_LOAD_SUCCESS(200, "COFFEECHAT_LOAD_SUCCESS", "커피챗 상세내용을 성공적으로 조회했습니다."),
     COFFEECHAT_JOIN_SUCCESS(201, "COFFEECHAT_JOIN_SUCCESS", "커피챗에 성공적으로 참여하였습니다."),
     COFFEECHAT_MESSAGES_LOAD_SUCCESS(200, "COFFEECHAT_MESSAGES_LOAD_SUCCESS", "커피챗 메시지를 성공적으로 조회했습니다."),
-    COFFEECHAT_MEMBER_LOAD_SUCCESS(200, "COFFEECHAT_MEMBER_LOAD_SUCCESS", "커피챗 참여자 목록을 성공적으로 조회했습니다.")
+    COFFEECHAT_MEMBER_LOAD_SUCCESS(200, "COFFEECHAT_MEMBER_LOAD_SUCCESS", "커피챗 참여자 목록을 성공적으로 조회했습니다."),
+
+    // 커피챗 후기
+    COFFEECHAT_REVIEW_CREATE_SUCCESS(201, "COFFECHAT_REVIEW_CREATE_SUCCESS", "커피챗 후기가 성공적으로 등록되었습니다."),
+    COFFEECHAT_REVIEWS_FETCH_SUCCESS(200, "COFFEECHAT_REVIEWS_FETCH_SUCCESS", "커피챗 후기를 성공적으로 조회했습니다.")
     ;
     private final int status;
     private final String code;

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/SuccessStatus.java
@@ -58,7 +58,8 @@ public enum SuccessStatus implements BaseCode {
     COFFEECHAT_LIST_LOAD_SUCCESS(200, "COFFEECHAT_LIST_LOAD_SUCCESS", "커피챗 목록을 성공적으로 조회했습니다."),
     COFFEECHAT_LOAD_SUCCESS(200, "COFFEECHAT_LOAD_SUCCESS", "커피챗 상세내용을 성공적으로 조회했습니다."),
     COFFEECHAT_JOIN_SUCCESS(201, "COFFEECHAT_JOIN_SUCCESS", "커피챗에 성공적으로 참여하였습니다."),
-    COFFEECHAT_MESSAGES_LOAD_SUCCESS(200, "COFFEECHAT_MESSAGES_LOAD_SUCCESS", "커피챗 메시지를 성공적으로 조회했습니다.")
+    COFFEECHAT_MESSAGES_LOAD_SUCCESS(200, "COFFEECHAT_MESSAGES_LOAD_SUCCESS", "커피챗 메시지를 성공적으로 조회했습니다."),
+    COFFEECHAT_MEMBER_LOAD_SUCCESS(200, "COFFEECHAT_MEMBER_LOAD_SUCCESS", "커피챗 참여자 목록을 성공적으로 조회했습니다.")
     ;
     private final int status;
     private final String code;

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/SuccessStatus.java
@@ -62,8 +62,9 @@ public enum SuccessStatus implements BaseCode {
     COFFEECHAT_MEMBER_LOAD_SUCCESS(200, "COFFEECHAT_MEMBER_LOAD_SUCCESS", "커피챗 참여자 목록을 성공적으로 조회했습니다."),
 
     // 커피챗 후기
+
     COFFEECHAT_REVIEW_CREATE_SUCCESS(201, "COFFECHAT_REVIEW_CREATE_SUCCESS", "커피챗 후기가 성공적으로 등록되었습니다."),
-    COFFEECHAT_REVIEWS_FETCH_SUCCESS(200, "COFFEECHAT_REVIEWS_FETCH_SUCCESS", "커피챗 후기를 성공적으로 조회했습니다.")
+    COFFEECHAT_REVIEW_LIST_LOAD_SUCCESS(200, "COFFEECHAT_REVIEW_LIST_LOAD_SUCCESS", "커피챗 후기를 성공적으로 조회했습니다.")
     ;
     private final int status;
     private final String code;

--- a/src/main/java/com/ktb/cafeboo/global/config/SecurityConfig.java
+++ b/src/main/java/com/ktb/cafeboo/global/config/SecurityConfig.java
@@ -29,6 +29,7 @@ public class SecurityConfig {
         List<RequestMatcher> permitAllMatchers = Arrays.asList(
             new AntPathRequestMatcher("/api/v1/auth/oauth"),
             new AntPathRequestMatcher("/api/v1/auth/kakao"),
+            new AntPathRequestMatcher("/api/v1/auth/refresh"),
             new AntPathRequestMatcher("/api/v1/users/email"),
             new AntPathRequestMatcher("/api/v1/reports/weekly/ai_callback"),
             new AntPathRequestMatcher("/v3/api-docs/**"),

--- a/src/main/java/com/ktb/cafeboo/global/enums/CoffeeChatFilterType.java
+++ b/src/main/java/com/ktb/cafeboo/global/enums/CoffeeChatFilterType.java
@@ -8,7 +8,8 @@ import java.util.Arrays;
 public enum CoffeeChatFilterType {
     ALL,
     JOINED,
-    COMPLETED;
+    ENDED,
+    REVIEWABLE;
 
     public static CoffeeChatFilterType from(String status) {
         return Arrays.stream(values())

--- a/src/main/java/com/ktb/cafeboo/global/enums/ReviewFilterType.java
+++ b/src/main/java/com/ktb/cafeboo/global/enums/ReviewFilterType.java
@@ -1,0 +1,20 @@
+package com.ktb.cafeboo.global.enums;
+
+import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
+import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ReviewFilterType {
+    ALL, MY;
+
+    public static ReviewFilterType from(String input) {
+        try {
+            return ReviewFilterType.valueOf(input.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new CustomApiException(ErrorStatus.INVALID_REVIEW_FILTER);
+        }
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/global/security/JwtProvider.java
+++ b/src/main/java/com/ktb/cafeboo/global/security/JwtProvider.java
@@ -2,9 +2,10 @@ package com.ktb.cafeboo.global.security;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTDecodeException;
 import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.exceptions.TokenExpiredException;
-import com.ktb.cafeboo.domain.auth.service.TokenBlacklistService;
+import com.auth0.jwt.interfaces.DecodedJWT;
 import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
 import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
 import lombok.RequiredArgsConstructor;
@@ -85,5 +86,13 @@ public class JwtProvider {
                 .getExpiresAt();
 
         return expiresAt.getTime() - System.currentTimeMillis();
+    }
+
+    public DecodedJWT decodeExpiredToken(String token) {
+        try {
+            return JWT.decode(token); // 검증 없이 디코드만
+        } catch (JWTDecodeException e) {
+            throw new CustomApiException(ErrorStatus.ACCESS_TOKEN_INVALID);
+        }
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -51,3 +51,7 @@ cloud.aws.s3.defaultProfileImageUrl=${DEFAULT_PROFILE_IMAGE_URL:https://cafeboo-
 cloud.aws.credentials.accessKey=${AWS_ACCESS_KEY}
 cloud.aws.credentials.secretKey=${AWS_SECRET_KEY}
 cloud.aws.region.static-region=ap-northeast-2
+
+# Image
+spring.servlet.multipart.max-file-size=5MB
+spring.servlet.multipart.max-request-size=20MB


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] 토큰 재발급 요청에 토큰의 유효성 검증을 우회하도록 지정
- [x] 만료되지 않은 토큰만 토큰 블랙리스트에 저장하도록 수정

## 🛠 변경사항
- JwtAuthenticationFilter에서 /auth/refresh 요청에 대해 accessToken 만료는 허용, 블랙리스트만 검사
- TokenBlacklistService에 만료된 토큰을 처리할 수 있는 decodeExpiredToken() 기반 블랙리스트 등록 로직 분리 (addToBlacklist(String accessToken))

## 💬 리뷰 요구사항
- x

## 🔍 테스트 방법(선택)
- postman 활용

fixes: #150 