### PR TITLE
[FIX]: 토큰 재발급 오류 수정

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/auth/service/TokenBlacklistService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/auth/service/TokenBlacklistService.java
@@ -1,13 +1,18 @@
 package com.ktb.cafeboo.domain.auth.service;
 
+import com.auth0.jwt.exceptions.TokenExpiredException;
+import com.auth0.jwt.interfaces.DecodedJWT;
 import com.ktb.cafeboo.global.enums.TokenBlacklistReason;
 import com.ktb.cafeboo.global.security.JwtProvider;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
+import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class TokenBlacklistService {
@@ -18,7 +23,24 @@ public class TokenBlacklistService {
     private static final String PREFIX = "blacklist:";
 
     public void addToBlacklist(String accessToken, String userId, TokenBlacklistReason reason) {
-        long remainingMillis = jwtProvider.getRemainingExpiration(accessToken);
+        long remainingMillis;
+
+        try {
+            // 정상적인 유효 토큰이면 이 경로로
+            remainingMillis = jwtProvider.getRemainingExpiration(accessToken);
+        } catch (TokenExpiredException e) {
+            // 만료된 토큰도 블랙리스트 등록: decode만 수행
+            DecodedJWT decodedJWT = jwtProvider.decodeExpiredToken(accessToken);
+            Date expiresAt = decodedJWT.getExpiresAt();
+            remainingMillis = expiresAt.getTime() - System.currentTimeMillis();
+
+            if (remainingMillis <= 0) {
+                // 만료 시간이 이미 지났다면 저장하지 않음
+                log.warn("만료된 토큰이므로 블랙리스트에 저장하지 않음.");
+                return;
+            }
+        }
+
         String value = reason.formatWithUserId(userId);
 
         redisTemplate.opsForValue().set(
@@ -28,6 +50,7 @@ public class TokenBlacklistService {
                 TimeUnit.MILLISECONDS
         );
     }
+
 
     public boolean isBlacklisted(String accessToken) {
         return Boolean.TRUE.equals(redisTemplate.hasKey(PREFIX + accessToken));

--- a/src/main/java/com/ktb/cafeboo/global/config/SecurityConfig.java
+++ b/src/main/java/com/ktb/cafeboo/global/config/SecurityConfig.java
@@ -29,6 +29,7 @@ public class SecurityConfig {
         List<RequestMatcher> permitAllMatchers = Arrays.asList(
             new AntPathRequestMatcher("/api/v1/auth/oauth"),
             new AntPathRequestMatcher("/api/v1/auth/kakao"),
+            new AntPathRequestMatcher("/api/v1/auth/refresh"),
             new AntPathRequestMatcher("/api/v1/users/email"),
             new AntPathRequestMatcher("/api/v1/reports/weekly/ai_callback"),
             new AntPathRequestMatcher("/v3/api-docs/**"),

--- a/src/main/java/com/ktb/cafeboo/global/security/JwtProvider.java
+++ b/src/main/java/com/ktb/cafeboo/global/security/JwtProvider.java
@@ -2,9 +2,10 @@ package com.ktb.cafeboo.global.security;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTDecodeException;
 import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.exceptions.TokenExpiredException;
-import com.ktb.cafeboo.domain.auth.service.TokenBlacklistService;
+import com.auth0.jwt.interfaces.DecodedJWT;
 import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
 import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
 import lombok.RequiredArgsConstructor;
@@ -85,5 +86,13 @@ public class JwtProvider {
                 .getExpiresAt();
 
         return expiresAt.getTime() - System.currentTimeMillis();
+    }
+
+    public DecodedJWT decodeExpiredToken(String token) {
+        try {
+            return JWT.decode(token); // 검증 없이 디코드만
+        } catch (JWTDecodeException e) {
+            throw new CustomApiException(ErrorStatus.ACCESS_TOKEN_INVALID);
+        }
     }
 }


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용

- [x]  토큰 재발급 요청에 토큰의 유효성 검증을 우회하도록 지정
- [x]  만료되지 않은 토큰만 토큰 블랙리스트에 저장하도록 수정

## 🛠 변경사항

- JwtAuthenticationFilter에서 /auth/refresh 요청에 대해 accessToken 만료는 허용, 블랙리스트만 검사
- TokenBlacklistService에 만료된 토큰을 처리할 수 있는 decodeExpiredToken() 기반 블랙리스트 등록 로직 분리 (addToBlacklist(String accessToken))

## 💬 리뷰 요구사항

- x

## 🔍 테스트 방법(선택)

- postman 활용

fixes: #150