### PR TITLE
[REFACTOR] 채팅 기능 테스트 간 발생한 오류 수정

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/ChatController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/ChatController.java
@@ -1,10 +1,9 @@
 package com.ktb.cafeboo.domain.coffeechat.controller;
 
-import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChat;
-import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatMember;
-import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatMessage;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.ktb.cafeboo.domain.coffeechat.dto.StompMessage;
 import com.ktb.cafeboo.domain.coffeechat.service.ChatService;
+import com.ktb.cafeboo.domain.user.service.UserService;
 import jakarta.annotation.PostConstruct;
 import java.util.HashMap;
 import java.util.Map;
@@ -28,6 +27,7 @@ public class ChatController {
     private final RedisTemplate<String, Object> redisTemplate; // RedisTemplate 주입
     private StreamOperations<String, Object, Object> streamOperations; // StreamOperations 선언
     private final ChatService chatService;
+    private final UserService userService;
 
     @PostConstruct
     private void init() {
@@ -36,31 +36,21 @@ public class ChatController {
 
     // 클라이언트에서 /chatrooms/{roomId}로 메시지를 보내면 이 메서드가 처리
     @MessageMapping("/chatrooms/{roomId}")
-    public void handleCoffeeChatMessage(@DestinationVariable String roomId, @Payload CoffeeChatMessage chatMessage, SimpMessageHeaderAccessor headerAccessor) {
+    public void handleCoffeeChatMessage(@DestinationVariable String roomId, @Payload StompMessage chatMessage, SimpMessageHeaderAccessor headerAccessor) {
 
         log.info("[ChatController.handleCoffeeChatMessage] - handleCoffeeChatMessage 호출");
-
         // 클라이언트에서 보낸 메시지 로그
-        CoffeeChatMember sender = chatMessage.getSender();
-        CoffeeChat coffeeChat = chatMessage.getCoffeeChat();
 
         log.info("[ChatController.handleCoffeeChatMessage] - 유저 {}로부터 커피챗 {}에 보내는 메시지를 받았습니다: {}",
-            sender.getId(), coffeeChat.getId(),
-            chatMessage.getContent());
+            chatMessage.getSenderId(), chatMessage.getCoffeechatId(),
+            chatMessage.getMessage());
 
         String sessionId = headerAccessor.getSessionId();
         if (sessionId == null) {
-            log.warn("Received message for room {} without a valid session ID. Message content: {}", roomId, chatMessage.getContent());
+            log.warn("Received message for room {} without a valid session ID. Message content: {}", roomId, chatMessage.getMessage());
             return; // 유효한 세션 ID가 없으면 STOMP 연결이 활성화되지 않을 것이기에 메시지 처리 중단
         }
 
-        // ChatMessage 객체를 Map<String, String>으로 변환
-        Map<String, String> messageMap = new HashMap<>();
-        messageMap.put("userId", sender.getId().toString());
-        messageMap.put("roomId", coffeeChat.getId().toString());
-        messageMap.put("content", chatMessage.getContent());
-        messageMap.put("type", chatMessage.getType().name()); // Enum은 String으로 변환
-        //messageMap.put("timestamp", String.valueOf(chatMessage.getTimestamp())); // long은 String으로 변환
         try{
             chatService.handleNewMessage(roomId, chatMessage);
         }
@@ -72,47 +62,5 @@ public class ChatController {
             log.error("[ChatController.handleCoffeeChatMessage] - 메시지 전송 실패");
             messagingTemplate.convertAndSendToUser(headerAccessor.getSessionId(), "/queue/errors", "메시지 전송 실패: 서버 오류.");
         }
-
-//before, 작동 되는 거 확인하면 삭제
-//        String coffeeChatStreamKey = "coffeechat:" + roomId + ":stream";
-//
-//        // ChatMessage 객체를 Map<String, String>으로 변환
-//        Map<String, String> messageMap = new HashMap<>();
-//        messageMap.put("userId", chatMessage.getUserId());
-//        messageMap.put("roomId", chatMessage.getRoomId());
-//        messageMap.put("content", chatMessage.getContent());
-//        messageMap.put("type", chatMessage.getType().name()); // Enum은 String으로 변환
-//        //messageMap.put("timestamp", String.valueOf(chatMessage.getTimestamp())); // long은 String으로 변환
-//
-//        // MapRecord를 생성하여 Stream에 추가
-//        MapRecord<String, String, String> record = StreamRecords.mapBacked(messageMap)
-//            .withStreamKey(coffeeChatStreamKey);
-//        RecordId recordId = streamOperations.add(record);
-//        System.out.println(
-//            "[ChatController.handleCoffeeChatMessage] - recordId " + recordId + "를 가지는 "
-//                + coffeeChatStreamKey + "메시지가 스트림에 등록되었습니다.");
-//
-//        // 브로커를 통해 해당 채팅방을 구독한 모든 클라이언트에게 메시지 브로드캐스팅
-//        // Destination: /topic/chatrooms/{roomId}
-//        messagingTemplate.convertAndSend("/topic/chatrooms/" + roomId, chatMessage);
-
-        // 브로커를 통해 해당 채팅방을 구독한 모든 클라이언트에게 메시지 브로드캐스팅
-        // Destination: /topic/chatrooms/{roomId}
-        messagingTemplate.convertAndSend("/topic/chatrooms/" + roomId, chatMessage);
     }
-
-    // WebSocket/STOMP 연결 시 호출 (옵션)
-    // @EventListener
-    // public void handleWebSocketConnectListener(SessionConnectedEvent event) {
-    //     SimpMessageHeaderAccessor headers = SimpMessageHeaderAccessor.wrap(event.getMessage());
-    //     System.out.println("WebSocket Connected: " + headers.getSessionId() + " by " + headers.getUser().getName());
-    //     // 사용자 로그인 정보 등을 활용하여 초기 데이터 전송 가능
-    // }
-
-    // WebSocket/STOMP 연결 해제 시 호출 (옵션)
-    // @EventListener
-    // public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
-    //     SimpMessageHeaderAccessor headers = SimpMessageHeaderAccessor.wrap(event.getMessage());
-    //     System.out.println("WebSocket Disconnected: " + headers.getSessionId());
-    // }
 }

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatListResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatListResponse.java
@@ -9,7 +9,7 @@ public record CoffeeChatListResponse(
         List<CoffeeChatSummary> coffeechats
 ) {
     public record CoffeeChatSummary(
-            Long coffechatId,
+            Long coffeechatId,
             String title,
             String time,
             int maxMemberCount,

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/StompMessage.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/StompMessage.java
@@ -1,0 +1,12 @@
+package com.ktb.cafeboo.domain.coffeechat.dto;
+
+import com.ktb.cafeboo.global.enums.MessageType;
+import lombok.Data;
+
+@Data
+public class StompMessage {
+    private String senderId;
+    private String coffeechatId;
+    private String message;
+    private MessageType type;
+}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/StompMessagePublish.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/StompMessagePublish.java
@@ -1,0 +1,55 @@
+package com.ktb.cafeboo.domain.coffeechat.dto;
+
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatMember;
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatMessage;
+import com.ktb.cafeboo.global.enums.MessageType;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class StompMessagePublish {
+    private String messageId; // 메시지 고유 ID (UUID)
+    private Long coffeechatId;
+    private MessageType messageType; // 메시지 타입 (TALK, SYSTEM 등)
+    private String content; // 메시지 내용
+    private LocalDateTime sentAt; // 메시지 전송 시간 (ISO 8601 형식으로 직렬화될 것임)
+    private SenderInfo sender; // 중첩된 Sender 객체
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @ToString
+    public static class SenderInfo { // 내부 클래스로 Sender 정보 정의
+        private String userId; // 사용자의 고유 ID (String 형태)
+        private String name; // 사용자 이름 또는 닉네임
+        private String profileImageUrl; // 사용자 프로필 이미지 URL
+    }
+
+    // Factory method (옵션: 엔티티로부터 DTO 생성 편의 메서드)
+    public static StompMessagePublish from(CoffeeChatMessage message, CoffeeChatMember senderMember) {
+        return StompMessagePublish.builder()
+            .messageId(message.getMessageUuid())
+            .coffeechatId(message.getCoffeeChat().getId())
+            .messageType(message.getType())
+            .content(message.getContent())
+            .sentAt(message.getCreatedAt()) // BaseEntity의 createdAt 필드 사용
+            .sender(SenderInfo.builder()
+                .userId(String.valueOf(senderMember.getUser().getId())) // User ID를 String으로 변환
+                .name(senderMember.getChatNickname()) // CoffeeChatMember의 닉네임 사용
+                .profileImageUrl("") // CoffeeChatMember의 프로필 이미지 사용
+                .build())
+            .build();
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatMessageService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatMessageService.java
@@ -108,4 +108,9 @@ public class CoffeeChatMessageService {
             return messageRepository.findByCoffeeChatIdAndIdLessThanOrderByIdDesc(chatId, cursorId, pageRequest);
         }
     }
+
+    public CoffeeChatMessage save(CoffeeChatMessage coffeeChatMessage){
+        CoffeeChatMessage savedMessage = messageRepository.save(coffeeChatMessage);
+        return savedMessage;
+    }
 }

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatService.java
@@ -32,6 +32,7 @@ public class CoffeeChatService {
     private final CoffeeChatMemberRepository coffeeChatMemberRepository;
     private final UserRepository userRepository;
     private final TagService tagService;
+    private final ChatService chatService;
 
     @Transactional
     public CoffeeChatCreateResponse create(Long userId, CoffeeChatCreateRequest request) {
@@ -123,6 +124,9 @@ public class CoffeeChatService {
         if (!chat.getStatus().equals(CoffeeChatStatus.ACTIVE)) {
             throw new CustomApiException(ErrorStatus.COFFEECHAT_NOT_ACTIVE);
         }
+
+        //커피챗 구독, 커피챗에서 오가는 메시지를 수신받기 위한 consumer group 등록
+        chatService.startListeningToCoffeeChat(String.valueOf(coffeechatId));
 
         if (chat.isJoinedBy(userId)) {
             throw new CustomApiException(ErrorStatus.COFFEECHAT_ALREADY_JOINED);

--- a/src/main/java/com/ktb/cafeboo/global/infra/redis/stream/listener/RedisStreamListener.java
+++ b/src/main/java/com/ktb/cafeboo/global/infra/redis/stream/listener/RedisStreamListener.java
@@ -1,39 +1,146 @@
 package com.ktb.cafeboo.global.infra.redis.stream.listener;
 
-import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatMessage;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ktb.cafeboo.domain.coffeechat.dto.StompMessagePublish;
+import com.ktb.cafeboo.global.enums.MessageType;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.HashMap;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.connection.Message;
-import org.springframework.data.redis.connection.stream.ObjectRecord;
+// ⭐ MapRecord<String, String, String>으로 변경 ⭐
+import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.data.redis.connection.stream.RecordId;
 import org.springframework.data.redis.stream.StreamListener;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 
+import java.util.Map;
+
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class RedisStreamListener implements StreamListener<String, ObjectRecord<String, CoffeeChatMessage>> {
+// ⭐ StreamListener<String, MapRecord<String, String, String>> 로 변경 ⭐
+public class RedisStreamListener implements StreamListener<String, MapRecord<String, String, String>> {
 
     private final SimpMessagingTemplate messagingTemplate;
+    private final ObjectMapper objectMapper;
 
     @Override
-    public void onMessage(ObjectRecord<String, CoffeeChatMessage> message) {
+    // ⭐ MapRecord<String, String, String> 으로 변경 ⭐
+    public void onMessage(MapRecord<String, String, String> message) {
+        log.error("[RedisStreamListener] === onMessage method called! === Record ID: {}",
+            message.getId());
+
         String streamKey = message.getStream();
         RecordId recordId = message.getId();
-        CoffeeChatMessage coffeechatMessage = message.getValue();
-        String roomId = String.valueOf(coffeechatMessage.getCoffeeChat().getId());
 
-        log.info("[RedisStreamListener.onMessage] - Stream {}에 메시지 {}를 수신받았습니다.", streamKey, coffeechatMessage);
+        StompMessagePublish stompMessage = null;
+        try {
+            Map<String, String> rawData = message.getValue(); // Base64 인코딩된 String 값들을 가진 Map
 
-        try{
-            //WebSocket을 통해 채팅방의 모든 구독자에게 메시지 전송
-            //
-            messagingTemplate.convertAndSend("/topic/chatrooms/" + roomId, message);
-            log.info("[RedisStreamListener.onMessage] - Stream {}에서 message {}를 WebSocket topic /topic/{} 로 전송했습니다..", streamKey, recordId.getValue(), roomId);
-        }
-        catch (Exception e) {
-            log.error("[RedisStreamListener.onMessage] - Stream {}에서 메시지 {}의 처리에 실패했습니다.", streamKey, recordId.getValue());
+            Map<String, Object> decodedData = new HashMap<>();
+            for (Map.Entry<String, String> entry : rawData.entrySet()) {
+                String key = entry.getKey();
+                String encodedValue = entry.getValue();
+
+                // _class 필드는 계속 무시
+                if ("_class".equals(key)) {
+                    continue;
+                }
+
+                if (encodedValue != null && !encodedValue.isEmpty()) {
+                    String cleanEncodedValue = encodedValue;
+                    if (encodedValue.startsWith("\"") && encodedValue.endsWith("\"")) {
+                        cleanEncodedValue = encodedValue.substring(1, encodedValue.length() - 1);
+                    }
+                    try {
+                        byte[] decodedBytes = Base64.getDecoder().decode(cleanEncodedValue);
+                        String decodedString = new String(decodedBytes, StandardCharsets.UTF_8);
+
+                        // ⭐⭐⭐ 각 필드에 맞는 타입으로 변환 및 디코딩 ⭐⭐⭐
+                        if ("coffeechatId".equals(key) || "sender.userId".equals(key)) { // userId는 sender 안에 있으므로 "sender.userId"
+                            try {
+                                decodedData.put(key, Long.parseLong(decodedString));
+                            } catch (NumberFormatException e) {
+                                log.warn("Failed to parse Long for key {}: {} - keeping as String.", key, decodedString);
+                                decodedData.put(key, decodedString); // 파싱 실패 시 String으로 유지
+                            }
+                        } else if ("messageType".equals(key)) { // ⭐ messageType 처리 추가 ⭐
+                            try {
+                                // Enum.valueOf()는 대소문자를 구분하므로, Enum 정의에 따라 toUpperCase() 등 적용 필요
+                                decodedData.put(key, MessageType.valueOf(decodedString)); // Enum으로 바로 변환
+                            } catch (IllegalArgumentException e) {
+                                log.warn("Failed to parse MessageType for key {}: {} - keeping as String. Error: {}", key, decodedString, e.getMessage());
+                                decodedData.put(key, decodedString); // 변환 실패 시 String으로 유지 (추후 ObjectMapper가 처리 못 할 수 있음)
+                            }
+                        }
+                        else if ("sentAt".equals(key)) {
+                            // LocalDateTime 필드는 String으로 유지하고 ObjectMapper가 처리하도록 합니다.
+                            decodedData.put(key, decodedString);
+                        }
+                        else if ("sender.name".equals(key) || "sender.profileImageUrl".equals(key) || "content".equals(key) || "messageId".equals(key)) {
+                            // 나머지 String 필드
+                            decodedData.put(key, decodedString);
+                        } else {
+                            // 예상치 못한 키는 디코딩된 문자열로 저장 (일반적인 경우)
+                            decodedData.put(key, decodedString);
+                        }
+
+                    } catch (IllegalArgumentException e) { // Base64 디코딩 실패
+                        log.warn("Base64 decoding failed for key {}: {} - using original value. Error: {}", key, encodedValue, e.getMessage());
+                        decodedData.put(key, cleanEncodedValue);
+                    }
+                } else {
+                    decodedData.put(key, encodedValue); // null 또는 빈 문자열은 그대로 유지
+                }
+            }
+
+            // ⭐⭐⭐ SenderInfo 내부 객체를 Map으로 다시 구성 (중요!) ⭐⭐⭐
+            // "sender.userId", "sender.name", "sender.profileImageUrl" 필드는
+            // ObjectMapper가 StompMessagePublish.sender 필드에 매핑할 때 SenderInfo 객체로 다시 묶여야 합니다.
+            // ObjectMapper의 convertValue는 점(.)으로 구분된 필드를 자동으로 중첩 객체로 인식하지 못할 수 있습니다.
+            // 따라서 수동으로 SenderInfo 맵을 생성하여 'sender' 키에 넣어줘야 합니다.
+            Map<String, Object> senderMap = new HashMap<>();
+            if (decodedData.containsKey("sender.userId")) {
+                senderMap.put("userId", decodedData.remove("sender.userId"));
+            }
+            if (decodedData.containsKey("sender.name")) {
+                senderMap.put("name", decodedData.remove("sender.name"));
+            }
+            if (decodedData.containsKey("sender.profileImageUrl")) {
+                senderMap.put("profileImageUrl", decodedData.remove("sender.profileImageUrl"));
+            }
+            if (!senderMap.isEmpty()) {
+                decodedData.put("sender", senderMap); // 'sender' 키에 SenderInfo Map 추가
+            }
+
+            stompMessage = objectMapper.convertValue(decodedData, StompMessagePublish.class);
+
+            log.info("[RedisStreamListener.onMessage] - 수신된 StompMessagePublish: {}", stompMessage);
+            if (stompMessage != null) {
+                log.info("  messageId: {}", stompMessage.getMessageId());
+                log.info("  coffeechatId: {}", stompMessage.getCoffeechatId());
+                log.info("  sender.userId: {}",
+                    stompMessage.getSender() != null ? stompMessage.getSender().getUserId()
+                        : "null");
+                log.info("  content: {}", stompMessage.getContent());
+            } else {
+                log.error("[RedisStreamListener.onMessage] - stompMessage가 null입니다. 수동 역직렬화 실패.");
+                return;
+            }
+
+            String roomId = String.valueOf(stompMessage.getCoffeechatId());
+            log.info("[RedisStreamListener.onMessage] - Stream '{}'에서 메시지 '{}'를 수신했습니다.", streamKey,
+                recordId.getValue());
+
+            messagingTemplate.convertAndSend("/topic/chatrooms/" + roomId, stompMessage);
+
+            log.info(
+                "[RedisStreamListener.onMessage] - WebSocket /topic/chatrooms/{} 로 메시지를 전송했습니다.",
+                roomId);
+        } catch (Exception e) {
+            log.error("[RedisStreamListener.onMessage] - 메시지 처리 중 예외 발생: {}", e.getMessage(), e);
         }
     }
 }


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] StreamMessageListenerContainer 내용 수정
- [x] 메시지 전송 과정에서 필요한 DTO 추가
- [x] STOMP를 통해 전송된 메시지 처리하는 과정에서 필요한 DTO 추가
- [x] 채팅 저장 로직 도입
- [x] Redis Stream에 등록된 메시지를 처리하는 Redis Stream Listener 구현 수정

## 🛠 변경사항
- StreamMessageListenerContainer

   StreamMessageListenerContainer에서 사용되는 데이터가 <String, ?> 에서 <String, MapRecord<String, String, String>>의 형태로 변환됨에 따라 해당 자료구조를 사용하는 부분의 코드를 전반적으로 수정했습니다. 

- DTO 추가

   기존 구현에 사용했던 CoffeeChatMessage DTO의 경우 STOMP를 통해 전송하는 채팅의 payload에 담긴 내용보다 많은 정보를 필요로 했습니다. 그렇기에 실제 payload와 DTO 매핑 과정에서 오류가 발생했고, chatService.handleNewMessage()가 호출되더라도 전송된 메시지가 Redis Stream에 publish 되지 않는 문제가 발생했습니다. 

    이에, 새로운 STOMP에서 전송되는 메시지에 사용할 StompMessage DTO를 선언해 사용하는 방식으로 수정 진행했습니다. 
    
    Redis Stream에 메시지를 publish 하는 과정에서 StompMessage DTO에서 API 명세에 맞춰 형식을 변환할 필요가 있었습니다. 이에 API 명세에 대응되는 StompMessagePublish DTO를 선언해 전송된 채팅 메시지를 가공하여 Redis Stream에 publish 될 수 있도록 수정 진행했습니다. 

- 채팅 저장 기능 구현

    기존에는 Redis에만 채팅 기록이 저장되었고 서버 재부팅, Redis 및 네트워크 오류 발생 시 데이터 손실로 이어질 수 있었습니다. 이에 채팅 전송 간, 프로젝트에서 사용하는 MySQL에 저장된 후 Redis Stream에 메시지를 publish 하는 것으로 데이터 손실을 막을 수 있도록 했습니다. 

    다만, 해당 부분의 경우 임의로 설정한 것이기에 추후 개선의 여지가 있을 것으로 보입니다. 

- Redis Stream Listener 수정

    메시지 전파 과정에서 ChatService. handleNewMessage()를 통해 Redis Stream에 등록한 메시지를 JSON 형식에 맞춰 직렬화 하는 부분에서 오류가 발생했습니다. 기대하는 데이터 형식과 다른 형식의 데이터가 반환되어 발생한 문제였고 Redis에 저장되는 과정에서 추가적인 단계가 있기에 발생하는 문제로 규정했습니다. XREAD 명령을 통해 특정 스트림에 등록된 메시지를 가져온 결과 일반적인 문자열이 아닌 인코딩된 형식의 읽을 수 없는 문자열이었습니다.

    검색 결과, Redis에 데이터가 등록되는 과정에서 JdkSerializationRedisSerializer가 사용되어 Base64-like 인코딩이 진행되었습니다. 현재는 RedisStreamListener의 구현에서 Base64-like 인코딩된 메시지의 파싱을 진행하지만 차후 RedisConfig에 serializer 설정 도입을 통해 추가적인 메시지의 파싱 단계를 줄일 수 있을 것이라 기대합니다.

## 💬 리뷰 요구사항
- PR 내용 읽으신 다음 이해 안되는 부분 있다면 코멘트 남겨주세요

## 🔍 테스트 방법(선택)
- FE 연동을 통한 로컬 서버 환경에서의 테스트
