### PR TITLE
[FEAT] 커피챗 후기 좋아요/취소 기능 구현 

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatController.java
@@ -10,13 +10,9 @@ import com.ktb.cafeboo.global.security.userdetails.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
 
 @Slf4j
 @RestController
@@ -26,7 +22,6 @@ public class CoffeeChatController {
 
     private final CoffeeChatService coffeeChatService;
     private final CoffeeChatMessageService coffeeChatMessageService;
-    private final CoffeeChatReviewService coffeeChatReviewService;
 
     @PostMapping
     public ResponseEntity<ApiResponse<CoffeeChatCreateResponse>> createCoffeeChat(
@@ -136,25 +131,4 @@ public class CoffeeChatController {
         return ResponseEntity.ok(ApiResponse.of(SuccessStatus.COFFEECHAT_MEMBER_LOAD_SUCCESS, response));
     }
 
-    @PostMapping(value = "/{coffeechatId}/reviews", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ApiResponse<CoffeeChatReviewCreateResponse>> createCoffeeChatReview(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
-            @PathVariable Long coffeechatId,
-            @RequestPart("memberId") String memberId,
-            @RequestPart("text") String text,
-            @RequestPart(value = "images", required = false) List<MultipartFile> images
-    ) {
-        Long userId = userDetails.getUserId();
-        log.info("[POST /api/v1/coffee-chats/{}/reviews] userId: {} 커피챗 후기 작성 요청 수신", coffeechatId, userId);
-
-        CoffeeChatReviewCreateRequest request = new CoffeeChatReviewCreateRequest(memberId, text, images);
-
-        CoffeeChatReviewCreateResponse response = coffeeChatReviewService.createCoffeeChatReview(
-                userId,
-                coffeechatId,
-                request
-        );
-
-        return ResponseEntity.ok(ApiResponse.of(SuccessStatus.COFFEECHAT_REVIEW_CREATE_SUCCESS, response));
-    }
 }

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatReviewController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatReviewController.java
@@ -1,16 +1,20 @@
 package com.ktb.cafeboo.domain.coffeechat.controller;
 
-import com.ktb.cafeboo.domain.coffeechat.dto.CoffeeChatReviewListResponse;
-import com.ktb.cafeboo.domain.coffeechat.dto.CoffeeChatReviewResponse;
+import com.ktb.cafeboo.domain.coffeechat.dto.*;
+import com.ktb.cafeboo.domain.coffeechat.service.CoffeeChatLikeService;
 import com.ktb.cafeboo.domain.coffeechat.service.CoffeeChatReviewService;
 import com.ktb.cafeboo.global.apiPayload.ApiResponse;
 import com.ktb.cafeboo.global.apiPayload.code.status.SuccessStatus;
 import com.ktb.cafeboo.global.security.userdetails.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @Slf4j
 @RestController
@@ -19,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 public class CoffeeChatReviewController {
 
     private final CoffeeChatReviewService coffeeChatReviewService;
+    private final CoffeeChatLikeService coffeeChatLikeService;
 
     @GetMapping
     public ResponseEntity<ApiResponse<CoffeeChatReviewListResponse>> getReviews(
@@ -45,5 +50,44 @@ public class CoffeeChatReviewController {
         return ResponseEntity.ok(
                 ApiResponse.of(SuccessStatus.COFFEECHAT_REVIEW_LOAD_SUCCESS, response)
         );
+    }
+
+    @PostMapping(value = "/{coffeechatId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<CoffeeChatReviewCreateResponse>> createCoffeeChatReview(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long coffeechatId,
+            @RequestPart("memberId") String memberId,
+            @RequestPart("text") String text,
+            @RequestPart(value = "images", required = false) List<MultipartFile> images
+    ) {
+        Long userId = userDetails.getUserId();
+        log.info("[POST /api/v1/coffee-chats/reviews/{}] userId: {} 커피챗 후기 작성 요청 수신", coffeechatId, userId);
+
+        CoffeeChatReviewCreateRequest request = new CoffeeChatReviewCreateRequest(memberId, text, images);
+
+        CoffeeChatReviewCreateResponse response = coffeeChatReviewService.createCoffeeChatReview(
+                userId,
+                coffeechatId,
+                request
+        );
+
+        return ResponseEntity.ok(ApiResponse.of(SuccessStatus.COFFEECHAT_REVIEW_CREATE_SUCCESS, response));
+    }
+
+    @PostMapping("/{coffeeChatId}/likes")
+    public ResponseEntity<ApiResponse<CoffeeChatReviewLikeResponse>> toggleLike(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long coffeeChatId
+    ) {
+        Long userId = userDetails.getUserId();
+        log.info("[POST /api/v1/coffee-chats/reviews/{}/likes] 좋아요 토글 요청 - userId: {}", coffeeChatId, userId);
+
+        CoffeeChatReviewLikeResponse response = coffeeChatLikeService.toggleLike(userId, coffeeChatId);
+
+        SuccessStatus resultStatus = response.liked()
+                ? SuccessStatus.COFFEECHAT_LIKE_SUCCESS
+                : SuccessStatus.COFFEECHAT_UNLIKE_SUCCESS;
+
+        return ResponseEntity.ok(ApiResponse.of(resultStatus, response));
     }
 }

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatCreateResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatCreateResponse.java
@@ -1,5 +1,5 @@
 package com.ktb.cafeboo.domain.coffeechat.dto;
 
 public record CoffeeChatCreateResponse(
-        String coffechatId
+        String coffeChatId
 ) {}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatDetailResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatDetailResponse.java
@@ -10,7 +10,7 @@ import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
 import java.util.List;
 
 public record CoffeeChatDetailResponse(
-        String coffechatId,
+        String coffeChatId,
         String title,
         String content,
         String time,

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatListResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatListResponse.java
@@ -12,7 +12,7 @@ public record CoffeeChatListResponse(
         List<CoffeeChatSummary> coffeechats
 ) {
     public record CoffeeChatSummary(
-            String coffechatId,
+            String coffeChatId,
             String title,
             String time,
             int maxMemberCount,

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatMessagesResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatMessagesResponse.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 @Builder
 public record CoffeeChatMessagesResponse(
-        String coffeechatId,
+        String coffeeChatId,
         List<MessageDto> messages,
         String nextCursor,
         boolean hasNext

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatReviewLikeResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatReviewLikeResponse.java
@@ -1,0 +1,7 @@
+package com.ktb.cafeboo.domain.coffeechat.dto;
+
+public record CoffeeChatReviewLikeResponse(
+        boolean liked,
+        int likeCount
+) {
+}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChatLike.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChatLike.java
@@ -2,6 +2,7 @@ package com.ktb.cafeboo.domain.coffeechat.model;
 
 import com.ktb.cafeboo.domain.user.model.User;
 import com.ktb.cafeboo.global.BaseEntity;
+import com.ktb.cafeboo.global.enums.CoffeeChatLikeStatus;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -23,10 +24,19 @@ public class CoffeeChatLike extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private CoffeeChatLikeStatus status;
+
     public static CoffeeChatLike of(CoffeeChat coffeeChat, User user) {
         return CoffeeChatLike.builder()
                 .coffeeChat(coffeeChat)
                 .user(user)
+                .status(CoffeeChatLikeStatus.ACTIVE)
                 .build();
+    }
+
+    public void setStatus(CoffeeChatLikeStatus status) {
+        this.status = status;
     }
 }

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/repository/CoffeeChatLikeRepository.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/repository/CoffeeChatLikeRepository.java
@@ -1,0 +1,11 @@
+package com.ktb.cafeboo.domain.coffeechat.repository;
+
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CoffeeChatLikeRepository extends JpaRepository<CoffeeChatLike, Long> {
+
+    Optional<CoffeeChatLike> findByCoffeeChatIdAndUserId(Long coffeeChatId, Long userId);
+}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatLikeService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatLikeService.java
@@ -1,0 +1,58 @@
+package com.ktb.cafeboo.domain.coffeechat.service;
+
+import com.ktb.cafeboo.domain.coffeechat.dto.CoffeeChatReviewLikeResponse;
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChat;
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatLike;
+import com.ktb.cafeboo.domain.coffeechat.repository.CoffeeChatLikeRepository;
+import com.ktb.cafeboo.domain.coffeechat.repository.CoffeeChatRepository;
+import com.ktb.cafeboo.domain.user.model.User;
+import com.ktb.cafeboo.domain.user.repository.UserRepository;
+import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
+import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
+import com.ktb.cafeboo.global.enums.CoffeeChatLikeStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CoffeeChatLikeService {
+
+    private final CoffeeChatRepository coffeeChatRepository;
+    private final CoffeeChatLikeRepository coffeeChatLikeRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public CoffeeChatReviewLikeResponse toggleLike(Long userId, Long coffeeChatId) {
+        CoffeeChat coffeeChat = coffeeChatRepository.findById(coffeeChatId)
+                .orElseThrow(() -> new CustomApiException(ErrorStatus.COFFEECHAT_NOT_FOUND));
+
+        CoffeeChatLike like = coffeeChatLikeRepository.findByCoffeeChatIdAndUserId(coffeeChatId, userId)
+                .orElse(null);
+
+        boolean liked;
+
+        if (like == null) {
+            // 좋아요 처음 누름
+            User user = userRepository.getReferenceById(userId);
+            CoffeeChatLike newLike = CoffeeChatLike.of(coffeeChat, user);
+            coffeeChatLikeRepository.save(newLike);
+            coffeeChat.increaseLikes();
+            liked = true;
+
+        } else if (like.getStatus() == CoffeeChatLikeStatus.CANCELLED) {
+            // 좋아요 다시 누름
+            like.setStatus(CoffeeChatLikeStatus.ACTIVE);
+            coffeeChat.increaseLikes();
+            liked = true;
+
+        } else {
+            // 좋아요 취소
+            like.setStatus(CoffeeChatLikeStatus.CANCELLED);
+            coffeeChat.decreaseLikes();
+            liked = false;
+        }
+
+        return new CoffeeChatReviewLikeResponse(liked, coffeeChat.getLikesCount());
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/SuccessStatus.java
@@ -65,7 +65,10 @@ public enum SuccessStatus implements BaseCode {
 
     COFFEECHAT_REVIEW_CREATE_SUCCESS(201, "COFFECHAT_REVIEW_CREATE_SUCCESS", "커피챗 후기가 성공적으로 등록되었습니다."),
     COFFEECHAT_REVIEW_LIST_LOAD_SUCCESS(200, "COFFEECHAT_REVIEW_LIST_LOAD_SUCCESS", "커피챗 후기 목록을 성공적으로 조회했습니다."),
-    COFFEECHAT_REVIEW_LOAD_SUCCESS(200, "COFFEECHAT_REVIEW_LOAD_SUCCESS", "커피챗 후기를 성공적으로 조회했습니다.")
+    COFFEECHAT_REVIEW_LOAD_SUCCESS(200, "COFFEECHAT_REVIEW_LOAD_SUCCESS", "커피챗 후기를 성공적으로 조회했습니다."),
+    COFFEECHAT_LIKE_SUCCESS(200, "COFFEECHAT_LIKE_SUCCESS", "커피챗 후기를 좋아요 처리했습니다."),
+    COFFEECHAT_UNLIKE_SUCCESS(200, "COFFEECHAT_UNLIKE_SUCCESS", "커피챗 후기 좋아요를 취소했습니다.")
+
     ;
     private final int status;
     private final String code;

--- a/src/main/java/com/ktb/cafeboo/global/enums/CoffeeChatLikeStatus.java
+++ b/src/main/java/com/ktb/cafeboo/global/enums/CoffeeChatLikeStatus.java
@@ -1,0 +1,5 @@
+package com.ktb.cafeboo.global.enums;
+
+public enum CoffeeChatLikeStatus {
+    ACTIVE, CANCELLED
+}


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] 커피챗 후기 좋아요 및 취소 기능 API 구현
- [x] CoffeeChatLike 엔티티를 생성/삭제하는 방식 대신 상태(status)를 토글하는 구조로 구현

## 🛠 변경사항
- `CoffeeChatLike` 엔티티 및 Repository 추가
- `CoffeeChatLikeService` 생성 및 toggleLike 로직 구현
- `CoffeeChatReviewController`에 좋아요/취소 API 엔드포인트 추가
- `CoffeeChat` 엔티티에 `likesCount` 필드 및 증감 메서드 추가

## 💬 리뷰 요구사항
- 좋아요 기능은 **유저 인증 정보(@AuthenticationPrincipal)**를 기반으로 동작하며,
그 외의 유효성 검증은 따로 두지 않았습니다.
- 해당 API는 토글 형태로 동작하기 때문에, 중복 좋아요나 중복 취소 요청에 대한 별도 예외 처리 없이 상태만 반전하도록 구현되었습니다.
- 혹시 생각나는 예외 상황이 있다면 코멘트 남겨주세요

## 🔍 테스트 방법(선택)

- 좋아요 생성 요청
<img width="832" alt="스크린샷 2025-06-12 오후 8 41 15" src="https://github.com/user-attachments/assets/0f187c9e-c85e-469f-b7b0-d92a13273f80" />

- 좋아요 취소 요청
<img width="832" alt="스크린샷 2025-06-12 오후 8 41 33" src="https://github.com/user-attachments/assets/61cae21f-75c1-4595-9a37-8099f91158bb" />

