### PR TITLE
[FEAT] 커피챗 참여 여부 조회 API 구현

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatController.java
@@ -1,8 +1,8 @@
 package com.ktb.cafeboo.domain.coffeechat.controller;
 
 import com.ktb.cafeboo.domain.coffeechat.dto.*;
+import com.ktb.cafeboo.domain.coffeechat.service.CoffeeChatMemberService;
 import com.ktb.cafeboo.domain.coffeechat.service.CoffeeChatMessageService;
-import com.ktb.cafeboo.domain.coffeechat.service.CoffeeChatReviewService;
 import com.ktb.cafeboo.domain.coffeechat.service.CoffeeChatService;
 import com.ktb.cafeboo.global.apiPayload.ApiResponse;
 import com.ktb.cafeboo.global.apiPayload.code.status.SuccessStatus;
@@ -22,6 +22,7 @@ public class CoffeeChatController {
 
     private final CoffeeChatService coffeeChatService;
     private final CoffeeChatMessageService coffeeChatMessageService;
+    private final CoffeeChatMemberService coffeeChatMemberService;
 
     @PostMapping
     public ResponseEntity<ApiResponse<CoffeeChatCreateResponse>> createCoffeeChat(
@@ -131,4 +132,18 @@ public class CoffeeChatController {
         return ResponseEntity.ok(ApiResponse.of(SuccessStatus.COFFEECHAT_MEMBER_LOAD_SUCCESS, response));
     }
 
+    @GetMapping("/{coffeechatId}/membership")
+    public ResponseEntity<ApiResponse<CoffeeChatMembershipCheckResponse>> checkMembership(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long coffeechatId
+    ) {
+        Long userId = userDetails.getUserId();
+        log.info("[GET /api/v1/coffee-chats/{}/membership] userId: {} 커피챗 참여 여부 조회 요청 수신", coffeechatId, userId);
+
+        CoffeeChatMembershipCheckResponse response = coffeeChatMemberService.checkMembership(coffeechatId, userId);
+
+        return ResponseEntity
+                .ok()
+                .body(ApiResponse.of(SuccessStatus.COFFEECHAT_MEMBERSHIP_CHECK_SUCCESS, response));
+    }
 }

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatMembershipCheckResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatMembershipCheckResponse.java
@@ -1,0 +1,9 @@
+package com.ktb.cafeboo.domain.coffeechat.dto;
+
+import lombok.Builder;
+
+@Builder
+public record CoffeeChatMembershipCheckResponse(
+        boolean isMember,
+        String memberId
+) {}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatMemberService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatMemberService.java
@@ -1,0 +1,40 @@
+package com.ktb.cafeboo.domain.coffeechat.service;
+
+import com.ktb.cafeboo.domain.coffeechat.dto.CoffeeChatMembershipCheckResponse;
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatMember;
+import com.ktb.cafeboo.domain.coffeechat.repository.CoffeeChatMemberRepository;
+import com.ktb.cafeboo.domain.coffeechat.repository.CoffeeChatRepository;
+import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
+import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class CoffeeChatMemberService {
+
+    private final CoffeeChatMemberRepository coffeeChatMemberRepository;
+    private final CoffeeChatRepository coffeeChatRepository;
+
+    public CoffeeChatMembershipCheckResponse checkMembership(Long coffeechatId, Long userId) {
+        if (!coffeeChatRepository.existsById(coffeechatId)) {
+            throw new CustomApiException(ErrorStatus.COFFEECHAT_NOT_FOUND);
+        }
+
+        Optional<CoffeeChatMember> memberOpt =
+                coffeeChatMemberRepository.findByCoffeeChatIdAndUserId(coffeechatId, userId);
+
+        if (memberOpt.isPresent()) {
+            return CoffeeChatMembershipCheckResponse.builder()
+                    .isMember(true)
+                    .memberId(String.valueOf(memberOpt.get().getId()))
+                    .build();
+        } else {
+            return CoffeeChatMembershipCheckResponse.builder()
+                    .isMember(false)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/SuccessStatus.java
@@ -67,9 +67,11 @@ public enum SuccessStatus implements BaseCode {
     COFFEECHAT_REVIEW_LIST_LOAD_SUCCESS(200, "COFFEECHAT_REVIEW_LIST_LOAD_SUCCESS", "커피챗 후기 목록을 성공적으로 조회했습니다."),
     COFFEECHAT_REVIEW_LOAD_SUCCESS(200, "COFFEECHAT_REVIEW_LOAD_SUCCESS", "커피챗 후기를 성공적으로 조회했습니다."),
     COFFEECHAT_LIKE_SUCCESS(200, "COFFEECHAT_LIKE_SUCCESS", "커피챗 후기를 좋아요 처리했습니다."),
-    COFFEECHAT_UNLIKE_SUCCESS(200, "COFFEECHAT_UNLIKE_SUCCESS", "커피챗 후기 좋아요를 취소했습니다.")
-
+    COFFEECHAT_UNLIKE_SUCCESS(200, "COFFEECHAT_UNLIKE_SUCCESS", "커피챗 후기 좋아요를 취소했습니다."),
+    COFFEECHAT_MEMBERSHIP_CHECK_SUCCESS(200, "COFFEECHAT_MEMBERSHIP_CHECK_SUCCESS", "커피챗 참여 여부를 성공적으로 조회했습니다.")
     ;
+
+
     private final int status;
     private final String code;
     private final String message;


### PR DESCRIPTION

# 📌 Pull Request

## ✨ 작업한 내용
- [x] 유저가 특정 커피챗에 참여 중인지 여부와 memberId를 반환합니다.
- [x] 커피챗에 참여 중인 경우 memberId를 함께 반환하여, 추후 커피챗 목록 복귀 시 활용할 수 있도록 구성하였습니다.

## 🛠 변경사항
- AccessToken의 `userId`기반 조회
- 커피챗 참여 여부 조회 API의 컨트롤러, 서비스 메서드 추가 및 dto 클래스 작성

## 💬 리뷰 요구사항
- x

## 🔍 테스트 방법(선택)
Postman
- 참여 O 
<img width="820" alt="스크린샷 2025-06-14 오후 6 13 49" src="https://github.com/user-attachments/assets/7979c049-b3e1-4870-83a1-5c8ac2504b6c" />


- 참여 X

<img width="843" alt="스크린샷 2025-06-14 오후 6 10 46" src="https://github.com/user-attachments/assets/c270ff1e-59f4-484f-a37d-21bbdfd888cb" />

Fixes: #140 