### PR TITLE
[REFACTOR] FE 연동 간 발생한 문제 수정 - deploy test

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatReviewController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatReviewController.java
@@ -41,15 +41,16 @@ public class CoffeeChatReviewController {
         return ResponseEntity.ok(ApiResponse.of(SuccessStatus.COFFEECHAT_REVIEW_LIST_LOAD_SUCCESS, response));
     }
 
-    @GetMapping("/{coffeeChatId}")
+    @GetMapping("/{coffeechatId}")
     public ResponseEntity<ApiResponse<CoffeeChatReviewResponse>> getCoffeeChatReview(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @PathVariable Long coffeeChatId
+            @PathVariable String coffeechatId
     ) {
         Long userId = userDetails.getUserId();
-        log.info("[GET /coffee-chats/reviews/{}] 후기 상세 조회 요청 - userId: {}", coffeeChatId, userId);
+        Long chatId = Long.parseLong(coffeechatId);
+        log.info("[GET /coffee-chats/reviews/{}] 후기 상세 조회 요청 - userId: {}", chatId, userId);
 
-        CoffeeChatReviewResponse response = coffeeChatReviewService.getReviewByCoffeeChatId(coffeeChatId);
+        CoffeeChatReviewResponse response = coffeeChatReviewService.getReviewByCoffeeChatId(chatId);
 
         return ResponseEntity.ok(
                 ApiResponse.of(SuccessStatus.COFFEECHAT_REVIEW_LOAD_SUCCESS, response)
@@ -59,34 +60,37 @@ public class CoffeeChatReviewController {
     @PostMapping(value = "/{coffeechatId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<CoffeeChatReviewCreateResponse>> createCoffeeChatReview(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @PathVariable Long coffeechatId,
+            @PathVariable String coffeechatId,
             @RequestPart("memberId") String memberId,
             @RequestPart("text") String text,
             @RequestPart(value = "images", required = false) List<MultipartFile> images
     ) {
         Long userId = userDetails.getUserId();
-        log.info("[POST /api/v1/coffee-chats/reviews/{}] userId: {} 커피챗 후기 작성 요청 수신", coffeechatId, userId);
+        Long chatId = Long.parseLong(coffeechatId);
+        log.info("[POST /api/v1/coffee-chats/reviews/{}] userId: {} 커피챗 후기 작성 요청 수신", chatId, userId);
 
         CoffeeChatReviewCreateRequest request = new CoffeeChatReviewCreateRequest(memberId, text, images);
 
         CoffeeChatReviewCreateResponse response = coffeeChatReviewService.createCoffeeChatReview(
                 userId,
-                coffeechatId,
+                chatId,
                 request
         );
 
         return ResponseEntity.ok(ApiResponse.of(SuccessStatus.COFFEECHAT_REVIEW_CREATE_SUCCESS, response));
     }
 
-    @PostMapping("/{coffeeChatId}/likes")
+    @PostMapping("/{coffeechatId}/likes")
     public ResponseEntity<ApiResponse<CoffeeChatReviewLikeResponse>> toggleLike(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @PathVariable Long coffeeChatId
+            @PathVariable String coffeechatId
     ) {
         Long userId = userDetails.getUserId();
-        log.info("[POST /api/v1/coffee-chats/reviews/{}/likes] 좋아요 토글 요청 - userId: {}", coffeeChatId, userId);
+        Long chatId = Long.parseLong(coffeechatId);
 
-        CoffeeChatReviewLikeResponse response = coffeeChatLikeService.toggleLike(userId, coffeeChatId);
+        log.info("[POST /api/v1/coffee-chats/reviews/{}/likes] 좋아요 토글 요청 - userId: {}", chatId, userId);
+
+        CoffeeChatReviewLikeResponse response = coffeeChatLikeService.toggleLike(userId, chatId);
 
         SuccessStatus resultStatus = response.liked()
                 ? SuccessStatus.COFFEECHAT_LIKE_SUCCESS

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatListResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatListResponse.java
@@ -30,10 +30,28 @@ public record CoffeeChatListResponse(
                 boolean isJoined,
                 boolean isReviewed
         ) {
-            CoffeeChatMember writerMember = chat.getMembers().stream()
-                    .filter(m -> m.getUser().getId().equals(chat.getWriter().getId()))
-                    .findFirst()
-                    .orElseThrow(() -> new CustomApiException(ErrorStatus.COFFEECHAT_MEMBER_NOT_FOUND));
+            MemberDto writerDto = chat.getMembers().stream()
+                // chat.getWriter()가 null일 가능성도 고려하여 필터 조건 추가
+                .filter(m -> chat.getWriter() != null && m.getUser().getId().equals(chat.getWriter().getId()))
+                .findFirst()
+                // CoffeeChatMember를 찾았다면, MemberDto로 변환합니다.
+                .map(m -> new MemberDto(
+                    m.getId().toString(),
+                    m.getChatNickname(),
+                    m.getProfileImageUrl(),
+                    m.isHost()
+                ))
+                // Optional이 비어있을 경우 (즉, 작성자 멤버를 찾지 못했을 경우) 실행됩니다.
+                .orElseGet(() -> {
+                    // 기본 MemberDto 객체를 생성하여 반환합니다.
+                    return new MemberDto(
+                        "unknown", // 유니크하거나 의미 있는 더미 ID
+                        "알 수 없는 작성자", // 기본 닉네임
+                        "default_profile_image_url.png", // 실제 존재하는 기본 이미지 URL로 변경 권장
+                        false // 호스트 여부 (알 수 없으므로 false)
+                    );
+                });
+
 
             return new CoffeeChatSummary(
                     chat.getId().toString(),
@@ -43,12 +61,7 @@ public record CoffeeChatListResponse(
                     chat.getCurrentMemberCount(),
                     chat.getTagNames(),
                     chat.getAddress(),
-                    new MemberDto(
-                            writerMember.getId().toString(),
-                            writerMember.getChatNickname(),
-                            writerMember.getProfileImageUrl(),
-                            writerMember.isHost()
-                    ),
+                    writerDto,
                     isJoined,
                     isReviewed
             );

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatMemberService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatMemberService.java
@@ -29,7 +29,8 @@ public class CoffeeChatMemberService {
         if (memberOpt.isPresent()) {
             return CoffeeChatMembershipCheckResponse.builder()
                     .isMember(true)
-                    .memberId(String.valueOf(memberOpt.get().getId()))
+//                    .memberId(String.valueOf(memberOpt.get().getId()))
+                    .memberId(String.valueOf(userId))
                     .build();
         } else {
             return CoffeeChatMembershipCheckResponse.builder()

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatService.java
@@ -67,15 +67,6 @@ public class CoffeeChatService {
                 ? s3Properties.getDefaultProfileImageUrl()
                 : user.getProfileImageUrl();
 
-        CoffeeChatMember hostMember = CoffeeChatMember.of(
-                chat,
-                user,
-                request.chatNickname(),
-                profileImageUrl,
-                true
-        );
-        chat.addMember(hostMember);
-
         CoffeeChat saved = coffeeChatRepository.save(chat);
 
         tagService.saveTagsToCoffeeChat(saved, request.tags());


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] 비즈니스 로직 분리
- [x] FE와의 연동을 위한 데이터 타입 수정
- [x] 에러 수정

## 🛠 변경사항
- 비즈니스 로직 분리

    CoffeeChatService에서 현재 create() 메서드에서 join() 메서드에서 진행되어야 할 가입 동작이 같이 진행되어 프로그램 실행 간 흐름에서 꼬이는 문제가 존재했습니다.

    create() 메서드에서 커피챗 생성 후 coffee chat member list의 갱신을 진행하던 것에서 생성 이후 join() 메서드가 호출되며 가입 및 중복 가입 조건을 체크하는 방식으로 구현을 수정했습니다.

- 데이터 타입 수정

    FE 수정이 번거로움에 따라 FE에서 보내는 데이터 타입인 String에 대응되도록 BE의 @PatthVariable을 String 타입으로 변경했습니다.

- 오류 수정
    i. 전체 커피챗 조회 간 발생하던 문제 
        기존 구현의 경우 커피챗을 탐색하며 가져온 list에 대해 writer 정보가 없다면 Custom Api Exception을 던지도록 했고 이 과정에서 FE에서 본래 나와야 할 "커피챗 목록이 존재하지 않습니다" 라는 디폴트 메시지 대신 "조회 간 오류가 발생했습니다"라는 에러 메시지가 출력되었습니다.

    이를 방지하기 위해 WriterDTO 구성 간 Optional이 비어있는 경우 임의로 default MemberDto를 생성해 return하도록 수정했습니다.

    ii. 잘못된 정보를 반환하던 문제
        .memberId(String.valueOf(memberOpt.get().getId())) 의 경우 DB 상 저장되어 있는 CoffeeChatMember의 unique id를 반환하도록 하는 것이고 이는 실제 유저의 id 값에 해당하는 값이 아닙니다.

     해당 정보가 유저의 id를 반영하도록 userId를 대입해 반환하도록 수정 진행했습니다.

## 💬 리뷰 요구사항
- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

## 🔍 테스트 방법(선택)
- 직접 테스트한 방법/결과 적기
