### PR TITLE
[FIX]: CoffeeChat 조회에서 ENDED 상태도 포함되도록 필터링 조건 수정

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChat.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChat.java
@@ -18,7 +18,7 @@ import java.util.*;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "coffee_chats")
-@Where(clause = "status = 'ACTIVE'")
+@Where(clause = "deleted_at IS NULL")
 public class CoffeeChat extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)


### PR DESCRIPTION

# 📌 Pull Request

## ✨ 작업한 내용
- [x] 후기 등 ENDED 상태 커피챗이 필요한 기능에서 조회되지 않던 문제 해결

## 🛠 변경사항
- @Where(clause = "status = 'ACTIVE'") 제거
- 대신 @Where(clause = "deleted_at is null")로 변경하여 soft delete 기준으로 조회

## 💬 리뷰 요구사항
리포지토리에서 이미 `status`를 활용하여 조회하고 있기 때문에 문제는 없습니다.

## 🔍 테스트 방법(선택)
- Postman 활용