### PR TITLE
[FIX] 커피챗 관련 오류 수정

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatController.java
@@ -45,7 +45,8 @@ public class CoffeeChatController {
             CoffeeChatJoinResponse joinResponse = coffeeChatService.join(
                 userDetails.getUserId(),
                 coffeechatId,
-                joinRequest
+                joinRequest,
+                true
             );
 
             return ResponseEntity
@@ -91,7 +92,8 @@ public class CoffeeChatController {
         CoffeeChatJoinResponse response = coffeeChatService.join(
             userDetails.getUserId(),
             coffeechatId,
-            request
+            request,
+            false
         );
         return ResponseEntity.status(HttpStatus.CREATED)
             .body(ApiResponse.of(SuccessStatus.COFFEECHAT_JOIN_SUCCESS, response));

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatMembershipCheckResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatMembershipCheckResponse.java
@@ -5,5 +5,6 @@ import lombok.Builder;
 @Builder
 public record CoffeeChatMembershipCheckResponse(
         boolean isMember,
+        String userId,
         String memberId
 ) {}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/StompMessagePublish.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/StompMessagePublish.java
@@ -46,7 +46,7 @@ public class StompMessagePublish {
             .content(message.getContent())
             .sentAt(message.getCreatedAt()) // BaseEntity의 createdAt 필드 사용
             .sender(SenderInfo.builder()
-                .userId(String.valueOf(senderMember.getUser().getId())) // User ID를 String으로 변환
+                .userId(String.valueOf(senderMember.getId())) // User ID를 String으로 변환
                 .name(senderMember.getChatNickname()) // CoffeeChatMember의 닉네임 사용
                 .profileImageUrl("") // CoffeeChatMember의 프로필 이미지 사용
                 .build())

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/repository/CoffeeChatMemberRepository.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/repository/CoffeeChatMemberRepository.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 
 public interface CoffeeChatMemberRepository extends JpaRepository<CoffeeChatMember, Long> {
 
-    Optional<CoffeeChatMember> findByCoffeeChatIdAndUserId(Long chatId, Long userId);
-
+    Optional<CoffeeChatMember> findByCoffeeChatIdAndUserId(Long chatId, Long Id);
+    Optional<CoffeeChatMember> findByCoffeeChatIdAndId(Long chatId, Long Id);
     boolean existsByCoffeeChatIdAndChatNickname(Long chatId, String chatNickname);
 }

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/ChatService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/ChatService.java
@@ -129,8 +129,9 @@ public class ChatService {
 
             // CoffeeChatMember (메시지 보낸 사람) 엔티티 조회
             // userId와 coffeechatId를 이용해 해당 채팅방의 멤버를 찾습니다.
-            CoffeeChatMember sender = coffeeChatMemberRepository.findByCoffeeChatIdAndUserId(Long.valueOf(coffeechatId), Long.valueOf(senderId))
+            CoffeeChatMember sender = coffeeChatMemberRepository.findByCoffeeChatIdAndId(Long.valueOf(coffeechatId), Long.valueOf(senderId))
                 .orElseThrow(() -> new IllegalArgumentException("Sender (CoffeeChatMember) not found for user ID: " + senderId + " in chat ID: " + coffeechatId));
+
             sender.getId();
 
             //RDB에 메시지 저장

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatMemberService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatMemberService.java
@@ -29,8 +29,8 @@ public class CoffeeChatMemberService {
         if (memberOpt.isPresent()) {
             return CoffeeChatMembershipCheckResponse.builder()
                     .isMember(true)
-//                    .memberId(String.valueOf(memberOpt.get().getId()))
-                    .memberId(String.valueOf(userId))
+                    .userId(String.valueOf(userId))
+                    .memberId(String.valueOf(memberOpt.get().getId()))
                     .build();
         } else {
             return CoffeeChatMembershipCheckResponse.builder()

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatService.java
@@ -113,7 +113,7 @@ public class CoffeeChatService {
     }
 
     @Transactional
-    public CoffeeChatJoinResponse join(Long userId, Long coffeechatId, CoffeeChatJoinRequest request) {
+    public CoffeeChatJoinResponse join(Long userId, Long coffeechatId, CoffeeChatJoinRequest request, Boolean isHost) {
         log.info("[CoffeeChatService.join] 커피챗 참여 요청: userId={}, chatId={}", userId, coffeechatId);
 
         User user = userRepository.findById(userId)
@@ -148,7 +148,7 @@ public class CoffeeChatService {
                 user,
                 request.chatNickname(),
                 profileImageUrl,
-                false
+                isHost
         );
         chat.addMember(member);
 


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] 방장 정보가 커피챗 생성 간 적용되도록 수정

## 🛠 변경사항
- memberId를 기준으로 방장으로 설정하고 있기 때문에 이전에 삭제했던 memberid에 대한 부분을 DTO에 추가 반영

    커피챗 생성, 가입 기준으로 host 정보가 true/false로 설정되어야 하는데 이전 구현에서는 join() 메서드에서 멤버가 추가됨에 따라 무조건적으로 isHost 필드가 false로 설정되었음. 이에 createCoffeeChat()에서 호출되는지 joinCoffeeChat() 에서 호출되는지 판단하기 위한 Boolean 파라미터 isHost 를 추가했습니다.

## 💬 리뷰 요구사항
- 코멘트 남겨주세요

## 🔍 테스트 방법(선택)
- FE 연동을 통한 로컬 환경에서 테스트 진행
