### PR TITLE
[FEAT] 커피챗 검열 기능 구현

### DIFF
--- a/docs/text-censorship-filter-guide.md  
+++ b/docs/text-censorship-filter-guide.md  
@@ -1,0 +1,107 @@
+# TextCensorshipFilter 사용 매뉴얼
+
+## 1. 목적
+
+`TextCensorshipFilter`는 **서비스 내 사용자가 작성하는 모든 텍스트에 대해 비속어 및 유해 표현을 필터링**하기 위한 공통 유틸 클래스입니다.
+
+검열 방식은 정책에 따라 다르게 설정할 수 있으며, 확장성과 일관된 적용을 위해 글로벌 영역에서 관리됩니다.
+
+---
+
+## 2. 필터 구성
+
+```java
+// 경로: com.ktb.cafeboo.global.censorship
+
+TextCensorshipFilter          // 통합 필터 관리 클래스
+├── TrieCensorshipFilter     // 금칙어 리스트 기반 사전 필터 (빠름)
+├── AiCensorshipFilter       // 문맥 기반 인공지능 검열 (정확도↑, 비용↑)
+
+```
+
+---
+
+## 3. 전략 설정 방식
+
+```java
+public enum CensorshipStrategy {
+    TRIE_ONLY,       // Trie 기반 필터만 사용 (기본)
+    AI_ONLY,         // AI 기반 필터만 사용
+    BOTH             // Trie + AI 모두 사용 (권장)
+}
+```
+
+- 전략은 **위치별로 다르게 설정 가능**합니다.
+
+    예를 들어, 채팅 메시지는 BOTH, 닉네임은 TRIE_ONLY 등.
+
+
+---
+
+## 4. 필터 사용 예시
+
+```java
+@Autowired
+private TextCensorshipFilter textCensorshipFilter;
+
+public void validateNickname(String nickname) {
+    boolean containsBadWord = textCensorshipFilter.containsBadWord(nickname, CensorshipStrategy.TRIE_ONLY);
+    if (containsBadWord) {
+        throw new CustomApiException(ErrorStatus.COFFEECHAT_NICKNAME_PROFANITY_NOT_ALLOWED);
+    }
+}
+
+```
+
+```java
+public void validateChatMessage(String message) {
+    boolean containsBadWord = textCensorshipFilter.containsBadWord(message, CensorshipStrategy.BOTH);
+    if (containsBadWord) {
+        throw new CustomApiException(ErrorStatus.COFFEECHAT_NICKNAME_PROFANITY_NOT_ALLOWED);
+    }
+}
+
+```
+
+---
+
+## 5. 적용 위치별 권장 전략
+
+| 적용 위치 | 검열 전략 (`CensorshipStrategy`) | 설명 |
+| --- | --- | --- |
+| 실시간 채팅 메시지 | `BOTH` | 빠른 반응 + 문맥 인식 필요 |
+| 커피챗 제목 | `TRIE_ONLY` | 문맥 인식 필요 |
+| 커피챗 본문 | `BOTH` | 노출 빈도 높고 서비스 신뢰도에 영향 |
+| 후기 작성 | `AI_ONLY` | 문장 단위 검열 중심 |
+| 닉네임/별명 | `TRIE_ONLY` | 간단한 문자열 필터로 충분 |
+
+---
+
+## 6. 금칙어 관리 방법
+
+- **저장 위치**: AWS S3 버킷 내 금칙어 텍스트 파일 (key: `cafeboo/text-file/text-censorship-keywords.txt`)
+- **파일 형식**: 각 줄마다 한 단어씩 작성된 `.txt` 파일
+- **로딩 방식**:
+  - 애플리케이션 실행 시 `TrieCensorshipFilter`에서 자동으로 S3에서 파일을 불러와 Trie에 로딩
+- **관리 방법**:
+  - 금칙어 파일을 업데이트할 경우, S3의 해당 경로에 파일을 다시 업로드하면 다음 애플리케이션 실행 시 반영됨
+  - (필요시 실시간 로딩/캐시 무효화 로직 구현 가능)
+
+---
+
+## 7. 커스텀 필터 추가 시
+
+- `TextCensorshipFilter`에 `CensorshipStrategy` 확장 가능
+- 새로운 필터 로직 추가 시, 아래 메서드를 수정하세요:
+
+```java
+public boolean containsBadWord(String text, CensorshipStrategy strategy) {
+    return switch (strategy) {
+        case TRIE_ONLY -> trieFilter.contains(text);
+        case AI_ONLY -> aiFilter.contains(text);
+        case BOTH -> trieFilter.contains(text) || aiFilter.contains(text);
+    };
+}
+```
+
+---

--- a/src/main/java/com/ktb/cafeboo/global/censorship/CensorshipStrategy.java
+++ b/src/main/java/com/ktb/cafeboo/global/censorship/CensorshipStrategy.java
@@ -1,0 +1,5 @@
+package com.ktb.cafeboo.global.censorship;
+
+public enum CensorshipStrategy {
+    TRIE_ONLY, AI_ONLY, BOTH
+}

--- a/src/main/java/com/ktb/cafeboo/global/censorship/TextCensorshipFilter.java
+++ b/src/main/java/com/ktb/cafeboo/global/censorship/TextCensorshipFilter.java
@@ -1,0 +1,21 @@
+package com.ktb.cafeboo.global.censorship;
+
+import com.ktb.cafeboo.global.censorship.filters.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TextCensorshipFilter {
+
+    private final TrieCensorshipFilter trieFilter;
+    private final AiCensorshipFilter aiFilter;
+
+    public boolean containsBadWord(String text, CensorshipStrategy strategy) {
+        return switch (strategy) {
+            case TRIE_ONLY -> trieFilter.contains(text);
+            case AI_ONLY -> aiFilter.contains(text);
+            case BOTH -> trieFilter.contains(text) || aiFilter.contains(text);
+        };
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/global/censorship/filters/AiCensorshipFilter.java
+++ b/src/main/java/com/ktb/cafeboo/global/censorship/filters/AiCensorshipFilter.java
@@ -1,0 +1,35 @@
+package com.ktb.cafeboo.global.censorship.filters;
+
+import com.ktb.cafeboo.global.infra.ai.client.AiServerClient;
+import com.ktb.cafeboo.global.infra.ai.dto.ToxicityDetectionRequest;
+import com.ktb.cafeboo.global.infra.ai.dto.ToxicityDetectionResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AiCensorshipFilter {
+
+    private final AiServerClient aiServerClient;
+
+    public boolean contains(String text) {
+        try {
+            ToxicityDetectionRequest request = ToxicityDetectionRequest.builder()
+                    .userInput(text)
+                    .build();
+
+            ToxicityDetectionResponse response = aiServerClient.detectToxicity(request);
+
+            log.info("[AiCensorshipFilter] AI 응답: status={}, is_toxic={}", response.getStatus(), response.getIsToxic());
+
+            // is_toxic == 0 → 유해
+            return response.getIsToxic() == 0;
+
+        } catch (Exception e) {
+            log.error("[AiCensorshipFilter] AI 검열 호출 실패", e);
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/global/censorship/filters/TrieCensorshipFilter.java
+++ b/src/main/java/com/ktb/cafeboo/global/censorship/filters/TrieCensorshipFilter.java
@@ -1,0 +1,65 @@
+package com.ktb.cafeboo.global.censorship.filters;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.ktb.cafeboo.global.infra.s3.S3Downloader;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TrieCensorshipFilter {
+
+    private final S3Downloader s3Downloader;
+
+    @Value("${censorship.trie.filename}")
+    private String filename;
+
+    private final TrieNode root = new TrieNode();
+
+    @PostConstruct
+    public void init() {
+        try {
+            List<String> keywords = s3Downloader.downloadKeywordLines(filename);
+            keywords.forEach(this::insert);
+            log.info("[TrieCensorshipFilter] 금칙어 {}개 로딩 완료", keywords.size());
+        } catch (Exception e) {
+            log.error("[TrieCensorshipFilter] 금칙어 로딩 실패", e);
+        }
+    }
+
+    public boolean contains(String text) {
+        for (int i = 0; i < text.length(); i++) {
+            TrieNode node = root;
+            for (int j = i; j < text.length(); j++) {
+                char c = text.charAt(j);
+                node = node.children.get(c);
+                if (node == null) break;
+                if (node.isEnd) {
+                    log.info("[TrieCensorshipFilter] 금칙어 감지: '{}'", text.substring(i, j + 1));
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private void insert(String word) {
+        TrieNode node = root;
+        for (char c : word.toCharArray()) {
+            node = node.children.computeIfAbsent(c, k -> new TrieNode());
+        }
+        node.isEnd = true;
+    }
+
+    private static class TrieNode {
+        Map<Character, TrieNode> children = new HashMap<>();
+        boolean isEnd = false;
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/global/infra/ai/client/AiServerClient.java
+++ b/src/main/java/com/ktb/cafeboo/global/infra/ai/client/AiServerClient.java
@@ -6,7 +6,9 @@ import com.ktb.cafeboo.global.infra.ai.dto.PredictCaffeineLimitByRuleRequest;
 import com.ktb.cafeboo.global.infra.ai.dto.PredictCaffeineLimitByRuleResponse;
 import com.ktb.cafeboo.global.infra.ai.dto.PredictCanIntakeCaffeineRequest;
 import com.ktb.cafeboo.global.infra.ai.dto.PredictCanIntakeCaffeineResponse;
-import java.util.List;
+import com.ktb.cafeboo.global.infra.ai.dto.ToxicityDetectionRequest;
+import com.ktb.cafeboo.global.infra.ai.dto.ToxicityDetectionResponse;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -46,6 +48,16 @@ public class AiServerClient {
             .retrieve()
             .bodyToMono(CreateWeeklyAnalysisResponse.class)
             .block();
+    }
+
+    public ToxicityDetectionResponse detectToxicity(ToxicityDetectionRequest request) {
+        return aiServerWebClient.post()
+                .uri("/internal/ai/toxicity_detect")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(request)
+                .retrieve()
+                .bodyToMono(ToxicityDetectionResponse.class)
+                .block();
     }
 }
 

--- a/src/main/java/com/ktb/cafeboo/global/infra/ai/dto/ToxicityDetectionRequest.java
+++ b/src/main/java/com/ktb/cafeboo/global/infra/ai/dto/ToxicityDetectionRequest.java
@@ -1,0 +1,13 @@
+package com.ktb.cafeboo.global.infra.ai.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ToxicityDetectionRequest {
+
+    @JsonProperty("user_input")
+    private final String userInput;
+}

--- a/src/main/java/com/ktb/cafeboo/global/infra/ai/dto/ToxicityDetectionResponse.java
+++ b/src/main/java/com/ktb/cafeboo/global/infra/ai/dto/ToxicityDetectionResponse.java
@@ -1,0 +1,12 @@
+package com.ktb.cafeboo.global.infra.ai.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class ToxicityDetectionResponse {
+    private String status;
+    private String message;
+    @JsonProperty("is_toxic")
+    private int isToxic;
+}

--- a/src/main/java/com/ktb/cafeboo/global/infra/s3/S3Downloader.java
+++ b/src/main/java/com/ktb/cafeboo/global/infra/s3/S3Downloader.java
@@ -1,0 +1,49 @@
+package com.ktb.cafeboo.global.infra.s3;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class S3Downloader {
+
+    private final S3Client s3Client;
+    private final S3Properties s3Properties;
+
+    public List<String> downloadKeywordLines(String filename) {
+        String fullKey = s3Properties.getDir() + "/text-file/" + filename;
+        log.info("[S3Downloader] 요청한 S3 Key: {}", fullKey);
+
+        try {
+            GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                    .bucket(s3Properties.getBucket())
+                    .key(fullKey)
+                    .build();
+
+            try (ResponseInputStream<GetObjectResponse> s3Object = s3Client.getObject(getObjectRequest);
+                 BufferedReader reader = new BufferedReader(new InputStreamReader(s3Object, StandardCharsets.UTF_8))) {
+
+                return reader.lines()
+                        .map(String::trim)
+                        .filter(line -> !line.isEmpty())
+                        .collect(Collectors.toList());
+            }
+
+        } catch (Exception e) {
+            log.error("[S3Downloader] 금칙어 파일 다운로드 실패 - filename: {}, 이유: {}", filename, e.getMessage(), e);
+            throw new RuntimeException("S3에서 키워드 파일 다운로드 실패", e);
+        }
+    }
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -39,3 +39,6 @@ logging.level.com.example.cafeboo=DEBUG
 # Health Check, Monitoring
 management.endpoints.web.exposure.include=health,prometheus
 management.endpoint.health.show-details=always
+
+# censorship
+censorship.trie.filename: text-censorship-keywords.txt

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -40,3 +40,6 @@ logging.level.com.example.cafeboo=DEBUG
 # Health Check, Monitoring
 management.endpoints.web.exposure.include=health,prometheus
 management.endpoint.health.show-details=always
+
+# censorship
+censorship.trie.filename: text-censorship-keywords.txt

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -55,3 +55,6 @@ cloud.aws.region.static-region=ap-northeast-2
 # Image
 spring.servlet.multipart.max-file-size=5MB
 spring.servlet.multipart.max-request-size=20MB
+
+# censorship
+censorship.trie.filename: text-censorship-keywords.txt


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] 공통 텍스트 검열 기능 도입 
- [x] Trie 기반 금칙어 사전 필터링 구현
- [x] AI 기반 문맥 검열 필터 연동 

## 🛠 변경사항
- `CensorshipStrategy` enum 추가
- `TrieCensorshipFilter` 구현 및 S3 키워드 로딩 적용
- `AiCensorshipFilter` 구현 (AI 서버 연동)

## 💬 리뷰 요구사항
- 현재 기능 구현을 해두었고 각 서비스에 호출해서 사용하면 됩니다.
- `docs/text-censorship-filter-guide.md` 경로에 사용 메뉴얼을 첨부해두었습니다. 
읽어 보시고, 사용법이 헷갈리다면 말씀주세요. 빠르게 적용하기 위해 검열 적용할 부분을 나누어 맡아서 적용해도 좋을 것 같습니다.
- [메뉴얼 노션으로 보기](https://www.notion.so/TextCensorshipFilter-213b43be904c8056be7ff54159d88c3f)

## 🔍 테스트 방법(선택)
- 전략을 번갈아 선택해가며 모두 각각의 필터가 정상 수행됨을 확인

closed: #159, #160
