### PR TITLE
[FEAT] 커피챗 리뷰 목록 및 상세 응답에 좋아요 여부(liked) 필드 추가

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatReviewController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatReviewController.java
@@ -50,7 +50,7 @@ public class CoffeeChatReviewController {
         Long chatId = Long.parseLong(coffeechatId);
         log.info("[GET /coffee-chats/reviews/{}] 후기 상세 조회 요청 - userId: {}", chatId, userId);
 
-        CoffeeChatReviewResponse response = coffeeChatReviewService.getReviewByCoffeeChatId(chatId);
+        CoffeeChatReviewResponse response = coffeeChatReviewService.getReviewByCoffeeChatId(userId, chatId);
 
         return ResponseEntity.ok(
                 ApiResponse.of(SuccessStatus.COFFEECHAT_REVIEW_LOAD_SUCCESS, response)

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatReviewResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatReviewResponse.java
@@ -11,5 +11,6 @@ public record CoffeeChatReviewResponse(
         List<String> tags,
         String address,
         int likeCount,
+        boolean liked,
         List<ReviewDto> reviews
 ) {}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/common/CoffeeChatReviewPreviewDto.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/common/CoffeeChatReviewPreviewDto.java
@@ -10,16 +10,18 @@ public record CoffeeChatReviewPreviewDto(
         List<String> tags,
         String address,
         int likesCount,
+        boolean liked,
         int imagesCount,
         String previewImageUrl
 ) {
-    public static CoffeeChatReviewPreviewDto from(CoffeeChat coffeeChat, int imagesCount, String previewImageUrl) {
+    public static CoffeeChatReviewPreviewDto from(CoffeeChat coffeeChat, int imagesCount, String previewImageUrl, boolean liked) {
         return new CoffeeChatReviewPreviewDto(
                 coffeeChat.getId().toString(),
                 coffeeChat.getName(),
                 coffeeChat.getTagNames(),
                 coffeeChat.getAddress(),
                 coffeeChat.getLikesCount(),
+                liked,
                 imagesCount,
                 previewImageUrl
         );

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/repository/CoffeeChatLikeRepository.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/repository/CoffeeChatLikeRepository.java
@@ -1,6 +1,7 @@
 package com.ktb.cafeboo.domain.coffeechat.repository;
 
 import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatLike;
+import com.ktb.cafeboo.global.enums.CoffeeChatLikeStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -8,4 +9,6 @@ import java.util.Optional;
 public interface CoffeeChatLikeRepository extends JpaRepository<CoffeeChatLike, Long> {
 
     Optional<CoffeeChatLike> findByCoffeeChatIdAndUserId(Long coffeeChatId, Long userId);
+
+    boolean existsByCoffeeChatIdAndUserIdAndStatus(Long coffeeChatId, Long userId, CoffeeChatLikeStatus status);
 }

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatLikeService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatLikeService.java
@@ -55,4 +55,13 @@ public class CoffeeChatLikeService {
 
         return new CoffeeChatReviewLikeResponse(liked, coffeeChat.getLikesCount());
     }
+
+    @Transactional(readOnly = true)
+    public boolean hasLiked(Long userId, Long coffeeChatId) {
+        return coffeeChatLikeRepository.existsByCoffeeChatIdAndUserIdAndStatus(
+                coffeeChatId,
+                userId,
+                CoffeeChatLikeStatus.ACTIVE
+        );
+    }
 }

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatReviewService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatReviewService.java
@@ -42,6 +42,7 @@ public class CoffeeChatReviewService {
     private final CoffeeChatRepository coffeeChatRepository;
     private final CoffeeChatReviewRepository coffeeChatReviewRepository;
     private final CoffeeChatMemberRepository coffeeChatMemberRepository;
+    private final CoffeeChatLikeService coffeeChatLikeService;
     private final S3Uploader s3Uploader;
 
     @Transactional
@@ -131,7 +132,9 @@ public class CoffeeChatReviewService {
                             .map(r -> r.getImages().get(0).getImageUrl())
                             .orElse(null);
 
-                    return CoffeeChatReviewPreviewDto.from(chat, totalImageCount, previewImageUrl);
+                    boolean liked = coffeeChatLikeService.hasLiked(userId, chat.getId());
+
+                    return CoffeeChatReviewPreviewDto.from(chat, totalImageCount, previewImageUrl, liked);
                 })
                 .toList();
 
@@ -142,7 +145,7 @@ public class CoffeeChatReviewService {
         );
     }
 
-    public CoffeeChatReviewResponse getReviewByCoffeeChatId(Long coffeeChatId) {
+    public CoffeeChatReviewResponse getReviewByCoffeeChatId(Long userId, Long coffeeChatId) {
         CoffeeChat coffeeChat = coffeeChatRepository.findWithDetailsById(coffeeChatId)
                 .orElseThrow(() -> new CustomApiException(ErrorStatus.COFFEECHAT_NOT_FOUND));
 
@@ -162,6 +165,8 @@ public class CoffeeChatReviewService {
                 ))
                 .toList();
 
+        boolean liked = coffeeChatLikeService.hasLiked(userId, coffeeChat.getId());
+
         return new CoffeeChatReviewResponse(
                 String.valueOf(coffeeChat.getId()),
                 coffeeChat.getName(),
@@ -169,6 +174,7 @@ public class CoffeeChatReviewService {
                 coffeeChat.getTagNames(),
                 coffeeChat.getAddress(),
                 coffeeChat.getLikesCount(),
+                liked,
                 reviewDtos
         );
     }


### PR DESCRIPTION

# 📌 Pull Request

## ✨ 작업한 내용
- [x] 커피챗 리뷰 목록 및 상세 조회 응답에 `liked` 필드 추가

## 🛠 변경사항
- 사용자가 해당 커피챗 리뷰에 좋아요를 눌렀는지 여부를 판단하기 위한 liked 필드 도입
- CoffeeChatReviewPreviewDto, CoffeeChatDetailResponse 등 응답 DTO에 liked 포함
- CoffeeChatLikeService.hasLiked(userId, coffeeChatId) 메서드 구현 및 응답 구성 시 활용

## 💬 리뷰 요구사항
- 유저의 좋아요 여부 판단 시, 특정 서비스가 직접 레포지토리에 접근하지 않고 `CoffeeChatLikeService.hasLiked`를 활용한 구조가 적절한지 검토 부탁드립니다.


## 🔍 테스트 방법(선택)
- 포스트맨
