### PR TITLE
[FEAT] 검열- 화이트리스트(예외어) 로직 도입

### DIFF
--- a/src/main/java/com/ktb/cafeboo/global/censorship/controller/CensorshipTestController.java
+++ b/src/main/java/com/ktb/cafeboo/global/censorship/controller/CensorshipTestController.java
@@ -1,0 +1,23 @@
+package com.ktb.cafeboo.global.censorship.controller;
+
+import com.ktb.cafeboo.global.censorship.filters.TrieCensorshipFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.*;
+
+@Profile({"local", "dev"})
+@RestController
+@RequestMapping("/internal/censorship")
+@RequiredArgsConstructor
+public class CensorshipTestController {
+
+    private final TrieCensorshipFilter censorshipFilter;
+
+    @GetMapping("/check")
+    public String checkText(@RequestParam String text) {
+        boolean contains = censorshipFilter.contains(text);
+        return contains
+                ? String.format("⚠️ 금칙어가 포함되어 있습니다: \"%s\"", text)
+                : String.format("✅ 금칙어가 포함되어 있지 않습니다: \"%s\"", text);
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/global/censorship/filters/TrieCensorshipFilter.java
+++ b/src/main/java/com/ktb/cafeboo/global/censorship/filters/TrieCensorshipFilter.java
@@ -18,31 +18,63 @@ public class TrieCensorshipFilter {
 
     private final S3Downloader s3Downloader;
 
-    @Value("${censorship.trie.filename}")
-    private String filename;
+    @Value("${censorship.blacklist-filename}")
+    private String blacklistFilename;
 
-    private final TrieNode root = new TrieNode();
+    @Value("${censorship.whitelist-filename}")
+    private String whitelistFilename;
+
+    private final TrieNode blacklistRoot = new TrieNode();
+    private final TrieNode whitelistRoot = new TrieNode();
 
     @PostConstruct
     public void init() {
         try {
-            List<String> keywords = s3Downloader.downloadKeywordLines(filename);
-            keywords.forEach(this::insert);
-            log.info("[TrieCensorshipFilter] 금칙어 {}개 로딩 완료", keywords.size());
+            List<String> blackList = s3Downloader.downloadKeywordLines(blacklistFilename);
+            List<String> whiteList = s3Downloader.downloadKeywordLines(whitelistFilename);
+
+            blackList.forEach(word -> insert(word, blacklistRoot));
+            whiteList.forEach(word -> insert(word, whitelistRoot));
+
+            log.info("[TrieCensorshipFilter] 블랙리스트 {}개, 화이트리스트 {}개 로딩 완료", blackList.size(), whiteList.size());
         } catch (Exception e) {
-            log.error("[TrieCensorshipFilter] 금칙어 로딩 실패", e);
+            log.error("[TrieCensorshipFilter] 금칙어/예외어 로딩 실패", e);
         }
     }
 
     public boolean contains(String text) {
         for (int i = 0; i < text.length(); i++) {
-            TrieNode node = root;
+            TrieNode node = blacklistRoot;
             for (int j = i; j < text.length(); j++) {
                 char c = text.charAt(j);
                 node = node.children.get(c);
                 if (node == null) break;
                 if (node.isEnd) {
-                    log.info("[TrieCensorshipFilter] 금칙어 감지: '{}'", text.substring(i, j + 1));
+                    String detected = text.substring(i, j + 1);
+                    if (!isWhitelisted(detected, text)) {
+                        log.info("[TrieCensorshipFilter] 금칙어 감지: '{}'", detected);
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    private boolean search(String word, TrieNode root) {
+        TrieNode node = root;
+        for (char c : word.toCharArray()) {
+            node = node.children.get(c);
+            if (node == null) return false;
+        }
+        return node.isEnd;
+    }
+
+    private boolean isWhitelisted(String detected, String text) {
+        for (int i = 0; i <= text.length() - detected.length(); i++) {
+            for (int j = i + detected.length(); j <= text.length(); j++) {
+                String candidate = text.substring(i, j);
+                if (candidate.contains(detected) && search(candidate, whitelistRoot)) {
                     return true;
                 }
             }
@@ -50,7 +82,7 @@ public class TrieCensorshipFilter {
         return false;
     }
 
-    private void insert(String word) {
+    private void insert(String word, TrieNode root) {
         TrieNode node = root;
         for (char c : word.toCharArray()) {
             node = node.children.computeIfAbsent(c, k -> new TrieNode());

--- a/src/main/java/com/ktb/cafeboo/global/config/SecurityConfig.java
+++ b/src/main/java/com/ktb/cafeboo/global/config/SecurityConfig.java
@@ -45,7 +45,8 @@ public class SecurityConfig {
             new AntPathRequestMatcher("/webjars/**"), // SockJS, STOMP.js가 webjars를 통해 제공된다면 필요// 웹소켓 엔드포인트
             new AntPathRequestMatcher("/api/chat/**"),
             new AntPathRequestMatcher("/api/chatrooms/**"),
-            new AntPathRequestMatcher("/chatrooms/{roomId}/member") // 테스트용
+            new AntPathRequestMatcher("/chatrooms/{roomId}/member"), // 테스트용
+            new AntPathRequestMatcher("/internal/censorship/check")
         );
 
         http

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -41,4 +41,5 @@ management.endpoints.web.exposure.include=health,prometheus
 management.endpoint.health.show-details=always
 
 # censorship
-censorship.trie.filename: text-censorship-keywords.txt
+censorship.blacklist-filename: censorship-blacklist-keywords.txt
+censorship.whitelist-filename: censorship-whitelist-keywords.txt

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -42,4 +42,5 @@ management.endpoints.web.exposure.include=health,prometheus
 management.endpoint.health.show-details=always
 
 # censorship
-censorship.trie.filename: text-censorship-keywords.txt
+censorship.blacklist-filename: censorship-blacklist-keywords.txt
+censorship.whitelist-filename: censorship-whitelist-keywords.txt

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -57,4 +57,5 @@ spring.servlet.multipart.max-file-size=5MB
 spring.servlet.multipart.max-request-size=20MB
 
 # censorship
-censorship.trie.filename: text-censorship-keywords.txt
+censorship.blacklist-filename: censorship-blacklist-keywords.txt
+censorship.whitelist-filename: censorship-whitelist-keywords.txt

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -59,3 +59,6 @@ spring.servlet.multipart.max-request-size=20MB
 # censorship
 censorship.blacklist-filename: censorship-blacklist-keywords.txt
 censorship.whitelist-filename: censorship-whitelist-keywords.txt
+
+# Profile
+spring.profiles.active=local


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] Trie 기반 금칙어 필터에 화이트리스트(예외어) 기능 추가
- [x] 검열 필터 동작을 간편히 테스트할 수 있도록 내부 테스트용 API 컨트롤러 추가

## 🛠 변경사항
- 화이트리스트 전용 Trie 트리 구조 도입 및 isWhitelisted() 로직 추가
- S3에서 화이트리스트 키워드 파일 별도 로딩 (censorship.whitelist-filename)
-` /internal/censorship/check` API 구현 (GET 방식, 토큰 없이 사용 가능)

## 💬 리뷰 요구사항


## 🔍 테스트 방법(선택)
-  로컬/개발 환경에서 `GET /internal/censorship/check?text=검열대상` API를 활용하여 트라이 검열을 테스팅할 수 있습니다.

<img width="734" alt="image" src="https://github.com/user-attachments/assets/30a0981b-025d-4ee6-8fd3-f4e811e24137" />


closed: #187 