### PR TITLE
[FIX] 커피챗 참여 조회 시, 채팅 닉네임 포함하도록 수정

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatMembershipCheckResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatMembershipCheckResponse.java
@@ -6,5 +6,6 @@ import lombok.Builder;
 public record CoffeeChatMembershipCheckResponse(
         boolean isMember,
         String userId,
-        String memberId
+        String memberId,
+        String chatNickname
 ) {}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatMemberService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatMemberService.java
@@ -31,6 +31,7 @@ public class CoffeeChatMemberService {
                     .isMember(true)
                     .userId(String.valueOf(userId))
                     .memberId(String.valueOf(memberOpt.get().getId()))
+                    .chatNickname(memberOpt.get().getChatNickname())
                     .build();
         } else {
             return CoffeeChatMembershipCheckResponse.builder()


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] 커피챗 참여 조회 API 응답 DTO에 채팅 닉네임(chatNickname) 필드를 추가
- [x] `user_id` 만으로 특정 채팅에서 사용하는 닉네임 조회가 안된점 수정 

## 🛠 변경사항
- `CoffeeChatMembershipCheckResponse` dto에 `chatNickname` 필드 추가
- 응답 생성 빌더 호출시, 해당 필드 반환하도록 서비스 로직 수정

## 💬 리뷰 요구사항
- x

## 🔍 테스트 방법(선택)
- Postman
`chatNickname` 필드가 정상적으로 포함됨을 확인
<img width="711" alt="image" src="https://github.com/user-attachments/assets/5c635c73-b3eb-45ce-8adc-560f41cc80bb" />

