### PR TITLE
[FIX] 채팅 기능 오류 수정

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/common/MessageDto.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/common/MessageDto.java
@@ -7,6 +7,6 @@ public record MessageDto(
         String messageId,
         MemberDto sender,
         String content,
-        MessageType type,
+        MessageType messageType,
         LocalDateTime sentAt
 ) {}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/common/MessageDto.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/common/MessageDto.java
@@ -1,10 +1,12 @@
 package com.ktb.cafeboo.domain.coffeechat.dto.common;
 
+import com.ktb.cafeboo.global.enums.MessageType;
 import java.time.LocalDateTime;
 
 public record MessageDto(
         String messageId,
         MemberDto sender,
         String content,
+        MessageType type,
         LocalDateTime sentAt
 ) {}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChatMessage.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChatMessage.java
@@ -20,7 +20,7 @@ public class CoffeeChatMessage extends BaseEntity {
     private CoffeeChat coffeeChat;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
+    @JoinColumn(name = "member_id", nullable = true)
     private CoffeeChatMember sender;
 
     @Column(name = "content", nullable = false, length = 300)

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/ChatService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/ChatService.java
@@ -122,13 +122,13 @@ public class ChatService {
         Map<String, String> messageMap = new HashMap<>();
 
         try{
-//            String content = message.getMessage();
-//            Boolean filterResult = textCensorshipFilter.containsBadWord(content, CensorshipStrategy.BOTH);
-//
-//            if(filterResult){
-//                log.info("[ChatService.handleMessage()] - 사용자 {} 가 보낸 메시지가 비속적 표현을 포함하고 있습니다", message.getSenderId());
-//                return;
-//            }
+            String content = message.getMessage();
+            Boolean filterResult = textCensorshipFilter.containsBadWord(content, CensorshipStrategy.BOTH);
+
+            if(filterResult){
+                log.info("[ChatService.handleMessage()] - 사용자 {} 가 보낸 메시지가 비속적 표현을 포함하고 있습니다", message.getSenderId());
+                return;
+            }
 
             String senderId = message.getSenderId();
             String coffeechatId = message.getCoffeechatId();

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatMessageService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatMessageService.java
@@ -66,6 +66,7 @@ public class CoffeeChatMessageService {
                                     sender.isHost()
                             ),
                             m.getContent(),
+                            m.getType(),
                             m.getCreatedAt()
                     );
                 })

--- a/src/main/java/com/ktb/cafeboo/global/config/WebSocketConfig.java
+++ b/src/main/java/com/ktb/cafeboo/global/config/WebSocketConfig.java
@@ -15,7 +15,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         // 1. /topic으로 시작하는 메시지를 브로커가 처리하도록 설정 (Pub/Sub)
         // 2. /queue로 시작하는 메시지를 브로커가 처리하도록 설정 (개인 메시지)
         // Spring의 Simple Broker (인메모리) 사용. 실제 서비스에서는 Redis, Kafka, RabbitMQ 등의 외부 브로커 사용 권장.
-        config.enableSimpleBroker("/topic", "/queue").setHeartbeatValue(new long[] {10000, 10000});
+        config.enableSimpleBroker("/topic", "/queue").setHeartbeatValue(new long[] {10000, 0});
 
         // 클라이언트가 서버로 메시지를 보낼 때 사용할 접두사 (Controller로 라우팅됨)
         config.setApplicationDestinationPrefixes("/app");

--- a/src/main/java/com/ktb/cafeboo/global/config/WebSocketConfig.java
+++ b/src/main/java/com/ktb/cafeboo/global/config/WebSocketConfig.java
@@ -15,7 +15,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         // 1. /topic으로 시작하는 메시지를 브로커가 처리하도록 설정 (Pub/Sub)
         // 2. /queue로 시작하는 메시지를 브로커가 처리하도록 설정 (개인 메시지)
         // Spring의 Simple Broker (인메모리) 사용. 실제 서비스에서는 Redis, Kafka, RabbitMQ 등의 외부 브로커 사용 권장.
-        config.enableSimpleBroker("/topic", "/queue");
+        config.enableSimpleBroker("/topic", "/queue").setHeartbeatValue(new long[] {10000, 10000});
 
         // 클라이언트가 서버로 메시지를 보낼 때 사용할 접두사 (Controller로 라우팅됨)
         config.setApplicationDestinationPrefixes("/app");
@@ -30,6 +30,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         // 클라이언트가 http://localhost:8080/ws 로 연결 시도
         registry.addEndpoint("/ws")
             .setAllowedOriginPatterns("*") // 모든 Origin 허용 (CORS). 실제 운영에서는 특정 Origin만 허용해야 함
-            .withSockJS(); // WebSocket을 지원하지 않는 브라우저를 위해 SockJS fallback 활성화
+            .withSockJS()
+            .setDisconnectDelay(300 * 1000);
     }
 }


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] 검열 기능 활성화
- [x] 채팅방 메시지 출력 관련 부분에 대응하는 DTO 필드 추가
- [x] 채팅방 나가기 기능 수정

## 🛠 변경사항
- 로컬 환경에서 테스트 불가능했던 검열 기능을 활성화했습니다.
- 채팅방 메시지 출력

    기획 의도 상 이전 채팅 내역을 조회할 때 Message type이 'TALK', 'ENTER', 'LEAVE' 일 때 다른 방식으로 화면 상에 표시되어야 합니다.

    하지만 현재의 API 구현에서는 대화 내역 조회 간 Message type에 대해 구분할 수 있는 필드를 제공하지 않았습니다. 그렇기에 memberId를 기준으로 본인의 메시지라고 판단되면 messag type에 관계 없이 'TALK'에 해당되는 UI로 출력되는 문제가 존재했습니다.

    MessageDTO 필드에 MessageType enum 필드를 추가한 것으로 해당 문제를 해결할 수 있을 것이라 기대합니다.

- 채팅방 나가기

    채팅방 퇴장 기능 이용 시, 한 번이라도 채팅을 쳤던 이용자는 해당 채팅방에서 탈퇴하는 것이 불가능했습니다.

    이는 CoffeeeChatMember와 CoffeeChatMessage가 외래키를 통해 연결되어 발생하는 문제였습니다. CoffeeeChatMember 삭제 시 그와 연관된 CoffeeChatMessage는 CoffeeChatMember 필드에 null을 허용하지 않는 상황이고 이에 따라 외래키 제약 오류를 발생시킵니다.

    이에, null을 허용하는 방안으로 수정을 제안합니다.

## 💬 리뷰 요구사항
- 궁금하신 부분 코멘트로 남겨주세요

## 🔍 테스트 방법(선택)
- 로컬 환경에서 테스트. 
