### PR TITLE
[FIX] heartbeat 관련 스케쥴러 추가

### DIFF
--- a/src/main/java/com/ktb/cafeboo/global/config/WebSocketConfig.java
+++ b/src/main/java/com/ktb/cafeboo/global/config/WebSocketConfig.java
@@ -1,7 +1,10 @@
 package com.ktb.cafeboo.global.config;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
@@ -9,6 +12,15 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 @Configuration
 @EnableWebSocketMessageBroker // STOMP를 이용한 메시지 브로커 기능을 활성화
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    // TaskScheduler를 주입받을 필드 선언
+    private TaskScheduler messageBrokerTaskScheduler;
+
+    // TaskScheduler 주입 (순환 참조 방지를 위해 @Lazy 사용)
+    @Autowired
+    public void setMessageBrokerTaskScheduler(@Lazy TaskScheduler taskScheduler) {
+        this.messageBrokerTaskScheduler = taskScheduler;
+    }
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry config) {


### PR DESCRIPTION

# 📌 Pull Request

## ✨ 작업한 내용
- [x] heartbeat 관련 스케쥴러 추가

## 🛠 변경사항
- setHeartbeatValue: 클라이언트와 서버 간 Heartbeat 협상 값을 설정합니다. (예: new long[] {10000, 0})

    setTaskScheduler: Spring이 Heartbeat 메시지를 실제로 스케줄링하고 전송하기 위해 필요한 스케줄러 빈을 연결합니다. 이것이 없다면 setHeartbeatValue를 설정했더라도 Heartbeat 메시지가 실제로 오가지 않을 수 있습니다.

## 💬 리뷰 요구사항
- X

## 🔍 테스트 방법(선택)
- BE 로그 확인 후 추가
