### PR TITLE
[REFACTOR] 커피챗 생성 후 자동 참여 로직을 서비스 계층으로 이동

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatController.java
@@ -33,25 +33,12 @@ public class CoffeeChatController {
         Long userId = userDetails.getUserId();
         log.info("[POST /api/v1/coffee-chats] userId: {} 커피챗 생성 요청 수신", userId);
 
-        try{
-            CoffeeChatCreateResponse createResponse = coffeeChatService.create(userId, request);
-
-            Long coffeechatId = Long.valueOf(createResponse.coffeeChatId());
-            CoffeeChatJoinRequest joinRequest = new CoffeeChatJoinRequest(
-                request.chatNickname(),
-                request.profileImageType()
-            );
-
-            CoffeeChatJoinResponse joinResponse = coffeeChatService.join(
-                userDetails.getUserId(),
-                coffeechatId,
-                joinRequest,
-                true
-            );
+        try {
+            CoffeeChatCreateResponse response = coffeeChatService.create(userId, request);
 
             return ResponseEntity
                 .status(HttpStatus.CREATED)
-                .body(ApiResponse.of(SuccessStatus.COFFEECHAT_CREATE_SUCCESS, createResponse));
+                .body(ApiResponse.of(SuccessStatus.COFFEECHAT_CREATE_SUCCESS, response));
         } catch (Exception e) {
 
             log.error("[POST /api/v1/coffee-chats] 커피챗 생성 및 참여 중 오류 발생: {}", e.getMessage(), e);

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatService.java
@@ -63,13 +63,16 @@ public class CoffeeChatService {
                 .kakaoPlaceUrl(loc.kakaoPlaceUrl())
                 .build();
 
-        String profileImageUrl = (request.profileImageType() == ProfileImageType.DEFAULT)
-                ? s3Properties.getDefaultProfileImageUrl()
-                : user.getProfileImageUrl();
-
         CoffeeChat saved = coffeeChatRepository.save(chat);
 
         tagService.saveTagsToCoffeeChat(saved, request.tags());
+
+        // 생성자 본인 참여
+        CoffeeChatJoinRequest joinRequest = new CoffeeChatJoinRequest(
+                request.chatNickname(),
+                request.profileImageType()
+        );
+        this.join(userId, saved.getId(), joinRequest, true);
 
         return new CoffeeChatCreateResponse(saved.getId().toString());
     }
@@ -111,9 +114,6 @@ public class CoffeeChatService {
 
         return CoffeeChatDetailResponse.from(chat, userId);
     }
-
-    // 이거를 무조건 신규가입으로 생각하는게아니라, 연결접속리소스를 생성한다는 관점으로 보면 이 api에 사전에
-    // member 인지 아닌지 판단해서 해도 괜찮을 거 같긴해요
 
     @Transactional
     public CoffeeChatJoinResponse join(Long userId, Long coffeechatId, CoffeeChatJoinRequest request, Boolean isHost) {


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] 커피챗 생성 후 자동 참여 로직을 서비스 계층으로 이동
- [x] 컨트롤러는 요청 위임만 하도록 책임 최소화

## 🛠 변경사항
- 컨트롤러에서 커피챗 생성(create) 및 참여(join) 로직을 분리하여 처리하던 부분을 서비스 메서드로 통합
- 커피챗 생성과 동시에 참여가 하나의 트랜잭션으로 처리되도록 변경

## 💬 리뷰 요구사항
- 테스트 코드를 작성하는 과정에서, 컨트롤러가 커피챗 생성 후 참여까지 직접 수행하며 비즈니스 로직을 담당하고 있음을 알게 되어서 수정 진행하였습니다. 

## 🔍 테스트 방법(선택)
- postman 활용
