### PR TITLE
[FIX] FE 연동 간 발생한 필드명 차이 수정

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatMessageService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatMessageService.java
@@ -53,6 +53,7 @@ public class CoffeeChatMessageService {
         }
 
         List<MessageDto> messageDtos = messages.stream()
+                .filter(m -> m.getSender() != null)
                 .map(m -> {
                     CoffeeChatMember sender = m.getSender();
                     String profileImageUrl = sender.getProfileImageUrl();


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] 채팅 내역 조회 간 발생하는 500 에러 수정

## 🛠 변경사항
- 메시지 조회 시 leaveChat() 메서드 호출 시 퇴장하는 sender가 보낸 메시지는 전부 null로 설정되도록 했습니다.

    이 과정에서 컬럼에 null을 포함하는 데이터가 조회되며 500 에러가 발생했고 filtering을 통해 해당 데이터들은 조회되지 않도록 수정했습니다.

## 💬 리뷰 요구사항
- X

## 🔍 테스트 방법(선택)
- dev 서버에서 로그 분석 및 테스트 진행
