### PR TITLE
[FEAT] 테스트 관련 설정 및 파일 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.4.5'
 	id 'io.spring.dependency-management' version '1.1.7'
+	id 'jacoco'
 }
 
 group = 'com.ktb'
@@ -53,11 +54,63 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	// test
+	testImplementation 'com.h2database:h2'
+	testImplementation 'org.springframework.boot:spring-boot-test'
+	testImplementation 'org.mockito:mockito-inline:5.2.0'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
-tasks.named('test') {
+jacoco {
+	toolVersion = "0.8.13" // JaCoCo 도구 버전 (최신 안정 버전 사용 권장)
+}
+
+// jacocoTestReport 태스크 설정
+jacocoTestReport {
+	dependsOn test // jacocoTestReport가 test 태스크 이후에 실행되도록 의존성 설정
+
+	reports {
+		xml.required = true // XML 보고서 생성 여부 (CI/CD 도구에서 파싱할 때 유용)
+		html.required = true // HTML 보고서 생성 여부 (사람이 보기 좋음)
+		csv.required = false // CSV 보고서 생성 여부 (선택 사항)
+
+		// 보고서 저장 경로 설정 (선택 사항, 기본값: build/reports/jacoco/test/html)
+		// html.outputLocation = layout.buildDirectory.dir('jacocoHtml')
+	}
+
+	// 커버리지 보고서에 포함/제외할 파일 설정 (선택 사항, 중요!)
+	// 프로젝트 구조에 따라 수정해야 합니다.
+	afterEvaluate {
+		classDirectories.setFrom(files(classDirectories.files.collect {
+			fileTree(dir: it, exclude: [
+					'com/ktb/cafeboo/CafebooApplication.class', // 메인 애플리케이션 클래스는 보통 제외
+					'**/*Application.class', // 모든 Application 클래스 제외
+					'**/*Config.class', // 설정 클래스 제외 (선택 사항)
+					'**/*DTO.class', // DTO 클래스 제외 (선택 사항)
+					'**/*Response.class', // 응답 DTO 클래스 제외 (선택 사항)
+					'**/*Request.class', // 요청 DTO 클래스 제외 (선택 사항)
+					'**/*Exception.class', // 예외 클래스 제외 (선택 사항)
+					'**/*ErrorStatus.class', // 에러 상태 enum 제외 (선택 사항)
+					'**/*SuccessStatus.class',
+					'com/ktb/cafeboo/domain/**/dto/**',
+					'com/ktb/cafeboo/global/**/dto/**',
+					'**/*Test.class' // 테스트 클래스 자체는 커버리지에서 제외 (기본적으로 제외됨)
+			])
+		}))
+	}
+}
+
+test {
+	// ...
+	systemProperty 'spring.profiles.active', 'test' // 테스트 전용 프로파일 사용 (선택 사항)
+	systemProperty 'debug', 'true' // 디버그 모드 활성화
+	jvmArgs += [
+			"-XX:+EnableDynamicAgentLoading",
+			"-Djdk.instrument.traceUsage"
+	]
 	useJUnitPlatform()
+	finalizedBy jacocoTestReport
 }

--- a/src/main/java/com/ktb/cafeboo/global/config/SecurityConfig.java
+++ b/src/main/java/com/ktb/cafeboo/global/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
@@ -20,6 +21,7 @@ import java.util.List;
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
+@Profile("!test")
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;

--- a/src/main/java/com/ktb/cafeboo/global/config/WebClientConfig.java
+++ b/src/main/java/com/ktb/cafeboo/global/config/WebClientConfig.java
@@ -3,10 +3,16 @@ package com.ktb.cafeboo.global.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
 public class WebClientConfig {
+
+    @Bean
+    public WebClient webClient() {
+        return WebClient.builder().build();
+    }
 
     @Value("${ai.server.base-url}")
     private String aiServerBaseUrl;

--- a/src/test/java/com/ktb/cafeboo/CafebooApplicationTests.java
+++ b/src/test/java/com/ktb/cafeboo/CafebooApplicationTests.java
@@ -2,8 +2,10 @@ package com.ktb.cafeboo;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class CafebooApplicationTests {
 
 	@Test

--- a/src/test/java/com/ktb/cafeboo/global/config/TestSecurityConfig.java
+++ b/src/test/java/com/ktb/cafeboo/global/config/TestSecurityConfig.java
@@ -1,0 +1,24 @@
+package com.ktb.cafeboo.global.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@Profile("test")
+public class TestSecurityConfig {
+    @Bean
+    public SecurityFilterChain testSecurityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(auth -> auth
+                .anyRequest().permitAll()
+            );
+        return http.build();
+    }
+}


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] 테스트 관련 설정, 의존성 추가
- [x] 테스트 간 사용하는 config 파일 추가

## 🛠 변경사항
- 테스트 관련 설정 추가 
    테스트 커버리지를 확인할 수 있는 Jacoco와 mock 객체의 생성에 사용되는 mockito 관련 설정 의존성을 추가했습니다.

    테스트에서는 TestSecurityConfig를 사용하기 때문에 이에 맞춰 실행되는 test application의 active profile 설정을 test profile을 사용하도록 수정했습니다.

    SecurityConfig의 경우 테스트 과정에서 사용되지 않는 것을 의도했기에 test시 실행되지 않도록 profile 설정을 진행했습니다.

    WebClientConfig의 경우 테스트 과정에서 noSuchBeanException이 발생했고 이를 해결하기 위해 [@Bean](https://github.com/Bean) 애노테이션을 이용해 webClient Bean의 등록을 진행했습니다.

- 테스트 관련 config 파일 추
    Spring Security의 경우 유닛 테스트 환경에서 구성하기 어려운 부분이기에 유닛 테스트에서 사용할 Security config 관련 설정 파일을 추가했습니다.

## 💬 리뷰 요구사항
- 읽어 보고 코멘트 남겨주세요.

## 🔍 테스트 방법(선택)
- 로컬 환경에서 테스트 실행 후 build success 확인
