### PR TITLE
[FEAT] 검열 시 예외 처리 추가 및 에러 enum 추가

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/ChatController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/ChatController.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.ktb.cafeboo.domain.coffeechat.dto.StompMessage;
 import com.ktb.cafeboo.domain.coffeechat.service.ChatService;
 import com.ktb.cafeboo.domain.user.service.UserService;
+import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
 import jakarta.annotation.PostConstruct;
 import java.util.HashMap;
 import java.util.Map;
@@ -53,6 +54,10 @@ public class ChatController {
 
         try{
             chatService.handleNewMessage(roomId, chatMessage);
+        }
+        catch (CustomApiException e){
+            log.error("[ChatController.handleCoffeeChatMessage] - 메시지 전송 실패 - 검열");
+            messagingTemplate.convertAndSendToUser(headerAccessor.getSessionId(), "/queue/errors", "메시지 전송 실패: 부적절한 표현을 담은 메시지");
         }
         catch (JsonProcessingException e){
             log.error("[ChatController.handleCoffeeChatMessage] - 메시지 직렬화 실패 오류. roomId: {}, {}", roomId, e.getMessage());

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/ChatService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/ChatService.java
@@ -7,6 +7,8 @@ import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatMember;
 import com.ktb.cafeboo.domain.coffeechat.dto.StompMessage;
 import com.ktb.cafeboo.domain.coffeechat.repository.CoffeeChatMemberRepository;
 import com.ktb.cafeboo.domain.coffeechat.repository.CoffeeChatRepository;
+import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
+import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
 import com.ktb.cafeboo.global.censorship.CensorshipStrategy;
 import com.ktb.cafeboo.global.censorship.TextCensorshipFilter;
 import com.ktb.cafeboo.global.config.RedisConfig;
@@ -127,7 +129,7 @@ public class ChatService {
 
             if(filterResult){
                 log.info("[ChatService.handleMessage()] - 사용자 {} 가 보낸 메시지가 비속적 표현을 포함하고 있습니다", message.getSenderId());
-                return;
+                throw new CustomApiException(ErrorStatus.CENSORED_MESSAGE);
             }
 
             String senderId = message.getSenderId();

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/ErrorStatus.java
@@ -39,7 +39,11 @@ public enum ErrorStatus implements BaseCode {
     ALARM_SETTING_NOT_FOUND(404, "ALARM_SETTING_NOT_FOUND", "알림 설정 정보를 찾을 수 없습니다."),
 
     // 섭취 내역 관련 오류
+    INVALID_INTAKE_INFO(400, "INVALID_INTAKE_INFO", "필수 데이터 필드가 누락되었습니다"),
     INTAKE_INFO_NOT_FOUND(404, "INTAKE_INFO_NOT_FOUND", "섭취 내역을 찾을 수 없습니다."),
+    RESIDUAL_SAVE_ERROR(500, "RESIDUAL_SAVE_ERROR", "카페인 잔존량 데이터 저장에 실패했습니다. 다시 시도해주세요."),
+    INTAKE_DELETE_FAILED(500, "INTAKE_DELETE_FAILED", "섭취 내역 삭제에 실패했습니다. 다시 시도해주세요."),
+    INTAKE_UPDATE_FAILED(500, "INTAKE_UPDATE_FAILED", "섭취 내역 수정에 실패했습니다. 다시 시도해주세요."),
 
     // 음료 관련 오류
     DRINK_NOT_FOUND(404, "DRINK_NOT_FOUND", "음료 정보를 찾을 수 없습니다."),
@@ -68,6 +72,7 @@ public enum ErrorStatus implements BaseCode {
     CHAT_NICKNAME_ALREADY_EXISTS(409, "CHAT_NICKNAME_ALREADY_EXISTS", "이미 사용 중인 채팅방 닉네임입니다."),
     CANNOT_LEAVE_CHAT_OWNER(400, "CANNOT_LEAVE_CHAT_OWNER", "작성자는 채팅방에서 나갈 수 없습니다."),
     INVALID_CURSOR(400, "INVALID_CURSOR", "커서 값이 유효하지 않습니다."),
+    CENSORED_MESSAGE(403, "CENSORED_MESSAGE", "부적절한 표현을 담은 메시지"),
 
     // 커피챗 후기 관련
     INVALID_IMAGE_COUNT(400, "INVALID_IMAGE_COUNT", "이미지는 최대 3장까지만 첨부할 수 있습니다."),


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] 검열 시 예외 처리 추가
- [x] 에러 enum 추가

## 🛠 변경사항
- 현재 메시지 처리에서 메시지가 검열되는 경우 exception 등이 발생하지 않아 메시지가 보내지지 않았을 때 유저가 어떠한 이유로 보내지지 않았는지 식별하기가 어려운 상황이었습니다.

  이에 따라 유저가 메시지 전송 과정에서 발생한 오류를 확인할 수 있도록 exception을 추가해 던지도록 설정했습니다. 

- 테스트 코드 작성 중 에러 처리가 미흡한 부분들에 대한 에러 enum을 추가했습니다. 

## 💬 리뷰 요구사항
- 읽어보신 후 코멘트 남겨주세요.

## 🔍 테스트 방법(선택)
- 로컬 환경에서 테스트 빌드로 확인
