### PR TITLE
[REFACTOR] 커피챗 참여 로직 분리 및 User 엔티티 빌더 추가

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatController.java
@@ -79,8 +79,7 @@ public class CoffeeChatController {
         CoffeeChatJoinResponse response = coffeeChatService.join(
             userDetails.getUserId(),
             coffeechatId,
-            request,
-            false
+            request
         );
         return ResponseEntity.status(HttpStatus.CREATED)
             .body(ApiResponse.of(SuccessStatus.COFFEECHAT_JOIN_SUCCESS, response));

--- a/src/main/java/com/ktb/cafeboo/domain/user/model/User.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/model/User.java
@@ -8,8 +8,7 @@ import com.ktb.cafeboo.global.BaseEntity;
 import com.ktb.cafeboo.global.enums.LoginType;
 import com.ktb.cafeboo.global.enums.UserRole;
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.Where;
 
@@ -19,6 +18,9 @@ import java.util.List;
 @Getter
 @Setter
 @Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 @Table(name = "users")
 @Where(clause = "deleted_at IS NULL")
 public class User extends BaseEntity {


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] 커피챗 생성 및 참여 로직 리팩터링
- [x] `User` 엔티티에 빌더 패턴 적용 

## 🛠 변경사항
- `CoffeeChatService#create` 내부에서 호출하던 참여 로직을 `joinMember`로 메서드 분리 및 private으로 변경
- `joinMember`의 인자로 `User` 객체를 넘기도록 수정하여, `userRepository.findById()` 중복 호출 제거
- 테스트 및 유연한 객체 생성을 위한 `User` 객체 `@Builder` 추가

## 💬 리뷰 요구사항
- 테스트 용이성을 위해서 프로덕션 코드를 수정하는 것에 대해서 추후 고민이 필요한 부분인 것 같습니다.
