### PR TITLE
[REFACTOR] 메시지 전송 오류 시 처리 방식 수정

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/ChatController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/ChatController.java
@@ -13,10 +13,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StreamOperations;
+import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.annotation.SendToUser;
 import org.springframework.stereotype.Controller;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 
@@ -53,22 +55,46 @@ public class ChatController {
             return; // 유효한 세션 ID가 없으면 STOMP 연결이 활성화되지 않을 것이기에 메시지 처리 중단
         }
 
-        String userIdentifier = principal.getName();
+//        String userIdentifier = principal.getName();
+//
+//        try{
+//            chatService.handleNewMessage(roomId, chatMessage);
+//        }
+//        catch (CustomApiException e){
+//            log.error("[ChatController.handleCoffeeChatMessage] - 메시지 전송 실패 - 검열");
+//            messagingTemplate.convertAndSendToUser(userIdentifier, "/queue/errors", "메시지 전송 실패: 부적절한 표현을 담은 메시지");
+//        }
+//        catch (JsonProcessingException e){
+//            log.error("[ChatController.handleCoffeeChatMessage] - 메시지 직렬화 실패 오류. roomId: {}, {}", roomId, e.getMessage());
+//            messagingTemplate.convertAndSendToUser(userIdentifier, "/queue/errors", "메시지 전송 실패: 유효하지 않은 메시지 형태.");
+//        }
+//        catch (Exception e) {
+//            log.error("[ChatController.handleCoffeeChatMessage] - 메시지 전송 실패");
+//            messagingTemplate.convertAndSendToUser(userIdentifier, "/queue/errors", "메시지 전송 실패: 서버 오류.");
+//        }
+    }
 
-        try{
-            chatService.handleNewMessage(roomId, chatMessage);
-        }
-        catch (CustomApiException e){
-            log.error("[ChatController.handleCoffeeChatMessage] - 메시지 전송 실패 - 검열");
-            messagingTemplate.convertAndSendToUser(userIdentifier, "/queue/errors", "메시지 전송 실패: 부적절한 표현을 담은 메시지");
-        }
-        catch (JsonProcessingException e){
-            log.error("[ChatController.handleCoffeeChatMessage] - 메시지 직렬화 실패 오류. roomId: {}, {}", roomId, e.getMessage());
-            messagingTemplate.convertAndSendToUser(userIdentifier, "/queue/errors", "메시지 전송 실패: 유효하지 않은 메시지 형태.");
-        }
-        catch (Exception e) {
-            log.error("[ChatController.handleCoffeeChatMessage] - 메시지 전송 실패");
-            messagingTemplate.convertAndSendToUser(userIdentifier, "/queue/errors", "메시지 전송 실패: 서버 오류.");
-        }
+    @MessageExceptionHandler(CustomApiException.class) // CustomApiException을 잡습니다.
+    @SendToUser("/queue/errors") // 이 메시지를 클라이언트의 /user/queue/errors로 보냅니다.
+    public String handleCustomApiException(CustomApiException ex) {
+        log.error("[ChatController.MessageExceptionHandler] - CustomApiException 발생: {}", ex.getMessage());
+        // 클라이언트에게 보낼 메시지 (응답 본문)
+        // ex.getMessage()는 "부적절한 표현을 담은 메시지"가 될 것입니다.
+        return "메시지 전송 실패: " + ex.getMessage();
+    }
+
+    @MessageExceptionHandler(IllegalArgumentException.class)
+    @SendToUser("/queue/errors")
+    public String handleIllegalArgumentException(IllegalArgumentException ex) {
+        log.error("[ChatController.MessageExceptionHandler] - IllegalArgumentException 발생: {}", ex.getMessage(), ex);
+        return "처리할 수 없는 요청: " + ex.getMessage();
+    }
+
+    @MessageExceptionHandler(Exception.class) // 가장 포괄적인 예외 처리
+    @SendToUser("/queue/errors")
+    public String handleGenericException(Exception ex) {
+        log.error("[ChatController.MessageExceptionHandler] - 알 수 없는 오류 발생: {}", ex.getMessage(), ex);
+        // 사용자에게는 일반적인 오류 메시지를, 자세한 내용은 서버 로그에 기록
+        return "서버 오류: 알 수 없는 문제가 발생했습니다. 다시 시도해 주세요.";
     }
 }


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] 메시지 전송 오류 처리 방식 수정.

## 🛠 변경사항
- 현재 FE에 전송 간 에러 발생 시 Error frame이 정상적으로 전송되지 않는 상황이고, 각 exception에 대한 동작을 추가해줘야 하므로 코드 상에서 불필요한 부분들이 많이 생성되었습니다.

    이에, ChatController에 @MessageExceptionHandler 애노테이션과 그 때의 message를 user에게 전달할 수 있도록 @SendToUser 애노테이션을 통해 메시지 처리를 진행하도록 수정했습니다.

## 💬 리뷰 요구사항
- X

## 🔍 테스트 방법(선택)
- FE와 dev 서버에서 연동을 통해 확인할 예정
