### PR TITLE
[FEAT] 카카오 기본 프로필 이미지 처리 및 유저 프로필 조회 기능 개선

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/auth/service/KakaoOauthService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/auth/service/KakaoOauthService.java
@@ -152,34 +152,17 @@ public class KakaoOauthService {
     }
 
     private User getOrCreateUser(KakaoUserResponse kakaoUser) {
-        String kakaoImageUrl = kakaoUser.getKakaoAccount().getProfile().getProfileImageUrl();
-
         return userRepository.findByOauthIdAndLoginType(kakaoUser.getId(), LoginType.KAKAO)
                 .map(user -> {
-                    // 기존 유저인데 프로필 이미지가 없는 경우
                     if (user.getProfileImageUrl() == null) {
-                        String profileImageUrl = (kakaoImageUrl != null && !kakaoImageUrl.isBlank())
-                                ? fetchKakaoProfileImage(kakaoImageUrl)
-                                : s3Uploader.getDefaultProfileImageUrl();
-
-                        user.updateProfileImage(profileImageUrl);
-                        userRepository.save(user);
+                        String profileImageUrl = getProfileImageOrDefault(kakaoUser);
+                        updateProfileImage(user, profileImageUrl);
                     }
                     return user;
                 })
                 .orElseGet(() -> {
-                    String profileImageUrl = (kakaoImageUrl != null && !kakaoImageUrl.isBlank())
-                            ? fetchKakaoProfileImage(kakaoImageUrl)
-                            : s3Uploader.getDefaultProfileImageUrl();
-
-                    User newUser = User.fromKakao(kakaoUser, profileImageUrl);
-                    User savedUser = userRepository.save(newUser);
-
-                    userAlarmSettingService.create(
-                            savedUser.getId(),
-                            new UserAlarmSettingCreateRequest(false, false, false)
-                    );
-                    return savedUser;
+                    String profileImageUrl = getProfileImageOrDefault(kakaoUser);
+                    return createNewUser(kakaoUser, profileImageUrl);
                 });
     }
 
@@ -249,4 +232,19 @@ public class KakaoOauthService {
         }
     }
 
+
+    private void updateProfileImage(User user, String profileImageUrl) {
+        user.updateProfileImage(profileImageUrl);
+        userRepository.save(user);
+    }
+
+    private User createNewUser(KakaoUserResponse kakaoUser, String profileImageUrl) {
+        User newUser = User.fromKakao(kakaoUser, profileImageUrl);
+        User savedUser = userRepository.save(newUser);
+        userAlarmSettingService.create(
+                savedUser.getId(),
+                new UserAlarmSettingCreateRequest(false, false, false)
+        );
+        return savedUser;
+    }
 }

--- a/src/main/java/com/ktb/cafeboo/domain/auth/service/KakaoOauthService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/auth/service/KakaoOauthService.java
@@ -232,6 +232,15 @@ public class KakaoOauthService {
         }
     }
 
+    private String getProfileImageOrDefault(KakaoUserResponse kakaoUser) {
+        boolean isDefaultImage = kakaoUser.getKakaoAccount().getProfile().isDefaultImage();
+        String kakaoImageUrl = kakaoUser.getKakaoAccount().getProfile().getProfileImageUrl();
+
+        if (kakaoImageUrl != null && !kakaoImageUrl.isBlank() && !isDefaultImage) {
+            return fetchKakaoProfileImage(kakaoImageUrl);
+        }
+        return s3Uploader.getDefaultProfileImageUrl();
+    }
 
     private void updateProfileImage(User user, String profileImageUrl) {
         user.updateProfileImage(profileImageUrl);

--- a/src/main/java/com/ktb/cafeboo/domain/user/dto/UserProfileResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/dto/UserProfileResponse.java
@@ -2,6 +2,7 @@ package com.ktb.cafeboo.domain.user.dto;
 
 public record UserProfileResponse(
         String nickname,
+        String profileImageUrl,
         int dailyCaffeineLimitMg,
         int coffeeBean,
         int challengeCount

--- a/src/main/java/com/ktb/cafeboo/domain/user/service/UserService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/service/UserService.java
@@ -23,22 +23,26 @@ public class UserService {
     private final OauthTokenRepository oauthTokenRepository;
     private final TokenBlacklistService tokenBlacklistService;
 
+    @Transactional(readOnly = true)
     public User findUserById(Long id){
         return userRepository.findById(id)
                 .orElseThrow(() -> new CustomApiException(ErrorStatus.USER_NOT_FOUND));
     }
 
+    @Transactional(readOnly = true)
     public EmailDuplicationResponse isEmailDuplicated(String email) {
         boolean isDuplicated = userRepository.existsByEmail(email);
         log.info("[UserService.isEmailDuplicated] 이메일 중복 확인 - email={}, duplicated={}", email, isDuplicated);
         return new EmailDuplicationResponse(email, isDuplicated);
     }
 
+    @Transactional(readOnly = true)
     public boolean hasCompletedOnboarding(User user) {
         return user.getHealthInfo() != null
                 && user.getCaffeinInfo() != null;
     }
-  
+
+    @Transactional(readOnly = true)
     public UserProfileResponse getUserProfile(Long targetUserId, Long currentUserId) {
         log.info("[UserService.getUserProfile] 사용자 프로필 조회 - targetUserId={}, currentUserId={}", targetUserId, currentUserId);
 
@@ -56,6 +60,7 @@ public class UserService {
 
         return new UserProfileResponse(
                 targetUser.getNickname(),
+                targetUser.getProfileImageUrl(),
                 (int) dailyCaffeineLimit,
                 targetUser.getCoffeeBean(),
                 0

--- a/src/main/java/com/ktb/cafeboo/global/infra/kakao/dto/KakaoUserResponse.java
+++ b/src/main/java/com/ktb/cafeboo/global/infra/kakao/dto/KakaoUserResponse.java
@@ -16,8 +16,12 @@ public class KakaoUserResponse {
         @Getter
         public static class Profile {
             private String nickname;
+
             @JsonProperty("profile_image_url")
             private String profileImageUrl;
+
+            @JsonProperty("is_default_image")
+            private boolean isDefaultImage;
         }
     }
 }


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] 카카오 로그인 시 유저 생성/업데이트 로직을 메서드 단위로 분리하여 가독성 및 재사용성 향상
- [x] 카카오 기본 프로필 이미지(`isDefaultImage`)인 경우 S3 업로드 생략하고 서비스 공통 기본 이미지로 대체
- [x] 유저 프로필 조회 응답에 `profileImageUrl` 포함하여 클라이언트에서 유저 이미지 표시 가능하도록 개선

## 🛠 변경사항
- `getOrCreateUser` 내부 로직을 `createNewUser`, `updateProfileImage`, `getProfileImageOrDefault` 등으로 분리
- `isDefaultImage` 값에 따라 불필요한 업로드를 방지하고, 공통 기본 프로필 이미지로 fallback 처리
- `UserProfileResponse` DTO에 `profileImageUrl` 필드 추가 및 서비스 로직 연동

## 💬 리뷰 요구사항
-

## 🔍 테스트 방법(선택)
- 카카오톡 기본 프로필 지정 후, 로그인 진행
- 카카오톡 기본 프로필인 경우, s3 업로드가 진행되지 않고 카테부의 기본 프로필로 저장되는 것 확인
<img width="941" alt="image" src="https://github.com/user-attachments/assets/bdbfa37e-1ccd-44ce-a952-514ee25fbb52" />

연관이슈
close: #211 