### PR TITLE
[FIX] stomp 메세지 유저 프로필 이미지 누락 수정

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/StompMessagePublish.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/StompMessagePublish.java
@@ -48,7 +48,7 @@ public class StompMessagePublish {
             .sender(SenderInfo.builder()
                 .memberId(String.valueOf(senderMember.getId())) // User ID를 String으로 변환
                 .chatNickname(senderMember.getChatNickname()) // CoffeeChatMember의 닉네임 사용
-                .profileImageUrl("") // CoffeeChatMember의 프로필 이미지 사용
+                .profileImageUrl(senderMember.getProfileImageUrl()) // CoffeeChatMember의 프로필 이미지 사용
                 .build())
             .build();
     }


### PR DESCRIPTION

# 📌 Pull Request

## ✨ 작업한 내용
- [x] stomp 메세지 유저 프로필 이미지 누락 수정

## 🛠 변경사항
- StompMessagePublish내 from 메서드 수정

## 💬 리뷰 요구사항
-x