### PR TITLE
[FEAT]: 사용자 프로필 수정 기능 추가

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/user/controller/UserController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/controller/UserController.java
@@ -14,10 +14,12 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @RestController
@@ -50,6 +52,27 @@ public class UserController {
         UserProfileResponse response = userService.getUserProfile(userId, userDetails.getUserId());
         return ResponseEntity.ok(ApiResponse.of(SuccessStatus.BASIC_PROFILE_FETCH_SUCCESS, response));
     }
+
+    @PatchMapping(value = "/{userId}/profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<UserProfileUpdateResponse>> updateUserProfile(
+            @PathVariable Long userId,
+            @RequestPart(required = false) String nickname,
+            @RequestPart(required = false) MultipartFile profileImage,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        log.info("[PATCH /api/v1/user/{}/profile] 사용자 프로필 수정 요청 수신", userId);
+
+        AuthChecker.checkOwnership(userId, userDetails.getUserId());
+
+        UserProfileUpdateRequest request = new UserProfileUpdateRequest(nickname, profileImage);
+
+        UserProfileUpdateResponse response = userService.updateUserProfile(userId, request);
+
+        return ResponseEntity.ok(
+                ApiResponse.of(SuccessStatus.BASIC_PROFILE_UPDATE_SUCCESS, response)
+        );
+    }
+
 
     @PostMapping("/{userId}/health")
     public ResponseEntity<ApiResponse<UserHealthInfoCreateResponse>> createHealthInfo(

--- a/src/main/java/com/ktb/cafeboo/domain/user/dto/UserProfileUpdateRequest.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/dto/UserProfileUpdateRequest.java
@@ -1,0 +1,10 @@
+package com.ktb.cafeboo.domain.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.springframework.web.multipart.MultipartFile;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record UserProfileUpdateRequest(
+        String nickname,
+        MultipartFile profileImage
+) {}

--- a/src/main/java/com/ktb/cafeboo/domain/user/dto/UserProfileUpdateResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/dto/UserProfileUpdateResponse.java
@@ -1,0 +1,8 @@
+package com.ktb.cafeboo.domain.user.dto;
+
+import java.time.LocalDateTime;
+
+public record UserProfileUpdateResponse(
+        String userId,
+        LocalDateTime updatedAt
+) {}

--- a/src/main/java/com/ktb/cafeboo/domain/user/model/User.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/model/User.java
@@ -115,10 +115,12 @@ public class User extends BaseEntity {
         this.favoriteDrinks.addAll(favorites);
     }
 
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
     public void updateProfileImage(String profileImageUrl) {
-        if (this.profileImageUrl == null) {
-            this.profileImageUrl = profileImageUrl;
-        }
+        this.profileImageUrl = profileImageUrl;
     }
 
     public void addCoffeeBeans(int amount) {

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/SuccessStatus.java
@@ -19,6 +19,7 @@ public enum SuccessStatus implements BaseCode {
     // 유저 관련 응답
     EMAIL_DUPLICATION_CHECK_SUCCESS(200, "EMAIL_DUPLICATION_CHECK_SUCCESS", "이메일 중복 확인 결과를 반환했습니다."),
     BASIC_PROFILE_FETCH_SUCCESS(200, "BASIC_PROFILE_FETCH_SUCCESS", "기본 프로필이 성공적으로 조회되었습니다."),
+    BASIC_PROFILE_UPDATE_SUCCESS(200, "BASIC_PROFILE_UPDATE_SUCCESS", "기본 프로필 정보가 성공적으로 수정되었습니다."),
     
     //유저 건강 프로필 관련 응답
     HEALTH_PROFILE_CREATION_SUCCESS(201, "HEALTH_PROFILE_CREATION_SUCCESS", "건강 프로필이 성공적으로 저장되었습니다."),


### PR DESCRIPTION

# 📌 Pull Request

## ✨ 작업한 내용
- [x] PATCH /api/v1/users/profile 엔드포인트 구현
- [x] 닉네임, 프로필 이미지 중 실제로 변경된 값만 반영
- [x] 프로필 이미지 변경 시 S3 업로드 처리 

## 🛠 변경사항
- 주요 코드 변경 사항 요약
- `UserController`에 PATCH /api/v1/users/profile 메서드 추가
- `UserService`에 `updateUserProfile`메서드 추가
- 사용자 프로필 수정용 DTO (`UserProfileUpdateRequest`, `UserProfileUpdateResponse`) 추가
- `S3Uploader`에 프로필 이미지 업로드 처리 로직 적용 (`uploadProfileImage`)

## 💬 리뷰 요구사항
- 기존 이미지를 S3에서 삭제하는 로직은 아직 포함되어 있지 않고, 현재는 새 이미지를 업로드한 뒤 URL만 교체하는 방식입니다.
- 이미지 삭제 전략은 따로 고민해볼 예정이니, 좋은 의견 있으시면 말씀해주세요
 
## 🔍 테스트 방법(선택)
- Postman을 활용한 업데이트 요청 성공
- S3 정상 업로드 확인