### PR TITLE
Refactor/eden.lee/coffeechat

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/scheduler/CoffeeChatScheduler.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/scheduler/CoffeeChatScheduler.java
@@ -19,9 +19,9 @@ public class CoffeeChatScheduler {
     private final CoffeeChatRepository coffeeChatRepository;
 
     /**
-     * 매일 자정(00:00)에 meetingTime 기준 만료 처리
+     * 매일 밤 9시(21:00)에 meetingTime 기준 만료 처리
      */
-    @Scheduled(cron = "0 0 0 * * *")
+    @Scheduled(cron = "0 0 21 * * *")
     @Transactional
     public void expireOutdatedCoffeeChats() {
         LocalDateTime todayMidnight = LocalDate.now().atStartOfDay();

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/scheduler/CoffeeChatScheduler.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/scheduler/CoffeeChatScheduler.java
@@ -21,7 +21,7 @@ public class CoffeeChatScheduler {
     /**
      * 매일 밤 9시(21:00)에 meetingTime 기준 만료 처리
      */
-    @Scheduled(cron = "0 0 21 * * *")
+    @Scheduled(cron = "0 0 21 * * *", zone = "Asia/Seoul")
     @Transactional
     public void expireOutdatedCoffeeChats() {
         LocalDateTime todayMidnight = LocalDate.now().atStartOfDay();


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] 커피챗 만료 처리 스케줄러의 실행 시간을 기존 매일 자정(00:00) 에서 매일 밤 9시(21:00, KST) 로 변경하였습니다.

## 🛠 변경사항
- `CoffeeChatScheduler.expireOutdatedCoffeeChats()` 메서드의` @Scheduled` 값 변경
    - `cron = "0 0 0 * * *" `→ `cron = "0 0 21 * * *", zone = "Asia/Seoul"`


## 💬 리뷰 요구사항
- x
