### PR TITLE
[FEAT] 카페인 다이어리 유닛 테스트

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/report/service/DailyStatisticsService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/report/service/DailyStatisticsService.java
@@ -182,26 +182,16 @@ public class DailyStatisticsService {
             throw new CustomApiException(ErrorStatus.BAD_REQUEST);
         }
 
-        int year = Integer.parseInt(targetYear);
-        int month = Integer.parseInt(targetMonth);
-        int week = Integer.parseInt(targetWeek);
+        int year, month, week;
 
-//        // 주어진 year와 month로 해당 달의 첫 번째 날짜를 얻습니다.
-//        LocalDate firstDayOfMonth = LocalDate.of(year, month, 1);
-//
-//        // 해당 달의 첫 번째 주 월요일을 찾습니다.
-//        LocalDate firstMondayOfMonth = firstDayOfMonth.with(TemporalAdjusters.firstInMonth(DayOfWeek.MONDAY));
-//
-//        // 만약 첫 번째 날짜가 월요일보다 앞선다면, 그 주는 이전 달의 마지막 주에 해당할 수 있습니다.
-//        // 이를 보정하기 위해 첫 번째 월요일이 없다면 해당 달의 1일로 시작하는 주를 기준으로 합니다.
-//        LocalDate firstWeekStart = firstMondayOfMonth.getMonthValue() != month ?
-//            firstDayOfMonth : firstMondayOfMonth;
-//
-//        // 첫 번째 주 시작 날짜에 (weekOfMonth - 1) 주를 더하여 해당 월의 weekOfMonth 번째 주의 시작 날짜를 얻습니다.
-//        LocalDate startDate = firstWeekStart.plusWeeks(week - 1);
-//
-//        LocalDate startOfWeek = startDate.with(DayOfWeek.MONDAY);
-//        LocalDate endOfWeek = startOfWeek.plusDays(6);
+        try{
+            year = Integer.parseInt(targetYear);
+            month = Integer.parseInt(targetMonth);
+            week = Integer.parseInt(targetWeek);
+        }
+        catch (Exception e){
+            throw new CustomApiException(ErrorStatus.BAD_REQUEST);
+        }
 
         LocalDate startOfMonth = LocalDate.of(year, month, 1);;
         DayOfWeek dayOfWeek = startOfMonth.getDayOfWeek();
@@ -221,18 +211,7 @@ public class DailyStatisticsService {
             endOfMonth = endOfMonth.minusWeeks(1);
         }
 
-//        // 주어진 year와 month로 해당 달의 첫 번째 날짜를 얻습니다.
-//        LocalDate startOfMonth = LocalDate.of(year, month, 1);
-//
-//        // 해당 달의 첫 번째 주 월요일을 찾습니다.
-//        LocalDate firstMondayOfMonth = firstDayOfMonth.with(TemporalAdjusters.firstInMonth(DayOfWeek.MONDAY));
-//
-//        // 만약 첫 번째 날짜가 월요일보다 앞선다면, 그 주는 이전 달의 마지막 주에 해당할 수 있습니다.
-//        // 이를 보정하기 위해 첫 번째 월요일이 없다면 해당 달의 1일로 시작하는 주를 기준으로 합니다.
-//        LocalDate firstWeekStart = firstMondayOfMonth.getMonthValue() != month ?
-//            firstDayOfMonth : firstMondayOfMonth;
-//
-//        // 첫 번째 주 시작 날짜에 (weekOfMonth - 1) 주를 더하여 해당 월의 weekOfMonth 번째 주의 시작 날짜를 얻습니다.
+       // 첫 번째 주 시작 날짜에 (weekOfMonth - 1) 주를 더하여 해당 월의 weekOfMonth 번째 주의 시작 날짜를 얻습니다.
         LocalDate startDate = startOfMonth.plusWeeks(week - 1).with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
         LocalDate endDate = startDate.plusDays(6);
 

--- a/src/main/java/com/ktb/cafeboo/domain/report/service/WeeklyReportScheduler.java
+++ b/src/main/java/com/ktb/cafeboo/domain/report/service/WeeklyReportScheduler.java
@@ -44,29 +44,6 @@ public class WeeklyReportScheduler {
     @Scheduled(cron = "0 0 12 ? * MON") // 매주 월요일 오전 9시, 현재는 12시로 설정
     public CreateWeeklyAnalysisResponse generateWeeklyReports() {
         log.info("[IntakeSuggestionService.getPredictedIntakeSuggestion] 호출 시작");
-//        int targetYear = 2024;
-//        int targetWeekNum = 19;
-//
-//        // ISO 8601 표준 (월요일 시작, 한 주의 최소 4일 포함)을 따르는 WeekFields 객체 생성
-//        WeekFields isoWeekFields = WeekFields.of(Locale.getDefault());
-//
-//        // 해당 년도의 첫 번째 날짜
-//        LocalDate firstDayOfYear = LocalDate.of(targetYear, 1, 1);
-//
-//        // 첫 번째 주(week 1)의 첫 번째 날 (월요일) 찾기
-//        LocalDate firstMonday = firstDayOfYear;
-//        if (firstMonday.getDayOfWeek() != DayOfWeek.MONDAY) {
-//            firstMonday = firstMonday.with(WeekFields.ISO.dayOfWeek(), 1); // 해당 주의 월요일로 이동
-//            if (firstMonday.getYear() > targetYear) {
-//                firstMonday = firstDayOfYear.plusWeeks(1).with(WeekFields.ISO.dayOfWeek(), 1);
-//            }
-//        }
-//
-//        // targetWeekNum 주의 시작 날짜 계산
-//        LocalDate startDate = firstMonday.plusWeeks(targetWeekNum - 1);
-//
-//        // targetWeekNum 주의 마지막 날짜 계산 (일요일)
-//        LocalDate endDate = startDate.plusDays(6);
 
         List<User> users = userRepository.findAll();
         String callbackUrl = "http://localhost:8080/api/v1/reports/weekly/ai_callback";

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/SuccessStatus.java
@@ -53,6 +53,7 @@ public enum SuccessStatus implements BaseCode {
 
     //AI 리포트 생성 관련 응답
     REPORT_GENERATION_SUCCESS(200, "AI_GENERATION_REPORT", "AI 리포트 생성 요청 성공"),
+    AI_CALLBACK_SUCCESS(200, "AI_CALLBACK_SUCCESS", "AI 콜백 함수 호출 성공"),
 
     //커피챗 관련 응답
     COFFEECHAT_CREATE_SUCCESS(201, "COFFEECHAT_CREATE_SUCCESS", "커피챗이 성공적으로 생성되었습니다."),

--- a/src/test/java/com/ktb/cafeboo/domain/caffeinediary/unit_test/controller/DiaryControllerTest.java
+++ b/src/test/java/com/ktb/cafeboo/domain/caffeinediary/unit_test/controller/DiaryControllerTest.java
@@ -1,0 +1,660 @@
+package com.ktb.cafeboo.domain.caffeinediary.unit_test.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.ktb.cafeboo.domain.auth.service.TokenBlacklistService;
+import com.ktb.cafeboo.domain.caffeinediary.controller.CaffeineIntakeController;
+import com.ktb.cafeboo.domain.caffeinediary.dto.CaffeineIntakeRequest;
+import com.ktb.cafeboo.domain.caffeinediary.dto.CaffeineIntakeResponse;
+import com.ktb.cafeboo.domain.caffeinediary.dto.DailyCaffeineDiaryResponse;
+import com.ktb.cafeboo.domain.caffeinediary.dto.MonthlyCaffeineDiaryResponse;
+import com.ktb.cafeboo.domain.caffeinediary.dto.MonthlyCaffeineDiaryResponse.DailyIntake;
+import com.ktb.cafeboo.domain.caffeinediary.dto.MonthlyCaffeineDiaryResponse.Filter;
+import com.ktb.cafeboo.domain.caffeinediary.model.CaffeineIntake;
+import com.ktb.cafeboo.domain.caffeinediary.repository.CaffeineIntakeRepository;
+import com.ktb.cafeboo.domain.caffeinediary.service.CaffeineIntakeService;
+import com.ktb.cafeboo.domain.drink.model.Drink;
+import com.ktb.cafeboo.domain.user.model.User;
+import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
+import com.ktb.cafeboo.global.apiPayload.code.status.SuccessStatus;
+import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
+import com.ktb.cafeboo.global.enums.LoginType;
+import com.ktb.cafeboo.global.enums.UserRole;
+import com.ktb.cafeboo.global.security.userdetails.CustomUserDetails;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+
+import java.time.LocalDateTime;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(CaffeineIntakeController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class DiaryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private CaffeineIntakeService caffeineIntakeService;
+
+    @MockitoBean
+    private TokenBlacklistService tokenBlacklistService;
+
+    @MockitoBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    private User user;
+    private Drink mockDrink;
+
+    private void setAuthentication(Long userId) {
+        user = User.builder()
+            .nickname("테스트")
+            .role(UserRole.USER)
+            .loginType(LoginType.KAKAO)
+            .build();
+        ReflectionTestUtils.setField(user, "id", userId);
+
+        CustomUserDetails customUserDetails = new CustomUserDetails(user);
+        UsernamePasswordAuthenticationToken auth =
+            new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setup(){
+        setAuthentication(1L);
+        objectMapper.registerModule(new JavaTimeModule());
+
+        mockDrink = Drink.builder()
+            .name("아메리카노")
+            .build();
+    }
+
+    @Nested
+    @DisplayName("카페인 섭취 기록 (POST /api/v1/caffeine-intakes)")
+    @WithMockUser
+    class RecordCaffeineIntakeTests {
+        @Test
+        @DisplayName("카페인 기록 성공 - 200 OK")
+        void 카페인_기록_성공() throws Exception {
+            // given
+            CaffeineIntakeRequest request = new CaffeineIntakeRequest(
+                "10", LocalDateTime.now(),1,100f, "GRANDE");
+
+            CaffeineIntakeResponse response = new CaffeineIntakeResponse(
+                "1", "10", "아메리카노", request.intakeTime(), 1, 150f);
+
+            when(caffeineIntakeService.recordCaffeineIntake(1L, request)).thenReturn(response);
+
+            // when
+            ResultActions result = mockMvc.perform(post("/api/v1/caffeine-intakes")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(request)
+                ))
+                .andExpect(status().isCreated());
+
+            // then
+            verify(caffeineIntakeService, times(1)).recordCaffeineIntake(eq(1L), any(CaffeineIntakeRequest.class));
+
+            result.andExpect(jsonPath("$.code").value("CAFFEINE_INTAKE_RECORDED"))
+                .andExpect(jsonPath("$.message").value("카페인 섭취 내역이 성공적으로 등록되었습니다."))
+                .andExpect(jsonPath("$.data.id").value(response.id()))
+                .andExpect(jsonPath("$.data.drinkId").value(response.drinkId()))
+                .andExpect(jsonPath("$.data.drinkName").value(response.drinkName()))
+                .andExpect(jsonPath("$.data.drinkCount").value(response.drinkCount()))
+                .andExpect(jsonPath("$.data.caffeineAmount").value(response.caffeineAmount()));
+
+        }
+
+        @Test
+        @DisplayName("카페인 섭취 내역 등록 실패 - 400 error")
+        void 카페인_기록_필수_필드_누락_시_실패() throws Exception {
+            // given
+            // drinkId가 null인 유효하지 않은 요청 생성
+            CaffeineIntakeRequest invalidRequest = new CaffeineIntakeRequest(
+                null, LocalDateTime.now(), 1, 100f, "GRANDE");
+
+            // 여기서는 'this.caffeineIntakeService' (Mock 객체)가 예외를 던지도록 설정합니다.
+            when(caffeineIntakeService.recordCaffeineIntake(1L, invalidRequest))
+                .thenThrow(new CustomApiException(ErrorStatus.INVALID_INTAKE_INFO));
+
+            // when
+            ResultActions result = mockMvc.perform(post("/api/v1/caffeine-intakes")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        objectMapper.writeValueAsString(invalidRequest)
+                    ))
+                .andExpect(status().isBadRequest());
+
+            // then
+            result.andExpect(jsonPath("$.code").value("INVALID_INTAKE_INFO"))
+                .andExpect(jsonPath("$.message").value("필수 데이터 필드가 누락되었습니다."));
+
+            verify(caffeineIntakeService, times(1)).recordCaffeineIntake(1L, invalidRequest);
+        }
+
+        @Test
+        @DisplayName("카페인 섭취 내역 등록 실패 - 500 error")
+        void 카페인_기록_실패_서버_오류() throws Exception {
+            // given
+            // drinkId가 null인 유효하지 않은 요청 생성
+            CaffeineIntakeRequest invalidRequest = new CaffeineIntakeRequest(
+                null, LocalDateTime.now(), 1, 100f, "GRANDE");
+
+            // 여기서는 'this.caffeineIntakeService' (Mock 객체)가 예외를 던지도록 설정합니다.
+            doThrow(new RuntimeException("알 수 없는 오류"))
+                .when(caffeineIntakeService).recordCaffeineIntake(1L, invalidRequest);
+
+            // when
+            ResultActions result = mockMvc.perform(post("/api/v1/caffeine-intakes")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        objectMapper.writeValueAsString(invalidRequest)
+                    ))
+                .andExpect(status().isInternalServerError());
+
+            // then
+            result.andExpect(jsonPath("$.code").value("INTERNAL_SERVER_ERROR"))
+                .andExpect(jsonPath("$.message").value("요청을 처리하는 도중 서버에서 문제가 발생했습니다."))
+                .andExpect(jsonPath("$.data").doesNotExist()
+                );
+
+            verify(caffeineIntakeService, times(1)).recordCaffeineIntake(1L, invalidRequest);
+        }
+    }
+
+    @Nested
+    @DisplayName("카페인 섭취 기록 삭제 (DELETE /api/v1/caffeine-intakes)")
+    @WithMockUser
+    class DeleteCaffeineIntakeTests{
+        @Test
+        @DisplayName("카페인 섭취 기록 삭제 성공")
+        void 카페인_섭취_기록_삭제_성공() throws Exception {
+            // given
+            Long intakeIdToDelete = 1L; // 삭제할 카페인 섭취 기록 ID
+
+            // mock 서비스의 deleteCaffeineIntake 메소드가 호출될 때 아무것도 하지 않도록 설정
+            doNothing().when(caffeineIntakeService).deleteCaffeineIntake(intakeIdToDelete);
+
+            // when
+            ResultActions result = mockMvc.perform(delete("/api/v1/caffeine-intakes/{intakeId}", intakeIdToDelete)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    )
+                .andExpect(status().isNoContent());
+
+            // then
+            result.andExpect(jsonPath("$").doesNotExist());
+
+            // mock 서비스의 deleteCaffeineIntake 메소드가 정확히 한 번 호출되었는지 검증
+            verify(caffeineIntakeService, times(1)).deleteCaffeineIntake(intakeIdToDelete);
+        }
+
+        @Test
+        @DisplayName("카페인 섭취 기록 삭제 실패 - 해당되는 섭취 내역 없음")
+        void 카페인_섭취_기록_삭제_실패() throws Exception {
+            // given
+            Long intakeIdToDelete = 1L; // 삭제할 카페인 섭취 기록 ID
+
+            doThrow(new CustomApiException(ErrorStatus.INTAKE_NOT_FOUND))
+                .when(caffeineIntakeService).deleteCaffeineIntake(intakeIdToDelete);
+
+            // when
+            // 컨트롤러의 삭제 메소드 호출
+            ResultActions result = mockMvc.perform(delete("/api/v1/caffeine-intakes/{intakeId}", intakeIdToDelete)
+                    .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isNotFound());
+
+            // then
+            result.andExpect(jsonPath("$.code").value("INTAKE_NOT_FOUND"))
+                    .andExpect(jsonPath("$.message").value("섭취 내역을 찾을 수 없습니다."))
+                    .andExpect(jsonPath("$.data").doesNotExist());
+
+            // mock 서비스의 deleteCaffeineIntake 메소드가 정확히 한 번 호출되었는지 검증
+            verify(caffeineIntakeService, times(1)).deleteCaffeineIntake(intakeIdToDelete);
+        }
+
+        @Test
+        @DisplayName("카페인 섭취 내역 삭제 실패 - 500 error")
+        void 카페인_기록_삭제_서버_오류() throws Exception {
+            // given
+            Long intakeIdToDelete = 1L; // 삭제할 카페인 섭취 기록 ID
+
+            // drinkId가 null인 유효하지 않은 요청 생성
+            CaffeineIntakeRequest invalidRequest = new CaffeineIntakeRequest(
+                null, LocalDateTime.now(), 1, 100f, "GRANDE");
+
+            // 여기서는 'this.caffeineIntakeService' (Mock 객체)가 예외를 던지도록 설정합니다.
+            doThrow(new RuntimeException("알 수 없는 오류"))
+                .when(caffeineIntakeService).deleteCaffeineIntake(intakeIdToDelete);
+
+            // when
+            ResultActions result = mockMvc.perform(delete("/api/v1/caffeine-intakes/{id}", intakeIdToDelete)
+                    .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isInternalServerError());
+
+            // then
+            result.andExpect(jsonPath("$.code").value("INTERNAL_SERVER_ERROR"))
+                .andExpect(jsonPath("$.message").value("요청을 처리하는 도중 서버에서 문제가 발생했습니다."))
+                .andExpect(jsonPath("$.data").doesNotExist()
+                );
+
+            verify(caffeineIntakeService, times(1)).deleteCaffeineIntake(intakeIdToDelete);
+        }
+    }
+
+    @Nested
+    @DisplayName("카페인 섭취 기록 수정 (PATCH /api/v1/caffeine-intakes)")
+    @WithMockUser
+    class UpdateCaffeineIntakeTests{
+        @Test
+        @DisplayName("카페인 섭취 기록 수정 성공")
+        void 카페인_섭취_기록_수정_성공() throws Exception {
+            // given
+            Long intakeIdToUpdate = 1L; // 삭제할 카페인 섭취 기록 ID
+
+            // mock request
+            CaffeineIntakeRequest request = new CaffeineIntakeRequest(
+                "11", LocalDateTime.now().plusHours(1), 2, 200f, "VENTI");
+
+            CaffeineIntakeResponse response = new CaffeineIntakeResponse(
+                intakeIdToUpdate.toString(), "11", "카페라떼", request.intakeTime(), 2, 200f);
+
+            when(caffeineIntakeService.updateCaffeineIntake(intakeIdToUpdate, request))
+                .thenReturn(response);
+
+            // when
+            ResultActions result = mockMvc.perform(patch("/api/v1/caffeine-intakes/{intakeId}", intakeIdToUpdate)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        objectMapper.writeValueAsString(request)
+                    )
+                )
+                .andExpect(status().isOk());
+
+            // then
+            result.andExpect(jsonPath("$.code").value("CAFFEINE_INTAKE_UPDATED"))
+                .andExpect(jsonPath("$.message").value("카페인 섭취 내역이 성공적으로 수정되었습니다."))
+                .andExpect(jsonPath("$.data.id").value(response.id()))
+                .andExpect(jsonPath("$.data.drinkId").value(response.drinkId()))
+                .andExpect(jsonPath("$.data.drinkName").value(response.drinkName()))
+                .andExpect(jsonPath("$.data.drinkCount").value(response.drinkCount()))
+                .andExpect(jsonPath("$.data.caffeineAmount").value(response.caffeineAmount()));;
+
+            // mock 서비스의 deleteCaffeineIntake 메소드가 정확히 한 번 호출되었는지 검증
+            verify(caffeineIntakeService, times(1)).updateCaffeineIntake(intakeIdToUpdate, request);
+        }
+
+        @Test
+        @DisplayName("카페인 섭취 기록 수정 실패 - 해당되는 섭취 내역 없음")
+        void 카페인_섭취_기록_수정_실패_invalid_id() throws Exception {
+            // given
+            Long intakeIdToUpdate = 1L; // 삭제할 카페인 섭취 기록 ID
+
+            // mock request
+            CaffeineIntakeRequest request = new CaffeineIntakeRequest(
+                "11", LocalDateTime.now().plusHours(1), 2, 200f, "VENTI");
+
+            doThrow(new CustomApiException(ErrorStatus.INTAKE_NOT_FOUND))
+                .when(caffeineIntakeService).updateCaffeineIntake(intakeIdToUpdate, request);
+
+            // when
+            // 컨트롤러의 삭제 메소드 호출
+            ResultActions result = mockMvc.perform(patch("/api/v1/caffeine-intakes/{intakeId}", intakeIdToUpdate)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        objectMapper.writeValueAsString(request)
+                    )
+                )
+                .andExpect(status().isNotFound());
+
+            // then
+            result.andExpect(jsonPath("$.code").value("INTAKE_NOT_FOUND"))
+                .andExpect(jsonPath("$.message").value("섭취 내역을 찾을 수 없습니다."))
+                .andExpect(jsonPath("$.data").doesNotExist()
+                );
+
+            // mock 서비스의 deleteCaffeineIntake 메소드가 정확히 한 번 호출되었는지 검증
+            verify(caffeineIntakeService, times(1)).updateCaffeineIntake(intakeIdToUpdate, request);
+        }
+
+        @Test
+        @DisplayName("카페인 섭취 기록 수정 실패 - 서버 오류")
+        void 카페인_섭취_기록_수정_실패_server_error() throws Exception {
+            // given
+            Long intakeIdToUpdate = 1L; // 삭제할 카페인 섭취 기록 ID
+
+            // mock request
+            CaffeineIntakeRequest request = new CaffeineIntakeRequest(
+                "11", LocalDateTime.now().plusHours(1), 2, 200f, "VENTI");
+
+            doThrow(new RuntimeException("서비스 내부에서 알 수 없는 오류 발생"))
+                .when(caffeineIntakeService).updateCaffeineIntake(intakeIdToUpdate, request);
+
+            // when
+            ResultActions result = mockMvc.perform(patch("/api/v1/caffeine-intakes/{intakeId}", intakeIdToUpdate)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        objectMapper.writeValueAsString(request)
+                    )
+                )
+                .andExpect(status().isInternalServerError());
+
+            // then
+            result.andExpect(jsonPath("$.code").value("INTERNAL_SERVER_ERROR"))
+                .andExpect(jsonPath("$.message").value("요청을 처리하는 도중 서버에서 문제가 발생했습니다."))
+                .andExpect(jsonPath("$.data").doesNotExist()
+                );
+
+            // mock 서비스의 deleteCaffeineIntake 메소드가 정확히 한 번 호출되었는지 검증
+            verify(caffeineIntakeService, times(1)).updateCaffeineIntake(intakeIdToUpdate, request);
+        }
+    }
+
+    @Nested
+    @DisplayName("카페인 다이어리 달력 조회 (GET /api/v1/caffeine-intakes/monthly)")
+    @WithMockUser
+    class getCaffeineIntakeDiaryTests{
+
+        @Test
+        @DisplayName("카페인 다이어리 달력 조회 성공 - 200")
+        void 카페인_다이어리_달력_조회_성공() throws Exception {
+            //given
+            String targetYear = "2025";
+            String targetMonth = "7";
+
+            List<DailyIntake> dailyIntakes = new ArrayList<>();
+            dailyIntakes.add(new DailyIntake("2025-07-01", 150.5f));
+            dailyIntakes.add(new DailyIntake("2025-07-02", 200.0f));
+            dailyIntakes.add(new DailyIntake("2025-07-03", 0.0f));
+
+            MonthlyCaffeineDiaryResponse response = new MonthlyCaffeineDiaryResponse(
+                new Filter(targetYear, targetMonth),
+                dailyIntakes
+            );
+
+            //when
+            when(caffeineIntakeService.getCaffeineIntakeDiary(1L, targetYear, targetMonth))
+                .thenReturn(response);
+
+            ResultActions result = mockMvc.perform(get("/api/v1/caffeine-intakes/monthly")
+                .param("year", targetYear)
+                .param("month", targetMonth)
+                .contentType(MediaType.APPLICATION_JSON));
+
+            //then
+            result.andExpect(status().isOk()) // HTTP 200 OK 검증
+                .andExpect(jsonPath("$.code").value(SuccessStatus.MONTHLY_CAFFEINE_CALENDAR_SUCCESS.getCode()))
+                .andExpect(jsonPath("$.message").value(SuccessStatus.MONTHLY_CAFFEINE_CALENDAR_SUCCESS.getMessage()))
+                .andExpect(jsonPath("$.data").exists())
+                .andExpect(jsonPath("$.data.filter.year").value(targetYear))
+                .andExpect(jsonPath("$.data.filter.month").value(targetMonth))
+                .andExpect(jsonPath("$.data.dailyIntakeList").isArray())
+                .andExpect(jsonPath("$.data.dailyIntakeList.length()").value(dailyIntakes.size()));
+
+            // dailyIntakeList 내부의 각 요소 검증
+            for (int i = 0; i < dailyIntakes.size(); i++) {
+                DailyIntake dailyIntake = dailyIntakes.get(i);
+                result.andExpect(jsonPath(String.format("$.data.dailyIntakeList[%d].date", i)).value(dailyIntake.date()))
+                    .andExpect(jsonPath(String.format("$.data.dailyIntakeList[%d].totalCaffeineMg", i)).value(dailyIntake.totalCaffeineMg()));
+            }
+
+            verify(caffeineIntakeService, times(1)).getCaffeineIntakeDiary(1L,  targetYear, targetMonth);
+
+        }
+
+        @Test
+        @DisplayName("카페인 다이어리 달력 조회 실패, 필수 파라미터 null or empty - 400")
+        void 카페인_다이어리_달력_조회_실패_필수_파라미터_null_or_empty() throws Exception {
+            //given
+            String targetYear = "2025";
+            String targetMonth = "";
+
+            doThrow(new CustomApiException(ErrorStatus.BAD_REQUEST))
+                .when(caffeineIntakeService).getCaffeineIntakeDiary(1L, targetYear, targetMonth);
+
+            //when
+            ResultActions result = mockMvc.perform(get("/api/v1/caffeine-intakes/monthly")
+                .param("year", targetYear)
+                .param("month", targetMonth)
+                .contentType(MediaType.APPLICATION_JSON));
+
+            //then
+            result.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(ErrorStatus.BAD_REQUEST.getCode()))
+                .andExpect(jsonPath("$.message").value(ErrorStatus.BAD_REQUEST.getMessage()))
+                .andExpect(jsonPath("$.data").doesNotExist());
+
+            verify(caffeineIntakeService, times(1)).getCaffeineIntakeDiary(1L, targetYear, targetMonth);
+        }
+
+        @Test
+        @DisplayName("카페인 다이어리 달력 조회 실패, 필수 파라미터 숫자 아님 - 400")
+        void 카페인_다이어리_달력_조회_실패_필수_파라미터_정수_아님() throws Exception {
+            //given
+            String targetYear = "ㅁㄴㅇㄹ";
+            String targetMonth = "abc";
+
+            doThrow(new CustomApiException(ErrorStatus.BAD_REQUEST))
+                .when(caffeineIntakeService).getCaffeineIntakeDiary(1L, targetYear, targetMonth);
+
+            //when
+            ResultActions result = mockMvc.perform(get("/api/v1/caffeine-intakes/monthly")
+                .param("year", targetYear)
+                .param("month", targetMonth)
+                .contentType(MediaType.APPLICATION_JSON));
+
+            //then
+            result.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(ErrorStatus.BAD_REQUEST.getCode()))
+                .andExpect(jsonPath("$.message").value(ErrorStatus.BAD_REQUEST.getMessage()))
+                .andExpect(jsonPath("$.data").doesNotExist());
+
+            verify(caffeineIntakeService, times(1)).getCaffeineIntakeDiary(1L, targetYear, targetMonth);
+        }
+
+        @Test
+        @DisplayName("카페인 다이어리 달력 조회 실패, 서버 오류 - 500")
+        void 카페인_다이어리_달력_조회_실패_서버_오류() throws Exception {
+            //given
+            String targetYear = "2025";
+            String targetMonth = "7";
+
+            doThrow(new RuntimeException("서비스 내부에서 알 수 없는 오류 발생"))
+                .when(caffeineIntakeService).getCaffeineIntakeDiary(1L, targetYear, targetMonth);
+
+            //when
+            ResultActions result = mockMvc.perform(get("/api/v1/caffeine-intakes/monthly")
+                .param("year", targetYear)
+                .param("month", targetMonth)
+                .contentType(MediaType.APPLICATION_JSON));
+
+            //then
+            result.andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.code").value(ErrorStatus.INTERNAL_SERVER_ERROR.getCode()))
+                .andExpect(jsonPath("$.message").value(ErrorStatus.INTERNAL_SERVER_ERROR.getMessage()))
+                .andExpect(jsonPath("$.data").doesNotExist());
+
+            verify(caffeineIntakeService, times(1)).getCaffeineIntakeDiary(1L, targetYear, targetMonth);
+        }
+    }
+
+    @Nested
+    @DisplayName("카페인 다이어리 일별 조회 (GET /api/v1/caffeine-intakes/daily)")
+    @WithMockUser
+    class getDailyCaffeineIntake{
+        @Test
+        @DisplayName("카페인 다이어리 일별 조회 성공 - 200")
+        void 카페인_다이어리_일별_조회_성공() throws Exception {
+            //given
+            String date = "2025-07-01";
+
+            List<DailyCaffeineDiaryResponse.IntakeDetail> mockIntakeDetails = new ArrayList<>();
+            mockIntakeDetails.add(new DailyCaffeineDiaryResponse.IntakeDetail(
+                "101", "drink1", "아메리카노", 1, 150.0f, "2025-06-25T09:00:00"
+            ));
+            mockIntakeDetails.add(new DailyCaffeineDiaryResponse.IntakeDetail(
+                "102", "drink2", "카페라떼", 2, 200.0f, "2025-06-25T14:00:00"
+            ));
+
+            DailyCaffeineDiaryResponse response = new DailyCaffeineDiaryResponse(
+                new DailyCaffeineDiaryResponse.Filter(date),
+                350.0f, // 150 + 200
+                mockIntakeDetails
+            );
+
+            //when
+            when(caffeineIntakeService.getDailyCaffeineIntake(1L, date))
+                .thenReturn(response);
+
+            ResultActions result = mockMvc.perform(get("/api/v1/caffeine-intakes/daily")
+                .param("date", date)
+                .contentType(MediaType.APPLICATION_JSON));
+
+            //then
+            result.andExpect(status().isOk()) // HTTP 200 OK 검증
+                .andExpect(jsonPath("$.code").value(SuccessStatus.DAILY_CAFFEINE_CALENDAR_SUCCESS.getCode()))
+                .andExpect(jsonPath("$.message").value(SuccessStatus.DAILY_CAFFEINE_CALENDAR_SUCCESS.getMessage()))
+                .andExpect(jsonPath("$.data").exists())
+                .andExpect(jsonPath("$.data.filter.date").value(date))
+                .andExpect(jsonPath("$.data.totalCaffeineMg").value(response.totalCaffeineMg()))
+                .andExpect(jsonPath("$.data.intakeList").isArray())
+                .andExpect(jsonPath("$.data.intakeList.length()").value(response.intakeList().size()));
+
+            // intakeList 내부의 각 요소 검증
+            for (int i = 0; i < mockIntakeDetails.size(); i++) {
+                DailyCaffeineDiaryResponse.IntakeDetail detail = mockIntakeDetails.get(i);
+                result.andExpect(jsonPath(String.format("$.data.intakeList[%d].intakeId", i)).value(detail.intakeId()))
+                    .andExpect(jsonPath(String.format("$.data.intakeList[%d].drinkId", i)).value(detail.drinkId()))
+                    .andExpect(jsonPath(String.format("$.data.intakeList[%d].drinkName", i)).value(detail.drinkName()))
+                    .andExpect(jsonPath(String.format("$.data.intakeList[%d].drinkCount", i)).value(detail.drinkCount()))
+                    .andExpect(jsonPath(String.format("$.data.intakeList[%d].caffeineMg", i)).value(detail.caffeineMg()))
+                    .andExpect(jsonPath(String.format("$.data.intakeList[%d].intakeTime", i)).value(detail.intakeTime()));
+            }
+
+
+            verify(caffeineIntakeService, times(1)).getDailyCaffeineIntake(1L, date);
+
+        }
+
+        @Test
+        @DisplayName("카페인 다이어리 일별 조회 실패, 필수 파라미터 null or empty - 400")
+        void 카페인_다이어리_일별_조회_실패_필수_파라미터_null_or_empty() throws Exception {
+            //given
+            String date = "";
+
+            doThrow(new CustomApiException(ErrorStatus.BAD_REQUEST))
+                .when(caffeineIntakeService).getDailyCaffeineIntake(1L, date);
+
+            //when
+            ResultActions result = mockMvc.perform(get("/api/v1/caffeine-intakes/daily")
+                .param("date", date)
+                .contentType(MediaType.APPLICATION_JSON));
+
+            //then
+            result.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(ErrorStatus.BAD_REQUEST.getCode()))
+                .andExpect(jsonPath("$.message").value(ErrorStatus.BAD_REQUEST.getMessage()))
+                .andExpect(jsonPath("$.data").doesNotExist());
+
+            verify(caffeineIntakeService, times(1)).getDailyCaffeineIntake(1L, date);
+        }
+
+        @Test
+        @DisplayName("카페인 다이어리 달력 조회 실패, 유효하지 않은 필수 파라미터 - 400")
+        void 카페인_다이어리_일별_조회_실패_필수_파라미터_정수_아님() throws Exception {
+            //given
+            String date = "2025/07/01";
+
+            doThrow(new CustomApiException(ErrorStatus.BAD_REQUEST))
+                .when(caffeineIntakeService).getDailyCaffeineIntake(1L, date);
+
+            //when
+            ResultActions result = mockMvc.perform(get("/api/v1/caffeine-intakes/daily")
+                .param("date", date)
+                .contentType(MediaType.APPLICATION_JSON));
+
+            //then
+            result.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(ErrorStatus.BAD_REQUEST.getCode()))
+                .andExpect(jsonPath("$.message").value(ErrorStatus.BAD_REQUEST.getMessage()))
+                .andExpect(jsonPath("$.data").doesNotExist());
+
+            verify(caffeineIntakeService, times(1)).getDailyCaffeineIntake(1L, date);
+        }
+
+        @Test
+        @DisplayName("카페인 다이어리 일별 조회 실패, 서버 오류 - 500")
+        void 카페인_다이어리_일별_조회_실패_서버_오류() throws Exception {
+            //given
+            String date = "2025-07-01";
+
+            List<DailyCaffeineDiaryResponse.IntakeDetail> mockIntakeDetails = new ArrayList<>();
+            mockIntakeDetails.add(new DailyCaffeineDiaryResponse.IntakeDetail(
+                "101", "drink1", "아메리카노", 1, 150.0f, "2025-06-25T09:00:00"
+            ));
+            mockIntakeDetails.add(new DailyCaffeineDiaryResponse.IntakeDetail(
+                "102", "drink2", "카페라떼", 2, 200.0f, "2025-06-25T14:00:00"
+            ));
+
+            DailyCaffeineDiaryResponse response = new DailyCaffeineDiaryResponse(
+                new DailyCaffeineDiaryResponse.Filter(date),
+                350.0f, // 150 + 200
+                mockIntakeDetails
+            );
+
+            doThrow(new RuntimeException("서비스 내부에서 알 수 없는 오류 발생"))
+                .when(caffeineIntakeService).getDailyCaffeineIntake(1L, date);
+
+            //when
+
+            ResultActions result = mockMvc.perform(get("/api/v1/caffeine-intakes/daily")
+                .param("date", date)
+                .contentType(MediaType.APPLICATION_JSON));
+
+            //then
+            result.andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.code").value(ErrorStatus.INTERNAL_SERVER_ERROR.getCode()))
+                .andExpect(jsonPath("$.message").value(ErrorStatus.INTERNAL_SERVER_ERROR.getMessage()))
+                .andExpect(jsonPath("$.data").doesNotExist());
+
+            verify(caffeineIntakeService, times(1)).getDailyCaffeineIntake(1L, date);
+        }
+    }
+}
+

--- a/src/test/java/com/ktb/cafeboo/domain/caffeinediary/unit_test/controller/DiaryControllerTest.java
+++ b/src/test/java/com/ktb/cafeboo/domain/caffeinediary/unit_test/controller/DiaryControllerTest.java
@@ -105,7 +105,6 @@ class DiaryControllerTest {
 
     @Nested
     @DisplayName("카페인 섭취 기록 (POST /api/v1/caffeine-intakes)")
-    @WithMockUser
     class RecordCaffeineIntakeTests {
         @Test
         @DisplayName("카페인 기록 성공 - 200 OK")
@@ -130,8 +129,8 @@ class DiaryControllerTest {
             // then
             verify(caffeineIntakeService, times(1)).recordCaffeineIntake(eq(1L), any(CaffeineIntakeRequest.class));
 
-            result.andExpect(jsonPath("$.code").value("CAFFEINE_INTAKE_RECORDED"))
-                .andExpect(jsonPath("$.message").value("카페인 섭취 내역이 성공적으로 등록되었습니다."))
+            result.andExpect(jsonPath("$.code").value(SuccessStatus.CAFFEINE_INTAKE_RECORDED.getCode()))
+                .andExpect(jsonPath("$.message").value(SuccessStatus.CAFFEINE_INTAKE_RECORDED.getMessage()))
                 .andExpect(jsonPath("$.data.id").value(response.id()))
                 .andExpect(jsonPath("$.data.drinkId").value(response.drinkId()))
                 .andExpect(jsonPath("$.data.drinkName").value(response.drinkName()))
@@ -161,8 +160,9 @@ class DiaryControllerTest {
                 .andExpect(status().isBadRequest());
 
             // then
-            result.andExpect(jsonPath("$.code").value("INVALID_INTAKE_INFO"))
-                .andExpect(jsonPath("$.message").value("필수 데이터 필드가 누락되었습니다."));
+            result.andExpect(jsonPath("$.code").value(ErrorStatus.INVALID_INTAKE_INFO.getCode()))
+                .andExpect(jsonPath("$.message").value(ErrorStatus.INVALID_INTAKE_INFO.getMessage()))
+                .andExpect(jsonPath("$.data").doesNotExist());
 
             verify(caffeineIntakeService, times(1)).recordCaffeineIntake(1L, invalidRequest);
         }
@@ -188,8 +188,8 @@ class DiaryControllerTest {
                 .andExpect(status().isInternalServerError());
 
             // then
-            result.andExpect(jsonPath("$.code").value("INTERNAL_SERVER_ERROR"))
-                .andExpect(jsonPath("$.message").value("요청을 처리하는 도중 서버에서 문제가 발생했습니다."))
+            result.andExpect(jsonPath("$.code").value(ErrorStatus.INTERNAL_SERVER_ERROR.getCode()))
+                .andExpect(jsonPath("$.message").value(ErrorStatus.INTERNAL_SERVER_ERROR.getMessage()))
                 .andExpect(jsonPath("$.data").doesNotExist()
                 );
 
@@ -199,7 +199,6 @@ class DiaryControllerTest {
 
     @Nested
     @DisplayName("카페인 섭취 기록 삭제 (DELETE /api/v1/caffeine-intakes)")
-    @WithMockUser
     class DeleteCaffeineIntakeTests{
         @Test
         @DisplayName("카페인 섭취 기록 삭제 성공")
@@ -240,8 +239,8 @@ class DiaryControllerTest {
                 .andExpect(status().isNotFound());
 
             // then
-            result.andExpect(jsonPath("$.code").value("INTAKE_NOT_FOUND"))
-                    .andExpect(jsonPath("$.message").value("섭취 내역을 찾을 수 없습니다."))
+            result.andExpect(jsonPath("$.code").value(ErrorStatus.INTAKE_NOT_FOUND.getCode()))
+                    .andExpect(jsonPath("$.message").value(ErrorStatus.INTAKE_NOT_FOUND.getMessage()))
                     .andExpect(jsonPath("$.data").doesNotExist());
 
             // mock 서비스의 deleteCaffeineIntake 메소드가 정확히 한 번 호출되었는지 검증
@@ -269,8 +268,8 @@ class DiaryControllerTest {
                 .andExpect(status().isInternalServerError());
 
             // then
-            result.andExpect(jsonPath("$.code").value("INTERNAL_SERVER_ERROR"))
-                .andExpect(jsonPath("$.message").value("요청을 처리하는 도중 서버에서 문제가 발생했습니다."))
+            result.andExpect(jsonPath("$.code").value(ErrorStatus.INTERNAL_SERVER_ERROR.getCode()))
+                .andExpect(jsonPath("$.message").value(ErrorStatus.INTERNAL_SERVER_ERROR.getMessage()))
                 .andExpect(jsonPath("$.data").doesNotExist()
                 );
 
@@ -280,7 +279,6 @@ class DiaryControllerTest {
 
     @Nested
     @DisplayName("카페인 섭취 기록 수정 (PATCH /api/v1/caffeine-intakes)")
-    @WithMockUser
     class UpdateCaffeineIntakeTests{
         @Test
         @DisplayName("카페인 섭취 기록 수정 성공")
@@ -308,8 +306,8 @@ class DiaryControllerTest {
                 .andExpect(status().isOk());
 
             // then
-            result.andExpect(jsonPath("$.code").value("CAFFEINE_INTAKE_UPDATED"))
-                .andExpect(jsonPath("$.message").value("카페인 섭취 내역이 성공적으로 수정되었습니다."))
+            result.andExpect(jsonPath("$.code").value(SuccessStatus.CAFFEINE_INTAKE_UPDATED.getCode()))
+                .andExpect(jsonPath("$.message").value(SuccessStatus.CAFFEINE_INTAKE_UPDATED.getMessage()))
                 .andExpect(jsonPath("$.data.id").value(response.id()))
                 .andExpect(jsonPath("$.data.drinkId").value(response.drinkId()))
                 .andExpect(jsonPath("$.data.drinkName").value(response.drinkName()))
@@ -344,8 +342,8 @@ class DiaryControllerTest {
                 .andExpect(status().isNotFound());
 
             // then
-            result.andExpect(jsonPath("$.code").value("INTAKE_NOT_FOUND"))
-                .andExpect(jsonPath("$.message").value("섭취 내역을 찾을 수 없습니다."))
+            result.andExpect(jsonPath("$.code").value(ErrorStatus.INTAKE_NOT_FOUND.getCode()))
+                .andExpect(jsonPath("$.message").value(ErrorStatus.INTAKE_NOT_FOUND.getMessage()))
                 .andExpect(jsonPath("$.data").doesNotExist()
                 );
 
@@ -376,8 +374,8 @@ class DiaryControllerTest {
                 .andExpect(status().isInternalServerError());
 
             // then
-            result.andExpect(jsonPath("$.code").value("INTERNAL_SERVER_ERROR"))
-                .andExpect(jsonPath("$.message").value("요청을 처리하는 도중 서버에서 문제가 발생했습니다."))
+            result.andExpect(jsonPath("$.code").value(ErrorStatus.INTERNAL_SERVER_ERROR.getCode()))
+                .andExpect(jsonPath("$.message").value(ErrorStatus.INTERNAL_SERVER_ERROR.getMessage()))
                 .andExpect(jsonPath("$.data").doesNotExist()
                 );
 
@@ -388,7 +386,6 @@ class DiaryControllerTest {
 
     @Nested
     @DisplayName("카페인 다이어리 달력 조회 (GET /api/v1/caffeine-intakes/monthly)")
-    @WithMockUser
     class getCaffeineIntakeDiaryTests{
 
         @Test
@@ -516,7 +513,6 @@ class DiaryControllerTest {
 
     @Nested
     @DisplayName("카페인 다이어리 일별 조회 (GET /api/v1/caffeine-intakes/daily)")
-    @WithMockUser
     class getDailyCaffeineIntake{
         @Test
         @DisplayName("카페인 다이어리 일별 조회 성공 - 200")


### PR DESCRIPTION
# 📌 Pull Request
테스트 코드 확인 관련 PR
연관된 PR: #220 

## ✨ 작업한 내용
컨트롤러 계층
- [x] DiaryControllerTest

서비스 계층
- [ ] CaffeineIntakeServiceTest 
- [ ] CaffeineResidualServiceTest

## 🛠 변경사항
- 카페인 다이어리 도메인의 컨트롤러 관련 테스트를 작성

## 🔍 테스트 방법(선택)
- `./gradlew clean test jacocoTestReport` 명령어를 실행해 Jacoco로 테스트 커버리지 수치화
![image](https://github.com/user-attachments/assets/4357a754-67d1-4e6f-83d1-130d7891643a)

