### PR TITLE
[FIX] 커피챗 만료 스케줄러 실행 시간 변경

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/scheduler/CoffeeChatScheduler.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/scheduler/CoffeeChatScheduler.java
@@ -19,9 +19,9 @@ public class CoffeeChatScheduler {
     private final CoffeeChatRepository coffeeChatRepository;
 
     /**
-     * 매일 밤 9시(21:00)에 meetingTime 기준 만료 처리
+     * 매일 오전 9시에 meetingTime 기준 만료 처리
      */
-    @Scheduled(cron = "0 0 21 * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 0 9 * * *", zone = "Asia/Seoul")
     @Transactional
     public void expireOutdatedCoffeeChats() {
         LocalDateTime todayMidnight = LocalDate.now().atStartOfDay();


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] 커피챗 만료 스케줄러의 실행 시점을 매일 밤 9시 → 매일 오전 9시로 변경
- [x] 오늘 날짜의 커피챗이 만료되지 않는 문제수정

## 🛠 변경사항
- `@Scheduled(cron = "0 0 9 * * *", zone = "Asia/Seoul")` 으로 변경

## 💬 리뷰 요구사항
-x
