### PR TITLE
[FIX] 커피챗 만료 스케줄러 실행 시간 변경

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -91,9 +91,9 @@ jobs:
           touch /opt/promtail/positions.yaml
           chown 65534:65534 /opt/promtail/positions.yaml
           
-          INSTANCE_NAME=$(curl -s -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/name)
+          INSTANCE_NAME=\$(curl -s -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/name)
 
-          cat <<EOC > /opt/promtail/promtail-config.yaml
+          cat > /opt/promtail/promtail.yaml <<EOC
           server:
             http_listen_port: 9080
             grpc_listen_port: 0
@@ -109,16 +109,17 @@ jobs:
                   labels:
                     job: back
                     app: cafeboo
-                    instance: "${HOSTNAME}"
+                    instance: "\${INSTANCE_NAME}"
                     __path__: /var/lib/docker/containers/*/*.log
           EOC
+          touch /opt/promtail/positions.yaml
+          chown 65534:65534 /opt/promtail/positions.yaml
 
           docker stop promtail || true
           docker rm promtail || true
 
           docker run -d --name promtail --network host \
             -v /var/lib/docker/containers:/var/lib/docker/containers:ro \
-            -v /opt/promtail/promtail-config.yaml:/etc/promtail/promtail.yaml \
             -v /opt/promtail:/etc/promtail \
             grafana/promtail:2.9.4 \
             -config.file=/etc/promtail/promtail.yaml


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] 커피챗 만료 스케줄러의 실행 시점을 매일 밤 9시 → 매일 오전 9시로 변경
- [x] 오늘 날짜의 커피챗이 만료되지 않는 문제수정

## 🛠 변경사항
- `@Scheduled(cron = "0 0 9 * * *", zone = "Asia/Seoul")` 으로 변경

## 💬 리뷰 요구사항
-x
