### PR TITLE
[FEAT] 음료 추천 API 추가

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/ai/controller/DrinkRecommendationController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/ai/controller/DrinkRecommendationController.java
@@ -1,0 +1,49 @@
+package com.ktb.cafeboo.domain.ai.controller;
+
+import com.ktb.cafeboo.domain.ai.service.DrinkRecommendationService;
+import com.ktb.cafeboo.global.apiPayload.ApiResponse;
+import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
+import com.ktb.cafeboo.global.apiPayload.code.status.SuccessStatus;
+import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
+import com.ktb.cafeboo.global.infra.ai.dto.CreateDrinkRecommendationResponse;
+import com.ktb.cafeboo.global.security.userdetails.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/api/v2/drink-recommendation")
+public class DrinkRecommendationController {
+
+    private final DrinkRecommendationService recommendationService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<?>> getRecommendation(@AuthenticationPrincipal CustomUserDetails userDetails){
+        Long userId = userDetails.getId();
+
+        try{
+            CreateDrinkRecommendationResponse response = recommendationService.getRecommendationResult(userId);
+
+            return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.of(SuccessStatus.RECOMMENDATION_GENERATE_SUCCESS, response));
+        }
+        catch (CustomApiException e){
+            return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.of(ErrorStatus.BAD_REQUEST, null));
+        }
+        catch (Exception e) {
+            return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.of(ErrorStatus.INTERNAL_SERVER_ERROR, null));
+        }
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/domain/ai/service/DrinkRecommendationService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/ai/service/DrinkRecommendationService.java
@@ -1,0 +1,59 @@
+package com.ktb.cafeboo.domain.ai.service;
+
+import com.ktb.cafeboo.domain.user.model.User;
+import com.ktb.cafeboo.domain.user.model.UserCaffeineInfo;
+import com.ktb.cafeboo.domain.user.model.UserHealthInfo;
+import com.ktb.cafeboo.domain.user.service.UserService;
+import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
+import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
+import com.ktb.cafeboo.global.infra.ai.client.AiServerClient;
+import com.ktb.cafeboo.global.infra.ai.dto.CreateDrinkRecommendationRequest;
+import com.ktb.cafeboo.global.infra.ai.dto.CreateDrinkRecommendationResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DrinkRecommendationService {
+    private final AiServerClient aiServerClient;
+    private final UserService userService;
+
+    public CreateDrinkRecommendationResponse getRecommendationResult(Long userId){
+
+        User user = userService.findUserById(userId);
+
+        UserHealthInfo healthInfo = user.getHealthInfo();
+        if (healthInfo == null) {
+            log.warn("[CreateDrinkRecommendationResponse.getRecommendationResult] 사용자 건강 정보 없음 - userId={}", user.getId());
+            throw new CustomApiException(ErrorStatus.HEALTH_PROFILE_NOT_FOUND);
+        }
+
+        UserCaffeineInfo caffeineInfo = user.getCaffeinInfo();
+        if (caffeineInfo == null) {
+            log.warn("[CaffeineRecommendationService.getRecommendationResult] 사용자 카페인 정보 없음 - userId={}", user.getId());
+            throw new CustomApiException(ErrorStatus.CAFFEINE_PROFILE_NOT_FOUND);
+        }
+
+        CreateDrinkRecommendationRequest request = CreateDrinkRecommendationRequest.builder()
+            .gender(healthInfo.getGender())
+            .age(healthInfo.getAge())
+            .weight(healthInfo.getWeight())
+            .height(healthInfo.getHeight())
+            .isSmoking(healthInfo.getSmoking() ? 1 : 0)
+            .isTakingBirthPill(healthInfo.getTakingBirthPill() ? 1 : 0)
+            .isPregnant(healthInfo.getPregnant() ? 1 : 0)
+            .caffeineSensitivity(caffeineInfo.getCaffeineSensitivity())
+            .build();
+
+        CreateDrinkRecommendationResponse response = aiServerClient.createCoffeeRecommendation(request);
+
+        if (!"success".equals(response.getStatus())) {
+            log.error("[CaffeineRecommendationService.getPredictedCaffeineLimitByRule] AI 서버 예측 실패 - message={}", response.getMessage());
+            throw new CustomApiException(ErrorStatus.AI_SERVER_ERROR);
+        }
+
+        return response;
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/domain/report/service/WeeklyReportService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/report/service/WeeklyReportService.java
@@ -1,6 +1,5 @@
 package com.ktb.cafeboo.domain.report.service;
 
-import com.ktb.cafeboo.domain.caffeinediary.model.CaffeineIntake;
 import com.ktb.cafeboo.domain.report.dto.MonthlyCaffeineReportResponse;
 import com.ktb.cafeboo.domain.report.dto.WeeklyCaffeineReportResponse;
 import com.ktb.cafeboo.domain.report.model.DailyStatistics;
@@ -8,15 +7,12 @@ import com.ktb.cafeboo.domain.report.model.MonthlyReport;
 import com.ktb.cafeboo.domain.report.model.WeeklyReport;
 import com.ktb.cafeboo.domain.report.repository.WeeklyReportRepository;
 import com.ktb.cafeboo.domain.user.model.User;
-import com.ktb.cafeboo.domain.user.model.UserCaffeinInfo;
-import com.ktb.cafeboo.domain.user.model.UserHealthInfo;
+import com.ktb.cafeboo.domain.user.model.UserCaffeineInfo;
 import com.ktb.cafeboo.domain.user.service.UserService;
 import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
 import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
-import com.ktb.cafeboo.global.infra.ai.client.AiServerClient;
 import com.ktb.cafeboo.global.infra.ai.dto.ReceiveWeeklyAnalysisRequest;
 import jakarta.transaction.Transactional;
-import java.time.DateTimeException;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.YearMonth;
@@ -74,7 +70,7 @@ public class WeeklyReportService {
         int week = Integer.parseInt(targetWeek);
 
         User user = userService.findUserById(userId);
-        UserCaffeinInfo userCaffeinInfo = user.getCaffeinInfo();
+        UserCaffeineInfo userCaffeineInfo = user.getCaffeinInfo();
 
         LocalDate startOfMonth = LocalDate.of(year, month, 1);;
         DayOfWeek dayOfWeek = startOfMonth.getDayOfWeek();
@@ -147,7 +143,7 @@ public class WeeklyReportService {
             startDate.toString(),
             endDate.toString(),
             weeklyTotal,
-            (int) userCaffeinInfo.getDailyCaffeineLimitMg(),
+            (int) userCaffeineInfo.getDailyCaffeineLimitMg(),
             overLimitDays,
             dailyAvg,
             dailyIntakeTotals,

--- a/src/main/java/com/ktb/cafeboo/domain/user/mapper/UserCaffeineInfoMapper.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/mapper/UserCaffeineInfoMapper.java
@@ -4,7 +4,7 @@ import com.ktb.cafeboo.domain.user.dto.UserCaffeineInfoCreateRequest;
 import com.ktb.cafeboo.domain.user.dto.UserCaffeineInfoResponse;
 import com.ktb.cafeboo.domain.user.dto.UserCaffeineInfoUpdateRequest;
 import com.ktb.cafeboo.domain.user.model.User;
-import com.ktb.cafeboo.domain.user.model.UserCaffeinInfo;
+import com.ktb.cafeboo.domain.user.model.UserCaffeineInfo;
 
 import java.time.LocalTime;
 import java.util.List;
@@ -12,9 +12,9 @@ import java.util.Optional;
 
 public class UserCaffeineInfoMapper {
 
-    public static UserCaffeinInfo toEntity(UserCaffeineInfoCreateRequest dto, User user) {
+    public static UserCaffeineInfo toEntity(UserCaffeineInfoCreateRequest dto, User user) {
 
-        return UserCaffeinInfo.builder()
+        return UserCaffeineInfo.builder()
                 .user(user)
                 .caffeineSensitivity(dto.caffeineSensitivity())
                 .averageDailyCaffeineIntake(dto.averageDailyCaffeineIntake())
@@ -22,7 +22,7 @@ public class UserCaffeineInfoMapper {
                 .build();
     }
 
-    public static void updateEntity(UserCaffeinInfo entity, UserCaffeineInfoUpdateRequest dto) {
+    public static void updateEntity(UserCaffeineInfo entity, UserCaffeineInfoUpdateRequest dto) {
         if (dto.caffeineSensitivity() != null)
             entity.setCaffeineSensitivity(dto.caffeineSensitivity());
         if (dto.averageDailyCaffeineIntake() != null)
@@ -31,7 +31,7 @@ public class UserCaffeineInfoMapper {
             entity.setFrequentDrinkTime(LocalTime.parse(dto.frequentDrinkTime()));
     }
 
-    public static UserCaffeineInfoResponse toResponse(UserCaffeinInfo entity) {
+    public static UserCaffeineInfoResponse toResponse(UserCaffeineInfo entity) {
         List<String> favoriteDrinks = Optional.ofNullable(entity.getUser().getFavoriteDrinks())
                 .orElse(List.of())
                 .stream()

--- a/src/main/java/com/ktb/cafeboo/domain/user/model/User.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/model/User.java
@@ -62,7 +62,7 @@ public class User extends BaseEntity {
     private UserHealthInfo healthInfo;
 
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-    private UserCaffeinInfo caffeinInfo;
+    private UserCaffeineInfo caffeinInfo;
 
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private UserAlarmSetting alarmSetting;

--- a/src/main/java/com/ktb/cafeboo/domain/user/model/UserCaffeineInfo.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/model/UserCaffeineInfo.java
@@ -15,7 +15,7 @@ import java.time.LocalTime;
 @NoArgsConstructor
 @Table(name = "user_caffeine_info")
 @Where(clause = "deleted_at IS NULL")
-public class UserCaffeinInfo extends BaseEntity {
+public class UserCaffeineInfo extends BaseEntity {
     @OneToOne
     @MapsId
     @JoinColumn(name = "user_id")

--- a/src/main/java/com/ktb/cafeboo/domain/user/repository/UserAlarmSettingRepository.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/repository/UserAlarmSettingRepository.java
@@ -1,7 +1,6 @@
 package com.ktb.cafeboo.domain.user.repository;
 
 import com.ktb.cafeboo.domain.user.model.UserAlarmSetting;
-import com.ktb.cafeboo.domain.user.model.UserCaffeinInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserAlarmSettingRepository extends JpaRepository<UserAlarmSetting, Long> {

--- a/src/main/java/com/ktb/cafeboo/domain/user/repository/UserCaffeineInfoRepository.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/repository/UserCaffeineInfoRepository.java
@@ -1,8 +1,8 @@
 package com.ktb.cafeboo.domain.user.repository;
 
-import com.ktb.cafeboo.domain.user.model.UserCaffeinInfo;
+import com.ktb.cafeboo.domain.user.model.UserCaffeineInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserCaffeineInfoRepository extends JpaRepository<UserCaffeinInfo, Long> {
+public interface UserCaffeineInfoRepository extends JpaRepository<UserCaffeineInfo, Long> {
     boolean existsByUserId(Long userId);
 }

--- a/src/main/java/com/ktb/cafeboo/domain/user/service/UserCaffeineInfoService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/service/UserCaffeineInfoService.java
@@ -7,7 +7,7 @@ import com.ktb.cafeboo.domain.report.service.DailyStatisticsService;
 import com.ktb.cafeboo.domain.user.dto.*;
 import com.ktb.cafeboo.domain.user.mapper.UserCaffeineInfoMapper;
 import com.ktb.cafeboo.domain.user.model.User;
-import com.ktb.cafeboo.domain.user.model.UserCaffeinInfo;
+import com.ktb.cafeboo.domain.user.model.UserCaffeineInfo;
 import com.ktb.cafeboo.domain.user.model.UserFavoriteDrinkType;
 import com.ktb.cafeboo.domain.user.repository.UserCaffeineInfoRepository;
 import com.ktb.cafeboo.domain.user.repository.UserRepository;
@@ -52,7 +52,7 @@ public class UserCaffeineInfoService {
         }
 
         try {
-            UserCaffeinInfo entity = UserCaffeineInfoMapper.toEntity(request, user);
+            UserCaffeineInfo entity = UserCaffeineInfoMapper.toEntity(request, user);
             entity.setSleepSensitiveThresholdMg(100f);  // 기본값
 
             try {
@@ -103,7 +103,7 @@ public class UserCaffeineInfoService {
                     return new CustomApiException(ErrorStatus.USER_NOT_FOUND);
                 });
 
-        UserCaffeinInfo entity = user.getCaffeinInfo();
+        UserCaffeineInfo entity = user.getCaffeinInfo();
         if (entity == null) {
             log.warn("[UserCaffeineInfoService.update] 카페인 정보 없음 - userId={}", userId);
             throw new CustomApiException(ErrorStatus.CAFFEINE_PROFILE_NOT_FOUND);
@@ -176,7 +176,7 @@ public class UserCaffeineInfoService {
                     return new CustomApiException(ErrorStatus.USER_NOT_FOUND);
                 });
 
-        UserCaffeinInfo entity = user.getCaffeinInfo();
+        UserCaffeineInfo entity = user.getCaffeinInfo();
         if (entity == null) {
             log.warn("[UserCaffeineInfoService.getCaffeineInfo] 카페인 정보 없음 - userId={}", userId);
             throw new CustomApiException(ErrorStatus.CAFFEINE_PROFILE_NOT_FOUND);

--- a/src/main/java/com/ktb/cafeboo/domain/user/service/UserHealthInfoService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/service/UserHealthInfoService.java
@@ -5,7 +5,7 @@ import com.ktb.cafeboo.domain.report.service.DailyStatisticsService;
 import com.ktb.cafeboo.domain.user.dto.*;
 import com.ktb.cafeboo.domain.user.mapper.UserHealthInfoMapper;
 import com.ktb.cafeboo.domain.user.model.User;
-import com.ktb.cafeboo.domain.user.model.UserCaffeinInfo;
+import com.ktb.cafeboo.domain.user.model.UserCaffeineInfo;
 import com.ktb.cafeboo.domain.user.model.UserHealthInfo;
 import com.ktb.cafeboo.domain.user.repository.UserHealthInfoRepository;
 import com.ktb.cafeboo.domain.user.repository.UserRepository;
@@ -77,7 +77,7 @@ public class UserHealthInfoService {
             UserHealthInfoMapper.updateEntity(healthInfo, request);
 
             try {
-                UserCaffeinInfo caffeinInfo = user.getCaffeinInfo();
+                UserCaffeineInfo caffeinInfo = user.getCaffeinInfo();
                 if (caffeinInfo != null) {
                     float predictedLimit = caffeineRecommendationService.getPredictedCaffeineLimitByRule(user, caffeinInfo.getCaffeineSensitivity());
                     caffeinInfo.setDailyCaffeineLimitMg(predictedLimit);

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/SuccessStatus.java
@@ -53,6 +53,7 @@ public enum SuccessStatus implements BaseCode {
 
     //AI 리포트 생성 관련 응답
     REPORT_GENERATION_SUCCESS(200, "AI_GENERATION_REPORT", "AI 리포트 생성 요청 성공"),
+    RECOMMENDATION_GENERATE_SUCCESS(200, "RECOMMENDATION_GENERATE_SUCESS", "커피 추천 목록 생성 성공"),
 
     //커피챗 관련 응답
     COFFEECHAT_CREATE_SUCCESS(201, "COFFEECHAT_CREATE_SUCCESS", "커피챗이 성공적으로 생성되었습니다."),

--- a/src/main/java/com/ktb/cafeboo/global/infra/ai/client/AiServerClient.java
+++ b/src/main/java/com/ktb/cafeboo/global/infra/ai/client/AiServerClient.java
@@ -1,5 +1,7 @@
 package com.ktb.cafeboo.global.infra.ai.client;
 
+import com.ktb.cafeboo.global.infra.ai.dto.CreateDrinkRecommendationRequest;
+import com.ktb.cafeboo.global.infra.ai.dto.CreateDrinkRecommendationResponse;
 import com.ktb.cafeboo.global.infra.ai.dto.CreateWeeklyAnalysisRequest;
 import com.ktb.cafeboo.global.infra.ai.dto.CreateWeeklyAnalysisResponse;
 import com.ktb.cafeboo.global.infra.ai.dto.PredictCaffeineLimitByRuleRequest;
@@ -58,6 +60,17 @@ public class AiServerClient {
                 .retrieve()
                 .bodyToMono(ToxicityDetectionResponse.class)
                 .block();
+    }
+
+    public CreateDrinkRecommendationResponse createCoffeeRecommendation(
+        CreateDrinkRecommendationRequest request){
+        return aiServerWebClient.post()
+            .uri("/internal/ai/drink_recommendation")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(request)
+            .retrieve()
+            .bodyToMono(CreateDrinkRecommendationResponse.class)
+            .block();
     }
 }
 

--- a/src/main/java/com/ktb/cafeboo/global/infra/ai/dto/CreateDrinkRecommendationRequest.java
+++ b/src/main/java/com/ktb/cafeboo/global/infra/ai/dto/CreateDrinkRecommendationRequest.java
@@ -1,0 +1,23 @@
+package com.ktb.cafeboo.global.infra.ai.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class CreateDrinkRecommendationRequest {
+    private String gender;
+    private int age;
+    private float height;
+    private float weight;
+    private int isPregnant;
+    private int isTakingBirthPill;
+    private int isSmoking;
+    private int caffeineSensitivity;
+    private float avgIntakePerDay;
+    private float avgCaffeineAmount;
+    private float dailyCaffeineLimit;
+}

--- a/src/main/java/com/ktb/cafeboo/global/infra/ai/dto/CreateDrinkRecommendationResponse.java
+++ b/src/main/java/com/ktb/cafeboo/global/infra/ai/dto/CreateDrinkRecommendationResponse.java
@@ -1,0 +1,46 @@
+package com.ktb.cafeboo.global.infra.ai.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class CreateDrinkRecommendationResponse {
+    private String status;
+    private String message;
+    private Data data;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static class Data {
+        private String status;
+        private RecommendationDetails data;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static class RecommendationDetails {
+        private List<Recommendation> recommendedDrinks;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static class Recommendation {
+        private Long drinkId;
+        private Double score;
+    }
+}


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] AI서버와의 통신을 통한 음료 추천 목록을 받아와 response로 반환하는 일련의 흐름을 구현했습니다.

## 🛠 변경사항
- AI 도메인에 음료 추천과 관련된 컨트롤러 추가 및 서비스 부분의 수정을 진행했습니다. 

## 💬 리뷰 요구사항
- 건의사항 있으시면 코멘트 남겨주세요. 
- 현재 로컬 서버에는 저 이외에 다른 유저 정보가 없어서 다음 그림과 같이 음료 추천 목록이 null로 나오는 것 같습니다. PR 머지 후 dev 서버에서 결과값이 어떻게 반환되는지 확인이 필요해보입니다. 

## 🔍 테스트 방법(선택)
- Postman을 이용한 API 호출을 통해 의도한 response 형태가 반환되었는지 확인 진행했습니다. 
