### PR TITLE
Refactor/eden.lee/coffeechat

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/common/CoffeeChatReviewPreviewDto.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/common/CoffeeChatReviewPreviewDto.java
@@ -14,11 +14,11 @@ public record CoffeeChatReviewPreviewDto(
         int imagesCount,
         String previewImageUrl
 ) {
-    public static CoffeeChatReviewPreviewDto from(CoffeeChat coffeeChat, int imagesCount, String previewImageUrl, boolean liked) {
+    public static CoffeeChatReviewPreviewDto from(CoffeeChat coffeeChat, List<String> tagNames, int imagesCount, String previewImageUrl, boolean liked) {
         return new CoffeeChatReviewPreviewDto(
                 coffeeChat.getId().toString(),
                 coffeeChat.getName(),
-                coffeeChat.getTagNames(),
+                tagNames,
                 coffeeChat.getAddress(),
                 coffeeChat.getLikesCount(),
                 liked,

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/repository/CoffeeChatLikeRepository.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/repository/CoffeeChatLikeRepository.java
@@ -3,7 +3,9 @@ package com.ktb.cafeboo.domain.coffeechat.repository;
 import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatLike;
 import com.ktb.cafeboo.global.enums.CoffeeChatLikeStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CoffeeChatLikeRepository extends JpaRepository<CoffeeChatLike, Long> {
@@ -11,4 +13,12 @@ public interface CoffeeChatLikeRepository extends JpaRepository<CoffeeChatLike, 
     Optional<CoffeeChatLike> findByCoffeeChatIdAndUserId(Long coffeeChatId, Long userId);
 
     boolean existsByCoffeeChatIdAndUserIdAndStatus(Long coffeeChatId, Long userId, CoffeeChatLikeStatus status);
+
+    @Query("""
+        SELECT cl FROM CoffeeChatLike cl
+        WHERE cl.user.id = :userId
+        AND cl.status = 'ACTIVE'
+        AND cl.coffeeChat.id IN :chatIds
+    """)
+    List<CoffeeChatLike> findLikesByUserAndChatIds(Long userId, List<Long> chatIds);
 }

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/repository/CoffeeChatReviewImageRepository.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/repository/CoffeeChatReviewImageRepository.java
@@ -1,0 +1,17 @@
+package com.ktb.cafeboo.domain.coffeechat.repository;
+
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatReviewImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface CoffeeChatReviewImageRepository extends JpaRepository<CoffeeChatReviewImage, Long> {
+    @Query("""
+        SELECT ri FROM CoffeeChatReviewImage ri
+        WHERE ri.review.id IN :reviewIds
+        ORDER BY ri.sortOrder
+    """)
+    List<CoffeeChatReviewImage> findAllByReviewIds(@Param("reviewIds") List<Long> reviewIds);
+}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatLikeService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatLikeService.java
@@ -14,6 +14,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class CoffeeChatLikeService {
@@ -63,5 +69,20 @@ public class CoffeeChatLikeService {
                 userId,
                 CoffeeChatLikeStatus.ACTIVE
         );
+    }
+
+    @Transactional(readOnly = true)
+    public Map<Long, Boolean> bulkCheckLiked(Long userId, List<Long> chatIds) {
+        List<CoffeeChatLike> likes = coffeeChatLikeRepository.findLikesByUserAndChatIds(userId, chatIds);
+
+        Set<Long> likedChatIds = likes.stream()
+                .map(like -> like.getCoffeeChat().getId())
+                .collect(Collectors.toSet());
+
+        return chatIds.stream()
+                .collect(Collectors.toMap(
+                        Function.identity(),
+                        likedChatIds::contains
+                ));
     }
 }

--- a/src/main/java/com/ktb/cafeboo/domain/tag/repository/CoffeeChatTagRepository.java
+++ b/src/main/java/com/ktb/cafeboo/domain/tag/repository/CoffeeChatTagRepository.java
@@ -1,11 +1,16 @@
 package com.ktb.cafeboo.domain.tag.repository;
 
-import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChat;
 import com.ktb.cafeboo.domain.tag.model.CoffeeChatTag;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface CoffeeChatTagRepository extends JpaRepository<CoffeeChatTag, Long> {
-    List<CoffeeChatTag> findAllByCoffeeChat(CoffeeChat coffeeChat);
+    @Query("""
+        SELECT cct FROM CoffeeChatTag cct
+        WHERE cct.coffeeChat.id IN :chatIds
+    """)
+    List<CoffeeChatTag> findByChatIds(List<Long> chatIds);
+
 }


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] 커피챗 후기 목록 조회 API에서 N+1 문제를 해결하고 성능 개선
- [x] 좋아요 상태, 리뷰 이미지, 태그 데이터를 IN 절 기반으로 한 번에 불러오는 방식으로 변경

## 🛠 변경사항
- N+1 문제 해결을 위해 Repository 계층에 IN 조건 기반의 일괄 조회 메서드 추가
- 서비스 계층에서 각각의 조회 결과를 Map으로 가공하여 DTO 변환 시 빠르게 접근 가능하도록 개선

## 💬 리뷰 요구사항
- N+1 문제를 해결한 방식에 대해 더 좋은 의견이 있거나, 궁금한 점 있으면 코멘트 주세요

## 🔍 테스트 방법(선택)
- IntelliJ Ultimate 프로파일러 활용 병목 지점 파악 및 개선 확인
- 후기 목록 API 호출 시 쿼리 수 감소 여부 확인
- JMeter를 활용하여, 응답속도와 처리량 개선 측정


항목 | 요청 타입 | 개선 전 | 개선 후 | 변화량
-- | -- | -- | -- | --
평균 응답 속도 (ms) | ALL | 474 | 209 | ▽ 265ms
  | MY | 447 | 201 | ▽ 246ms
최대 응답 속도 (ms) | ALL | 1598 | 768 | ▽ 830ms
  | MY | 1516 | 670 | ▽ 846ms
Throughput (req/sec) | ALL | 316.4 | 537.9 | ▲ 약 70% 증가
  | MY | 329.9 | 549.8 | ▲ 약 67% 증가
CPU 사용률 (%) | ALL | 51% | 50% | ▽ 1%
  | MY | 59% | 49% | ▽ 10%

