### PR TITLE
[FEAT] Kafka 관련 설정 추가 및 메시지 발행 비즈니스 로직 수정

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/ChatService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/ChatService.java
@@ -13,6 +13,7 @@ import com.ktb.cafeboo.global.censorship.CensorshipStrategy;
 import com.ktb.cafeboo.global.censorship.TextCensorshipFilter;
 import com.ktb.cafeboo.global.config.RedisConfig;
 import com.ktb.cafeboo.global.enums.MessageType;
+import com.ktb.cafeboo.global.infra.kafka.producer.KafkaMessageProducer;
 import com.ktb.cafeboo.global.infra.redis.stream.listener.RedisStreamListener;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
@@ -71,6 +72,7 @@ public class ChatService {
     private final CoffeeChatMemberRepository coffeeChatMemberRepository;
     private final CoffeeChatMessageService coffeeChatMessageService;
     private final TextCensorshipFilter textCensorshipFilter;
+    private final KafkaMessageProducer kafkaMessageProducer;
 
     private static final String CHAT_STREAM_PREFIX = "coffeechat:room:";
     private static final String CHAT_CONSUMER_GROUP_PREFIX = "coffeechat:group:";
@@ -161,11 +163,12 @@ public class ChatService {
 
             log.info("[ChatService.handleNewMessage] - 직렬화 전 messagePublish 객체 데이터: {}", messagePublish);
 
-            ObjectRecord<String, StompMessagePublish> record =
-                ObjectRecord.create(streamKey, messagePublish); // 스트림 키 지정 (필수)
-
-            RecordId recordId = redisTemplate.opsForStream().add(record);
-            log.info("[ChatService.handleNewMessage] - Stream {}에 추가된 메시지: {}", streamKey, recordId.getValue());
+//            ObjectRecord<String, StompMessagePublish> record =
+//                ObjectRecord.create(streamKey, messagePublish); // 스트림 키 지정 (필수)
+//
+//            RecordId recordId = redisTemplate.opsForStream().add(record);
+            kafkaMessageProducer.publishChatMessage(messagePublish);
+            log.info("[ChatService.handleNewMessage] - Kafka 토픽 {}에 추가된 메시지: {}", KafkaMessageProducer.CHAT_MESSAGES_TOPIC, messagePublish.getMessageId());
         }
         catch (Exception e){
             log.error("[ChatService.handleNewMessage] - 메시지 전송 오류. roomId: {}, message: {}", message.getCoffeechatId(), e.getMessage(), e);

--- a/src/main/java/com/ktb/cafeboo/global/config/KafkaConsumerConfiguration.java
+++ b/src/main/java/com/ktb/cafeboo/global/config/KafkaConsumerConfiguration.java
@@ -1,0 +1,69 @@
+package com.ktb.cafeboo.global.config;
+
+import com.ktb.cafeboo.domain.coffeechat.dto.StompMessagePublish;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.ContainerProperties.AckMode;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import software.amazon.awssdk.utils.ImmutableMap;
+
+@EnableKafka
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class KafkaConsumerConfiguration {
+
+    @Value("${spring.application.name}") // 기본값도 지정할 수 있습니다.
+    private String kafkaConsumerGroupIdPrefix;
+
+    @Value("${kafka.dlq.topic}")
+    private String dlqTopic;
+
+    @Bean
+    public ConsumerFactory<String, StompMessagePublish> consumerFactory(){
+        String kafkaConsumerGroupId = kafkaConsumerGroupIdPrefix + java.util.UUID.randomUUID().toString();
+
+        JsonDeserializer<StompMessagePublish> jsonDeserializer = new JsonDeserializer<>(StompMessagePublish.class, false);
+        jsonDeserializer.addTrustedPackages("*");
+
+        ErrorHandlingDeserializer<StompMessagePublish> errorHandlingValueDeserializer = new ErrorHandlingDeserializer<>(jsonDeserializer);
+
+        Map<String, Object> consumerConfigurations =
+            ImmutableMap.<String, Object>builder()
+                .put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092")
+                .put(ConsumerConfig.GROUP_ID_CONFIG, kafkaConsumerGroupId)
+                .put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class)
+                .put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class)
+                .put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, jsonDeserializer.getClass().getName())
+                .put(ErrorHandlingDeserializer.KEY_DESERIALIZER_CLASS, StringDeserializer.class.getName())
+                .put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest")
+                .put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false)
+                .build();
+
+        log.info("[KafkaConsumerConfiguration.consumerFactory] group id {}를 가지는 consumerFactory 생성", kafkaConsumerGroupId);
+
+        return new DefaultKafkaConsumerFactory<>(consumerConfigurations);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, StompMessagePublish> kafkaListenerContainerFactory(){
+        ConcurrentKafkaListenerContainerFactory<String, StompMessagePublish> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        factory.getContainerProperties().setAckMode(AckMode.MANUAL_IMMEDIATE);
+        factory.setConcurrency(Runtime.getRuntime().availableProcessors());
+        return factory;
+    }
+
+
+}

--- a/src/main/java/com/ktb/cafeboo/global/config/KafkaProducerConfiguration.java
+++ b/src/main/java/com/ktb/cafeboo/global/config/KafkaProducerConfiguration.java
@@ -1,0 +1,59 @@
+package com.ktb.cafeboo.global.config;
+
+import com.ktb.cafeboo.domain.coffeechat.dto.StompMessagePublish;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+import software.amazon.awssdk.utils.ImmutableMap;
+
+@EnableKafka
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class KafkaProducerConfiguration {
+
+    @Bean
+    public ProducerFactory<String, StompMessagePublish> producerFactory() {
+       Map<String, Object> producerConfigurations =
+           ImmutableMap.<String, Object>builder()
+               .put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092")
+               .put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class)
+               .put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class)
+               .put(JsonSerializer.ADD_TYPE_INFO_HEADERS, false)
+               .build();
+
+        return new DefaultKafkaProducerFactory<>(producerConfigurations);
+    }
+
+    // KafkaTemplate을 생성하는 Bean 메서드
+    @Bean
+    public KafkaTemplate<String, StompMessagePublish> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+    @Bean
+    public ProducerFactory<String, Object> dlqProducerFactory(){
+        Map<String, Object> producerConfigurations =
+            ImmutableMap.<String, Object>builder()
+                .put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092")
+                .put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class)
+                .put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class)
+                .put(JsonSerializer.ADD_TYPE_INFO_HEADERS, false) // DLQ 메시지도 JSON으로 직렬화 (오류 정보 포함 가능)
+                .build();
+        return new DefaultKafkaProducerFactory<>(producerConfigurations);
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> dlqKafkaTemplate() {
+        return new KafkaTemplate<>(dlqProducerFactory());
+    }
+
+}

--- a/src/main/java/com/ktb/cafeboo/global/infra/kafka/consumer/KafkaMessageListener.java
+++ b/src/main/java/com/ktb/cafeboo/global/infra/kafka/consumer/KafkaMessageListener.java
@@ -1,0 +1,39 @@
+package com.ktb.cafeboo.global.infra.kafka.consumer;
+
+import com.ktb.cafeboo.domain.coffeechat.dto.StompMessagePublish;
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatMessage;
+import com.ktb.cafeboo.global.infra.kafka.producer.KafkaMessageProducer;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.listener.AcknowledgingMessageListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class KafkaMessageListener implements AcknowledgingMessageListener<String, StompMessagePublish> {
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @KafkaListener(topics = KafkaMessageProducer.CHAT_MESSAGES_TOPIC,
+                   containerFactory = "kafkaListenerContainerFactory")
+    @Override
+    public void onMessage(ConsumerRecord<String, StompMessagePublish> record, Acknowledgment acknowledgment) {
+        String roomId = record.key();
+        StompMessagePublish stompMessage = record.value();
+
+        log.info("[KafkaChatMessageListener] Received message from Kafka for WebSockets. Topic: '{}', Partition: {}, Offset: {}. Room ID: {}, Message ID: {}",
+            record.topic(), record.partition(), record.offset(), roomId, stompMessage.getMessageId());
+
+        try{
+            messagingTemplate.convertAndSend("/topic/chatrooms/" + roomId, stompMessage);
+            acknowledgment.acknowledge();
+        }
+        catch (Exception e) {
+
+        }
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/global/infra/kafka/producer/KafkaMessageProducer.java
+++ b/src/main/java/com/ktb/cafeboo/global/infra/kafka/producer/KafkaMessageProducer.java
@@ -1,0 +1,34 @@
+package com.ktb.cafeboo.global.infra.kafka.producer;
+
+import com.ktb.cafeboo.domain.coffeechat.dto.StompMessagePublish;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class KafkaMessageProducer {
+    public static final String CHAT_MESSAGES_TOPIC = "coffeechat-messages";
+
+    private final KafkaTemplate<String, StompMessagePublish> kafkaTemplate;
+
+    public void publishChatMessage(StompMessagePublish message) {
+        String messageKey = String.valueOf(message.getCoffeechatId());
+
+        log.info("Sending message to Kafka topic '{}' with key '{}': {}",
+            CHAT_MESSAGES_TOPIC, messageKey, message);
+
+        kafkaTemplate.send(CHAT_MESSAGES_TOPIC, messageKey, message)
+            .whenComplete((result, ex) -> {
+                if (ex == null) {
+                    log.info("Message sent successfully to partition {} with offset {}",
+                        result.getRecordMetadata().partition(),
+                        result.getRecordMetadata().offset());
+                } else {
+                    log.error("Failed to send message: {}", ex.getMessage(), ex);
+                }
+            });
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -34,6 +34,10 @@ ai.server.base-url: http://localhost:8000
 spring.data.redis.host=localhost
 spring.data.redis.port=6379
 
+# Kafka
+spring.kafka.bootstrap-servers=localhost:9092
+spring.kafka.consumer.group-id=myGroup
+
 # JWT
 jwt.secret=${JWT_SECRET}
 
@@ -60,5 +64,5 @@ spring.servlet.multipart.max-request-size=20MB
 censorship.blacklist-filename: censorship-blacklist-keywords.txt
 censorship.whitelist-filename: censorship-whitelist-keywords.txt
 
-# Profile
-spring.profiles.active=local
+# Kafka
+kafka.dlq.topic=chat-messages.dlq


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] Kafka 관련 설정 파일 추가

## 🛠 변경사항
- Kafka 사용에 필요한 관련 config 파일 추가
- Kafka에 사용되는 producer, consumer 관련 설정 추가
- handleNewMessage() 메서드에서 redis stream에 발행하는 것에서 kafka에 메시지 발행하도록 동작 수정

## 💬 리뷰 요구사항
- 이해 안되는 부분 있으시면 코멘트 남겨주세요 

## 🔍 테스트 방법(선택)
- 로컬 환경에서 403 에러로 테스트 불가에 따라 개발 서버에서 테스트 후 수정 진행하겠습니다. 
