### PR TITLE
[FEAT] 비회원(GUEST) 사용자 기능 도입

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/auth/dto/GuestLoginResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/auth/dto/GuestLoginResponse.java
@@ -1,0 +1,7 @@
+package com.ktb.cafeboo.domain.auth.dto;
+
+public record GuestLoginResponse(
+        String accessToken,
+        String userId,
+        String role
+) {}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatController.java
@@ -16,7 +16,6 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-@PreAuthorize("hasRole('USER')")
 @Slf4j
 @RestController
 @RequestMapping("/api/v1/coffee-chats")
@@ -27,6 +26,7 @@ public class CoffeeChatController {
     private final CoffeeChatMessageService coffeeChatMessageService;
     private final CoffeeChatMemberService coffeeChatMemberService;
 
+    @PreAuthorize("hasRole('USER')")
     @PostMapping
     public ResponseEntity<ApiResponse<CoffeeChatCreateResponse>> createCoffeeChat(
         @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -63,6 +63,7 @@ public class CoffeeChatController {
         return ResponseEntity.ok(ApiResponse.of(SuccessStatus.COFFEECHAT_LIST_LOAD_SUCCESS, response));
     }
 
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/{coffeechatId}")
     public ResponseEntity<ApiResponse<CoffeeChatDetailResponse>> getCoffeeChatDetail(
         @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -72,6 +73,7 @@ public class CoffeeChatController {
         return ResponseEntity.ok(ApiResponse.of(SuccessStatus.COFFEECHAT_LOAD_SUCCESS, response));
     }
 
+    @PreAuthorize("hasRole('USER')")
     @PostMapping("/{coffeechatId}/members")
     public ResponseEntity<ApiResponse<CoffeeChatJoinResponse>> joinCoffeeChat(
         @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -87,6 +89,7 @@ public class CoffeeChatController {
             .body(ApiResponse.of(SuccessStatus.COFFEECHAT_JOIN_SUCCESS, response));
     }
 
+    @PreAuthorize("hasRole('USER')")
     @DeleteMapping("/{coffeechatId:\\d+}/members/{memberId:\\d+}")
     public ResponseEntity<Void> leaveChat(
         @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -97,6 +100,7 @@ public class CoffeeChatController {
         return ResponseEntity.noContent().build();
     }
 
+    @PreAuthorize("hasRole('USER')")
     @DeleteMapping("/{coffeechatId:\\d+}")
     public ResponseEntity<Void> deleteCoffeeChat(
         @PathVariable Long coffeechatId,
@@ -109,6 +113,7 @@ public class CoffeeChatController {
         return ResponseEntity.noContent().build(); // 204 No Content
     }
 
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/{coffeechatId}/messages")
     public ResponseEntity<ApiResponse<CoffeeChatMessagesResponse>> getMessages(
         @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -143,7 +148,7 @@ public class CoffeeChatController {
 
         return ResponseEntity.ok(ApiResponse.of(SuccessStatus.COFFEECHAT_MEMBER_LOAD_SUCCESS, response));
     }
-
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/{coffeechatId}/membership")
     public ResponseEntity<ApiResponse<CoffeeChatMembershipCheckResponse>> checkMembership(
             @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -159,6 +164,7 @@ public class CoffeeChatController {
                 .body(ApiResponse.of(SuccessStatus.COFFEECHAT_MEMBERSHIP_CHECK_SUCCESS, response));
     }
 
+    @PreAuthorize("hasRole('USER')")
     @PostMapping("/{coffeechatId}/listeners")
     public ResponseEntity<?> createCoffeeChatListener(
         @AuthenticationPrincipal CustomUserDetails userDetails,

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatController.java
@@ -12,9 +12,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+@PreAuthorize("hasRole('USER')")
 @Slf4j
 @RestController
 @RequestMapping("/api/v1/coffee-chats")

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatReviewController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatReviewController.java
@@ -21,7 +21,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
-@PreAuthorize("hasRole('USER')")
 @Slf4j
 @RestController
 @RequestMapping("/api/v1/coffee-chats/reviews")
@@ -43,6 +42,7 @@ public class CoffeeChatReviewController {
         return ResponseEntity.ok(ApiResponse.of(SuccessStatus.COFFEECHAT_REVIEW_LIST_LOAD_SUCCESS, response));
     }
 
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/{coffeechatId}")
     public ResponseEntity<ApiResponse<CoffeeChatReviewResponse>> getCoffeeChatReview(
             @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -59,6 +59,7 @@ public class CoffeeChatReviewController {
         );
     }
 
+    @PreAuthorize("hasRole('USER')")
     @PostMapping(value = "/{coffeechatId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<CoffeeChatReviewCreateResponse>> createCoffeeChatReview(
             @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -82,6 +83,7 @@ public class CoffeeChatReviewController {
         return ResponseEntity.ok(ApiResponse.of(SuccessStatus.COFFEECHAT_REVIEW_CREATE_SUCCESS, response));
     }
 
+    @PreAuthorize("hasRole('USER')")
     @PostMapping("/{coffeechatId}/likes")
     public ResponseEntity<ApiResponse<CoffeeChatReviewLikeResponse>> toggleLike(
             @AuthenticationPrincipal CustomUserDetails userDetails,

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatReviewController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatReviewController.java
@@ -14,12 +14,14 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
+@PreAuthorize("hasRole('USER')")
 @Slf4j
 @RestController
 @RequestMapping("/api/v1/coffee-chats/reviews")

--- a/src/main/java/com/ktb/cafeboo/domain/user/controller/UserController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/controller/UserController.java
@@ -17,6 +17,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -53,6 +54,7 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.of(SuccessStatus.BASIC_PROFILE_FETCH_SUCCESS, response));
     }
 
+    @PreAuthorize("hasRole('USER')")
     @PatchMapping(value = "/{userId}/profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<UserProfileUpdateResponse>> updateUserProfile(
             @PathVariable Long userId,
@@ -73,7 +75,7 @@ public class UserController {
         );
     }
 
-
+    @PreAuthorize("hasRole('USER')")
     @PostMapping("/{userId}/health")
     public ResponseEntity<ApiResponse<UserHealthInfoCreateResponse>> createHealthInfo(
             @PathVariable Long userId,
@@ -87,6 +89,7 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.of(SuccessStatus.HEALTH_PROFILE_CREATION_SUCCESS, response));
     }
 
+    @PreAuthorize("hasRole('USER')")
     @PatchMapping("/{userId}/health")
     public ResponseEntity<ApiResponse<UserHealthInfoUpdateResponse>> updateHealthInfo(
             @PathVariable Long userId,
@@ -100,6 +103,7 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.of(SuccessStatus.HEALTH_PROFILE_UPDATE_SUCCESS, response));
     }
 
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/{userId}/health")
     public ResponseEntity<ApiResponse<UserHealthInfoResponse>> getHealthInfo(
             @PathVariable Long userId,
@@ -112,6 +116,7 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.of(SuccessStatus.HEALTH_PROFILE_FETCH_SUCCESS, response));
     }
 
+    @PreAuthorize("hasRole('USER')")
     @PostMapping("/{userId}/caffeine")
     public ResponseEntity<ApiResponse<UserCaffeineInfoCreateResponse>> createCaffeineInfo(
             @PathVariable Long userId,
@@ -127,6 +132,7 @@ public class UserController {
                 .body(ApiResponse.of(SuccessStatus.CAFFEINE_PROFILE_CREATION_SUCCESS, response));
     }
 
+    @PreAuthorize("hasRole('USER')")
     @PatchMapping("/{userId}/caffeine")
     public ResponseEntity<ApiResponse<UserCaffeineInfoUpdateResponse>> updateCaffeineInfo(
             @PathVariable Long userId,
@@ -140,6 +146,7 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.of(SuccessStatus.CAFFEINE_PROFILE_UPDATE_SUCCESS, response));
     }
 
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/{userId}/caffeine")
     public ResponseEntity<ApiResponse<UserCaffeineInfoResponse>> getCaffeineInfo(
             @PathVariable Long userId,
@@ -152,6 +159,7 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.of(SuccessStatus.CAFFEINE_PROFILE_FETCH_SUCCESS, response));
     }
 
+    @PreAuthorize("hasRole('USER')")
     @PostMapping("/{userId}/alarm")
     public ResponseEntity<ApiResponse<UserAlarmSettingCreateResponse>> createAlarmSetting(
             @PathVariable Long userId,
@@ -166,6 +174,7 @@ public class UserController {
                 .body(ApiResponse.of(SuccessStatus.ALARM_SETTING_CREATION_SUCCESS, response));
     }
 
+    @PreAuthorize("hasRole('USER')")
     @PatchMapping("/{userId}/alarm")
     public ResponseEntity<ApiResponse<UserAlarmSettingUpdateResponse>> updateAlarmSetting(
             @PathVariable Long userId,
@@ -179,6 +188,7 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.of(SuccessStatus.ALARM_SETTING_UPDATE_SUCCESS, response));
     }
 
+    @PreAuthorize("hasRole('USER')")
     @GetMapping("/{userId}/alarm")
     public ResponseEntity<ApiResponse<UserAlarmSettingResponse>> getAlarmSetting(
             @PathVariable Long userId,
@@ -191,6 +201,7 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.of(SuccessStatus.ALARM_SETTING_FETCH_SUCCESS, response));
     }
 
+    @PreAuthorize("hasRole('USER')")
     @DeleteMapping("/{userId}")
     public ResponseEntity<Void> deleteUser(
             @PathVariable Long userId,

--- a/src/main/java/com/ktb/cafeboo/domain/user/model/User.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/model/User.java
@@ -31,7 +31,7 @@ public class User extends BaseEntity {
     private String password;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(nullable = false, length = 20)
     private LoginType loginType;
 
     @Column

--- a/src/main/java/com/ktb/cafeboo/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/repository/UserRepository.java
@@ -3,7 +3,11 @@ package com.ktb.cafeboo.domain.user.repository;
 import com.ktb.cafeboo.domain.user.model.User;
 import com.ktb.cafeboo.global.enums.LoginType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -11,6 +15,13 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByOauthIdAndLoginType(Long oauthId, LoginType loginType);
 
     boolean existsByEmail(String email);
+
+    @Query("""
+        SELECT u FROM User u
+        WHERE u.loginType = 'GUEST'
+        AND u.createdAt < :todayStart
+    """)
+    List<User> findGuestUsersBefore(@Param("todayStart") LocalDateTime todayStart);
 
 }
 

--- a/src/main/java/com/ktb/cafeboo/domain/user/scheduler/GuestCleanupScheduler.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/scheduler/GuestCleanupScheduler.java
@@ -1,0 +1,37 @@
+package com.ktb.cafeboo.domain.user.scheduler;
+
+import com.ktb.cafeboo.domain.user.model.User;
+import com.ktb.cafeboo.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GuestCleanupScheduler {
+
+    private final UserRepository userRepository;
+
+    // 매일 오전 10시 (cron 표현식: 초 분 시 일 월 요일)
+    @Scheduled(cron = "0 0 10 * * *")
+    public void deleteOldGuestUsers() {
+        LocalDateTime todayStart = LocalDate.now().atStartOfDay();
+
+        List<User> oldGuests = userRepository.findGuestUsersBefore(todayStart);
+
+        if (oldGuests.isEmpty()) {
+            log.info("[GuestCleanupScheduler] 삭제 대상 게스트 유저 없음");
+            return;
+        }
+
+        log.info("[GuestCleanupScheduler] {}명의 오래된 게스트 유저 삭제 시작", oldGuests.size());
+        userRepository.deleteAll(oldGuests);
+        log.info("[GuestCleanupScheduler] 오래된 게스트 유저 삭제 완료");
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/domain/user/service/UserService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/user/service/UserService.java
@@ -7,10 +7,13 @@ import com.ktb.cafeboo.domain.user.dto.UserProfileResponse;
 import com.ktb.cafeboo.domain.user.dto.UserProfileUpdateRequest;
 import com.ktb.cafeboo.domain.user.dto.UserProfileUpdateResponse;
 import com.ktb.cafeboo.domain.user.model.User;
+import com.ktb.cafeboo.domain.user.model.UserCaffeineInfo;
 import com.ktb.cafeboo.domain.user.repository.UserRepository;
 import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
 import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
+import com.ktb.cafeboo.global.enums.LoginType;
 import com.ktb.cafeboo.global.enums.TokenBlacklistReason;
+import com.ktb.cafeboo.global.enums.UserRole;
 import com.ktb.cafeboo.global.infra.s3.S3Uploader;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,6 +23,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.UUID;
 
 @Slf4j
 @Service
@@ -138,5 +142,34 @@ public class UserService {
         }
       
         log.info("[UserService.deleteUser] 사용자 soft delete 완료 - userId={}", userId);
+    }
+
+    @Transactional
+    public User createGuestUser() {
+        String guestToken = UUID.randomUUID().toString();
+        String nickname = "guest_" + guestToken.substring(0, 3);
+
+        User guest = User.builder()
+                .loginType(LoginType.GUEST)
+                .nickname(nickname)
+                .role(UserRole.GUEST)
+                .darkMode(false)
+                .coffeeBean(0)
+                .profileImageUrl(s3Uploader.getDefaultProfileImageUrl())
+                .refreshToken("")
+                .build();
+
+        UserCaffeineInfo caffeineInfo = UserCaffeineInfo.builder()
+                .user(guest)
+                .caffeineSensitivity(0)
+                .averageDailyCaffeineIntake(0f)
+                .frequentDrinkTime(null)
+                .dailyCaffeineLimitMg(400.0f)         // 기본값
+                .sleepSensitiveThresholdMg(100.0f)    // 기본값
+                .build();
+
+        guest.setCaffeinInfo(caffeineInfo);
+
+        return userRepository.save(guest);
     }
 }

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/code/status/SuccessStatus.java
@@ -15,6 +15,7 @@ public enum SuccessStatus implements BaseCode {
     // 인증 관련 응답
     LOGIN_SUCCESS(200, "LOGIN_SUCCESS", "성공적으로 로그인되었습니다."),
     TOKEN_REFRESH_SUCCESS(200, "TOKEN_REFRESH_SUCCESS", "액세스 토큰이 성공적으로 재발급되었습니다."),
+    GUEST_LOGIN_SUCCESS(201, "GUEST_LOGIN_SUCCESS", "비회원 로그인에 성공하였습니다."),
 
     // 유저 관련 응답
     EMAIL_DUPLICATION_CHECK_SUCCESS(200, "EMAIL_DUPLICATION_CHECK_SUCCESS", "이메일 중복 확인 결과를 반환했습니다."),

--- a/src/main/java/com/ktb/cafeboo/global/apiPayload/exception/ApiExceptionHandler.java
+++ b/src/main/java/com/ktb/cafeboo/global/apiPayload/exception/ApiExceptionHandler.java
@@ -4,8 +4,10 @@ import com.ktb.cafeboo.global.apiPayload.ApiResponse;
 import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
 import com.ktb.cafeboo.global.apiPayload.code.BaseCode;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -37,4 +39,13 @@ public class ApiExceptionHandler {
                 .status(error.getStatus())
                 .body(ApiResponse.onFailure(error));
     }
+
+    @ExceptionHandler(AuthorizationDeniedException.class)
+    public ResponseEntity<ApiResponse<?>> handleAuthorizationDeniedException(AuthorizationDeniedException ex) {
+        log.warn("Authorization failed: {}", ex.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.FORBIDDEN)
+                .body(ApiResponse.onFailure(ErrorStatus.FORBIDDEN));
+    }
+
 }

--- a/src/main/java/com/ktb/cafeboo/global/config/SecurityConfig.java
+++ b/src/main/java/com/ktb/cafeboo/global/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
@@ -22,6 +23,7 @@ import java.util.List;
 @EnableWebSecurity
 @RequiredArgsConstructor
 @Profile("!test")
+@EnableMethodSecurity(prePostEnabled = true)
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
@@ -32,6 +34,7 @@ public class SecurityConfig {
             new AntPathRequestMatcher("/api/v1/auth/oauth"),
             new AntPathRequestMatcher("/api/v1/auth/kakao"),
             new AntPathRequestMatcher("/api/v1/auth/refresh"),
+            new AntPathRequestMatcher("/api/v1/auth/guest"),
             new AntPathRequestMatcher("/api/v1/users/email"),
             new AntPathRequestMatcher("/api/v1/reports/weekly/ai_callback"),
             new AntPathRequestMatcher("/v3/api-docs/**"),

--- a/src/main/java/com/ktb/cafeboo/global/enums/LoginType.java
+++ b/src/main/java/com/ktb/cafeboo/global/enums/LoginType.java
@@ -1,5 +1,5 @@
 package com.ktb.cafeboo.global.enums;
 
 public enum LoginType {
-    BASIC, KAKAO
+    BASIC, KAKAO, GUEST
 }

--- a/src/main/java/com/ktb/cafeboo/global/enums/UserRole.java
+++ b/src/main/java/com/ktb/cafeboo/global/enums/UserRole.java
@@ -1,5 +1,5 @@
 package com.ktb.cafeboo.global.enums;
 
 public enum UserRole {
-    ADMIN, USER
+    ADMIN, USER, GUEST
 }

--- a/src/main/java/com/ktb/cafeboo/global/security/JwtProvider.java
+++ b/src/main/java/com/ktb/cafeboo/global/security/JwtProvider.java
@@ -23,7 +23,7 @@ public class JwtProvider {
     @Value("${jwt.secret}")
     private String SECRET_KEY;
 
-    private final long accessTokenValidity = 24 * 60 * 60 * 1000;  // 60분
+    private final long accessTokenValidity = 24 * 60 * 60 * 1000;  // 1일
     private final long refreshTokenValidity = 14 * 24 * 60 * 60 * 1000;  // 14일
 
     public String createAccessToken(String userId, String loginType, String role) {


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] 비회원 로그인 API 추가
- [x] GUEST 유저 권한 기반 접근 제어 적용
- [x] 생성일이 오늘보다 이전인 GUEST 유저를 자동 삭제하는 스케줄러 도입

## 🛠 변경사항
-`POST /api/v1/auth/guest`: GUEST 계정 생성 및 로그인 API 추가
- `UserRole`, `LoginType`에 GUEST 타입 도입
- GUEST 유저 권한 분리: `@PreAuthorize("hasRole('USER')")`로 일반 유저 API 보호
- `GuestCleanupScheduler` : 매일 오전 10시 게스트 유저 삭제 스케줄러

## 💬 리뷰 요구사항
- GUEST 유저의 접근 제한 정책이 적절한지 피드백 주시면 감사하겠습니다

## 🔍 테스트 방법(선택)
- 비회원 로그인 후 접근 가능한 API 호출 테스트
- `@PreAuthorize` 적용된 API 접근 시 403 응답 여부 확인
- 하루 이상 지난 GUEST 유저가 자동 삭제되는지 로그 및 DB 상태 확인

Closed:  #231