### PR TITLE
[FEAT] Kafka 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,9 @@ dependencies {
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.projectlombok:lombok'
 
+	// Kafka
+	implementation 'org.springframework.kafka:spring-kafka'
+
 	// test
 	testImplementation 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-test'

--- a/src/main/java/com/ktb/cafeboo/global/config/KafkaConsumerConfiguration.java
+++ b/src/main/java/com/ktb/cafeboo/global/config/KafkaConsumerConfiguration.java
@@ -30,6 +30,9 @@ public class KafkaConsumerConfiguration {
     @Value("${kafka.dlq.topic}")
     private String dlqTopic;
 
+    @Value("spring.data.kafka.port")
+    private String kafkaHost;
+
     @Bean
     public ConsumerFactory<String, StompMessagePublish> consumerFactory(){
         String kafkaConsumerGroupId = kafkaConsumerGroupIdPrefix + java.util.UUID.randomUUID().toString();
@@ -41,7 +44,7 @@ public class KafkaConsumerConfiguration {
 
         Map<String, Object> consumerConfigurations =
                 ImmutableMap.<String, Object>builder()
-                        .put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092")
+                        .put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaHost)
                         .put(ConsumerConfig.GROUP_ID_CONFIG, kafkaConsumerGroupId)
                         .put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class)
                         .put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class)

--- a/src/main/java/com/ktb/cafeboo/global/config/KafkaConsumerConfiguration.java
+++ b/src/main/java/com/ktb/cafeboo/global/config/KafkaConsumerConfiguration.java
@@ -1,0 +1,67 @@
+package com.ktb.cafeboo.global.config;
+
+import com.ktb.cafeboo.domain.coffeechat.dto.StompMessagePublish;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.ContainerProperties.AckMode;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import software.amazon.awssdk.utils.ImmutableMap;
+
+@EnableKafka
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class KafkaConsumerConfiguration {
+
+    @Value("${spring.application.name}") // 기본값도 지정할 수 있습니다.
+    private String kafkaConsumerGroupIdPrefix;
+
+    @Value("${kafka.dlq.topic}")
+    private String dlqTopic;
+
+    @Bean
+    public ConsumerFactory<String, StompMessagePublish> consumerFactory(){
+        String kafkaConsumerGroupId = kafkaConsumerGroupIdPrefix + java.util.UUID.randomUUID().toString();
+
+        JsonDeserializer<StompMessagePublish> jsonDeserializer = new JsonDeserializer<>(StompMessagePublish.class, false);
+        jsonDeserializer.addTrustedPackages("*");
+
+        ErrorHandlingDeserializer<StompMessagePublish> errorHandlingValueDeserializer = new ErrorHandlingDeserializer<>(jsonDeserializer);
+
+        Map<String, Object> consumerConfigurations =
+                ImmutableMap.<String, Object>builder()
+                        .put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092")
+                        .put(ConsumerConfig.GROUP_ID_CONFIG, kafkaConsumerGroupId)
+                        .put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class)
+                        .put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class)
+                        .put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, jsonDeserializer.getClass().getName())
+                        .put(ErrorHandlingDeserializer.KEY_DESERIALIZER_CLASS, StringDeserializer.class.getName())
+                        .put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest")
+                        .put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false)
+                        .build();
+
+        log.info("[KafkaConsumerConfiguration.consumerFactory] group id {}를 가지는 consumerFactory 생성", kafkaConsumerGroupId);
+
+        return new DefaultKafkaConsumerFactory<>(consumerConfigurations, new StringDeserializer(), errorHandlingValueDeserializer);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, StompMessagePublish> kafkaListenerContainerFactory(){
+        ConcurrentKafkaListenerContainerFactory<String, StompMessagePublish> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        factory.getContainerProperties().setAckMode(AckMode.MANUAL_IMMEDIATE);
+        factory.setConcurrency(Runtime.getRuntime().availableProcessors());
+        return factory;
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/global/config/KafkaProducerConfiguration.java
+++ b/src/main/java/com/ktb/cafeboo/global/config/KafkaProducerConfiguration.java
@@ -1,0 +1,59 @@
+package com.ktb.cafeboo.global.config;
+
+import com.ktb.cafeboo.domain.coffeechat.dto.StompMessagePublish;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+import software.amazon.awssdk.utils.ImmutableMap;
+
+@EnableKafka
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class KafkaProducerConfiguration {
+
+    @Bean
+    public ProducerFactory<String, StompMessagePublish> producerFactory() {
+        Map<String, Object> producerConfigurations =
+                ImmutableMap.<String, Object>builder()
+                        .put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092")
+                        .put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class)
+                        .put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class)
+                        .put(JsonSerializer.ADD_TYPE_INFO_HEADERS, true)
+                        .build();
+
+        return new DefaultKafkaProducerFactory<>(producerConfigurations);
+    }
+
+    // KafkaTemplate을 생성하는 Bean 메서드
+    @Bean
+    public KafkaTemplate<String, StompMessagePublish> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+    @Bean
+    public ProducerFactory<String, Object> dlqProducerFactory(){
+        Map<String, Object> producerConfigurations =
+                ImmutableMap.<String, Object>builder()
+                        .put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092")
+                        .put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class)
+                        .put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class)
+                        .put(JsonSerializer.ADD_TYPE_INFO_HEADERS, false) // DLQ 메시지도 JSON으로 직렬화 (오류 정보 포함 가능)
+                        .build();
+        return new DefaultKafkaProducerFactory<>(producerConfigurations);
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> dlqKafkaTemplate() {
+        return new KafkaTemplate<>(dlqProducerFactory());
+    }
+
+}

--- a/src/main/java/com/ktb/cafeboo/global/config/KafkaProducerConfiguration.java
+++ b/src/main/java/com/ktb/cafeboo/global/config/KafkaProducerConfiguration.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.EnableKafka;
@@ -21,11 +22,14 @@ import software.amazon.awssdk.utils.ImmutableMap;
 @Slf4j
 public class KafkaProducerConfiguration {
 
+    @Value("spring.data.kafka.port")
+    private String kafkaHost;
+
     @Bean
     public ProducerFactory<String, StompMessagePublish> producerFactory() {
         Map<String, Object> producerConfigurations =
                 ImmutableMap.<String, Object>builder()
-                        .put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092")
+                        .put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaHost)
                         .put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class)
                         .put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class)
                         .put(JsonSerializer.ADD_TYPE_INFO_HEADERS, true)

--- a/src/main/java/com/ktb/cafeboo/global/infra/kafka/consumer/KafkaMessageListener.java
+++ b/src/main/java/com/ktb/cafeboo/global/infra/kafka/consumer/KafkaMessageListener.java
@@ -1,0 +1,38 @@
+package com.ktb.cafeboo.global.infra.kafka.consumer;
+
+import com.ktb.cafeboo.domain.coffeechat.dto.StompMessagePublish;
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatMessage;
+import com.ktb.cafeboo.global.infra.kafka.producer.KafkaMessageProducer;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.listener.AcknowledgingMessageListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class KafkaMessageListener implements AcknowledgingMessageListener<String, StompMessagePublish> {
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @KafkaListener(topics = KafkaMessageProducer.CHAT_MESSAGES_TOPIC,
+            containerFactory = "kafkaListenerContainerFactory")
+    @Override
+    public void onMessage(ConsumerRecord<String, StompMessagePublish> record, Acknowledgment acknowledgment) {
+        String roomId = record.key();
+        StompMessagePublish stompMessage = record.value();
+
+        log.info("[KafkaChatMessageListener] Received message from Kafka for WebSockets. Topic: '{}', Partition: {}, Offset: {}. Room ID: {}, Message ID: {}",
+                record.topic(), record.partition(), record.offset(), roomId, stompMessage.getMessageId());
+
+        try{
+            messagingTemplate.convertAndSend("/topic/chatrooms/" + roomId, stompMessage);
+            acknowledgment.acknowledge();
+        }
+        catch (Exception e) {
+
+        }
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/global/infra/kafka/producer/KafkaMessageProducer.java
+++ b/src/main/java/com/ktb/cafeboo/global/infra/kafka/producer/KafkaMessageProducer.java
@@ -1,0 +1,34 @@
+package com.ktb.cafeboo.global.infra.kafka.producer;
+
+import com.ktb.cafeboo.domain.coffeechat.dto.StompMessagePublish;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class KafkaMessageProducer {
+    public static final String CHAT_MESSAGES_TOPIC = "coffeechat-messages";
+
+    private final KafkaTemplate<String, StompMessagePublish> kafkaTemplate;
+
+    public void publishChatMessage(StompMessagePublish message) {
+        String messageKey = String.valueOf(message.getCoffeechatId());
+
+        log.info("Sending message to Kafka topic '{}' with key '{}': {}",
+                CHAT_MESSAGES_TOPIC, messageKey, message);
+
+        kafkaTemplate.send(CHAT_MESSAGES_TOPIC, messageKey, message)
+                .whenComplete((result, ex) -> {
+                    if (ex == null) {
+                        log.info("Message sent successfully to partition {} with offset {}",
+                                result.getRecordMetadata().partition(),
+                                result.getRecordMetadata().offset());
+                    } else {
+                        log.error("Failed to send message: {}", ex.getMessage(), ex);
+                    }
+                });
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/global/infra/kafka/service/KafkaProducerService.java
+++ b/src/main/java/com/ktb/cafeboo/global/infra/kafka/service/KafkaProducerService.java
@@ -1,0 +1,21 @@
+package com.ktb.cafeboo.global.infra.kafka.service;
+
+import com.ktb.cafeboo.domain.coffeechat.dto.StompMessagePublish;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class KafkaProducerService {
+    private final KafkaTemplate<String, StompMessagePublish> kafkaTemplate;
+
+    // ✨ sendMessage 메서드 파라미터 타입 변경 ✨
+    public void sendMessage(String topic, StompMessagePublish message) {
+        log.info("[KafkaProducerService] Kafka 메시지 전송 중 - Topic: {}, Message: {}", topic, message);
+        kafkaTemplate.send(topic, message);
+        log.info("[KafkaProducerService] Kafka 메시지 전송 완료!");
+    }
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -43,3 +43,7 @@ management.endpoint.health.show-details=always
 # censorship
 censorship.blacklist-filename: censorship-blacklist-keywords.txt
 censorship.whitelist-filename: censorship-whitelist-keywords.txt
+
+# Kafka
+spring.data.kafka.host=${DEV_KAFKA_HOST}
+spring.data.kafka.port=${DEV_KAFKA_HOST:9092}

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -44,3 +44,7 @@ management.endpoint.health.show-details=always
 # censorship
 censorship.blacklist-filename: censorship-blacklist-keywords.txt
 censorship.whitelist-filename: censorship-whitelist-keywords.txt
+
+# Kafka
+spring.data.kafka.host=${PROD_KAFKA_HOST}
+spring.data.kafka.port=${PROD_KAFKA_HOST:9092}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -64,4 +64,6 @@ censorship.whitelist-filename: censorship-whitelist-keywords.txt
 spring.profiles.active=local
 
 # Kafka
+spring.data.kafka.host=localhost
+spring.data.kafka.port=9092
 kafka.dlq.topic=coffeechat-dlq-topic

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -62,3 +62,6 @@ censorship.whitelist-filename: censorship-whitelist-keywords.txt
 
 # Profile
 spring.profiles.active=local
+
+# Kafka
+kafka.dlq.topic=coffeechat-dlq-topic


### PR DESCRIPTION
# 📌 Pull Request
관련 PR: https://github.com/100-hours-a-week/13-Cafeboo-BE/pull/233

## ✨ 작업한 내용
- [x] Kafka로의 전환에 따른 config 추가
- [x] Kafka로의 전환에 따른 메시지 발행 및 전파 로직 수정
- [x] Kafka producer, consumer 관련 설정 추가
- [x] Kafka 관련 의존성 추가 

## 🛠 변경사항
- Kafka로의 전환에 따른 config 파일들을 추가했습니다. 각각 producer, consumer의 생성에 필요한 config 파일이고 이를 활용해 메시지를 발행, 전파하게 됩니다. 
- 채팅 내역을 관리하는 메시징 큐가 redis stream에서 kafka로 전환됨에 따라 메시지의 발행, 전파 흐름도 Kafka에 맞게 설정될 필요가 있었습니다. 이에 따라, handleNewMesssage() 메서드가 실행되며 채팅 메시지를 전송하고, 전송된 메시지가 메시지 큐에서 처리되는 과정을 Kafka에 맞게 수정했습니다. 

## 💬 리뷰 요구사항
- 읽어보신 후 이해되지 않는 부분이 있다면 코멘트 남겨주세요

## 🔍 테스트 방법(선택)
![image](https://github.com/user-attachments/assets/54e434d4-30bb-4eb7-8cbc-9bf344030bf1)

- 현재 제 로컬 환경에서 FE - BE 연동하여 카카오 OAuth 로그인 시도 시 403 error가 발생해서 FE를 연동해 테스트가 불가능한 상태였습니다. 
   
   이에 따라 BE의 static/template 부분에 임의의 html, css, js 파일을 구현해 채팅 내역이 전송되고, 화면 상에 출력되는 부분까지만 테스트를 진행했을 때의 그림을 첨부합니다.

   실제 동작의 경우, 개발 서버에 올린 후 의도한대로 작동하는지 확인해봐야 할 거 같습니다!