### PR TITLE
[FEAT] 커피챗 목록 실시간 업데이트에 SSE 도입

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatSseController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/controller/CoffeeChatSseController.java
@@ -1,0 +1,24 @@
+package com.ktb.cafeboo.domain.coffeechat.controller;
+
+import com.ktb.cafeboo.domain.coffeechat.service.CoffeeChatSseService;
+import com.ktb.cafeboo.global.security.userdetails.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/sse/coffee-chats")
+public class CoffeeChatSseController {
+
+    private final CoffeeChatSseService coffeeChatSseService;
+
+    @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter subscribeToCoffeeChat(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        return coffeeChatSseService.subscribe(userDetails.getUserId());
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatJoinResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatJoinResponse.java
@@ -1,9 +1,10 @@
 package com.ktb.cafeboo.domain.coffeechat.dto;
 
 public record CoffeeChatJoinResponse(
-        String memberId
+        String memberId,
+        Integer currentMemberCount
 ) {
-    public static CoffeeChatJoinResponse from(Long memberId) {
-        return new CoffeeChatJoinResponse(memberId.toString());
+    public static CoffeeChatJoinResponse of(Long memberId, Integer currentMemberCount) {
+        return new CoffeeChatJoinResponse(memberId.toString(), currentMemberCount);
     }
 }

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatListResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/CoffeeChatListResponse.java
@@ -1,9 +1,6 @@
 package com.ktb.cafeboo.domain.coffeechat.dto;
 
 import com.ktb.cafeboo.domain.coffeechat.dto.common.MemberDto;
-import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatMember;
-import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
-import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
 
 import java.util.List;
 
@@ -32,10 +29,8 @@ public record CoffeeChatListResponse(
                 boolean isReviewed
         ) {
             MemberDto writerDto = chat.getMembers().stream()
-                // chat.getWriter()가 null일 가능성도 고려하여 필터 조건 추가
                 .filter(m -> chat.getWriter() != null && m.getUser().getId().equals(chat.getWriter().getId()))
                 .findFirst()
-                // CoffeeChatMember를 찾았다면, MemberDto로 변환합니다.
                 .map(m -> new MemberDto(
                     m.getId().toString(),
                     m.getChatNickname(),
@@ -52,7 +47,6 @@ public record CoffeeChatListResponse(
                         false // 호스트 여부 (알 수 없으므로 false)
                     );
                 });
-
 
             return new CoffeeChatSummary(
                     chat.getId().toString(),

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/sse/CoffeeChatUpdatePayload.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/sse/CoffeeChatUpdatePayload.java
@@ -1,0 +1,6 @@
+package com.ktb.cafeboo.domain.coffeechat.dto.sse;
+
+public record CoffeeChatUpdatePayload(
+        String coffeeChatId,
+        Integer currentMemberCount
+) {}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/sse/DeletedCoffeeChatPayload.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/sse/DeletedCoffeeChatPayload.java
@@ -1,0 +1,4 @@
+package com.ktb.cafeboo.domain.coffeechat.dto.sse;
+
+public record DeletedCoffeeChatPayload(String coffeeChatId) {}
+

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/sse/NewCoffeeChatPayload.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/sse/NewCoffeeChatPayload.java
@@ -1,0 +1,22 @@
+package com.ktb.cafeboo.domain.coffeechat.dto.sse;
+
+import java.util.List;
+
+public record NewCoffeeChatPayload(
+        String coffeeChatId,
+        String title,
+        String date,
+        String time,
+        Integer maxMemberCount,
+        Integer currentMemberCount,
+        List<String> tags,
+        String address,
+        Writer writer
+) {
+    public record Writer(
+            Long memberId,
+            String chatNickname,
+            String profileImageUrl,
+            boolean isHost
+    ) {}
+}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChat.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChat.java
@@ -89,12 +89,12 @@ public class CoffeeChat extends BaseEntity {
 
     public void addMember(CoffeeChatMember member) {
         this.members.add(member);
-        this.currentMemberCount = this.members.size();
+        this.currentMemberCount += 1;
     }
 
     public void removeMember(CoffeeChatMember member) {
         this.members.remove(member);
-        this.currentMemberCount = this.members.size();
+        this.currentMemberCount -= 1;
     }
 
     public boolean isJoinedBy(Long userId) {

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatSseService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatSseService.java
@@ -1,0 +1,123 @@
+package com.ktb.cafeboo.domain.coffeechat.service;
+
+import com.ktb.cafeboo.domain.coffeechat.dto.sse.CoffeeChatUpdatePayload;
+import com.ktb.cafeboo.domain.coffeechat.dto.sse.DeletedCoffeeChatPayload;
+import com.ktb.cafeboo.domain.coffeechat.dto.sse.NewCoffeeChatPayload;
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChat;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+@RequiredArgsConstructor
+public class CoffeeChatSseService {
+
+    // 클라이언트별 SseEmitter 저장소 (userId 기준)
+    private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+    // SSE 연결 구독
+    public SseEmitter subscribe(Long userId) {
+        SseEmitter emitter = new SseEmitter(10 * 60 * 1000L); // 10분 타임아웃
+
+        emitters.put(userId, emitter);
+
+        emitter.onCompletion(() -> {
+            emitter.complete();
+            emitters.remove(userId);
+        });
+
+        emitter.onTimeout(() -> {
+            emitter.complete();
+            emitters.remove(userId);
+        });
+
+        emitter.onError((e) -> {
+            emitter.complete();
+            emitters.remove(userId);
+        });
+
+
+        // 연결 확인용 더미 이벤트 전송
+        try {
+            emitter.send(SseEmitter.event()
+                    .name("connect")
+                    .data("SSE connection established.")); // 503 에러 방지를 위한 더미 데이터
+        } catch (IOException e) {
+            emitter.completeWithError(e);
+        }
+
+        return emitter;
+    }
+
+    public void sendCurrentMemberCountUpdate(Long coffeeChatId, Integer currentMemberCount) {
+        CoffeeChatUpdatePayload payload = new CoffeeChatUpdatePayload(
+                coffeeChatId.toString(),
+                currentMemberCount
+        );
+
+        emitters.forEach((userId, emitter) -> {
+            try {
+                emitter.send(SseEmitter.event()
+                        .name("current-member-count")
+                        .data(payload));
+            } catch (IOException e) {
+                emitter.complete();
+                emitters.remove(userId);
+            }
+        });
+    }
+
+    public void sendNewCoffeeChat(CoffeeChat chat) {
+        LocalDateTime meetingTime = chat.getMeetingTime();
+
+        NewCoffeeChatPayload payload = new NewCoffeeChatPayload(
+                chat.getId().toString(),
+                chat.getName(),
+                meetingTime.toLocalDate().toString(),
+                meetingTime.toLocalTime().toString(),
+                chat.getMaxMemberCount(),
+                chat.getCurrentMemberCount(),
+                chat.getTagNames(),
+                chat.getAddress(),
+                new NewCoffeeChatPayload.Writer(
+                        chat.getWriter().getId(),
+                        chat.getWriter().getNickname(),
+                        chat.getWriter().getProfileImageUrl(),
+                        true
+                )
+        );
+
+        emitters.forEach((userId, emitter) -> {
+            try {
+                emitter.send(SseEmitter.event()
+                        .name("new-coffeechat")
+                        .data(payload));
+            } catch (IOException e) {
+                emitter.complete();
+                emitters.remove(userId);
+            }
+        });
+    }
+
+
+    public void sendDeletedCoffeeChat(Long coffeeChatId) {
+        DeletedCoffeeChatPayload payload = new DeletedCoffeeChatPayload(coffeeChatId.toString());
+
+        emitters.forEach((userId, emitter) -> {
+            try {
+                emitter.send(SseEmitter.event()
+                        .name("deleted-coffeechat")
+                        .data(payload));
+            } catch (IOException e) {
+                emitter.complete();
+                emitters.remove(userId);
+            }
+        });
+    }
+
+}

--- a/src/main/java/com/ktb/cafeboo/global/infra/sse/SseSender.java
+++ b/src/main/java/com/ktb/cafeboo/global/infra/sse/SseSender.java
@@ -1,0 +1,22 @@
+package com.ktb.cafeboo.global.infra.sse;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@Component
+public class SseSender {
+
+    public void sendAfterCommit(Runnable action) {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    action.run();
+                }
+            });
+        } else {
+            action.run();
+        }
+    }
+}


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] 커피챗 목록 실시간 업데이트를 위한 SSE 기능 도입 
(기존: 5초 간격 short polling 방식)
- [x] 커피챗 생성/삭제/참여자 수 변동 시 클라이언트에 이벤트 전송

## 🛠 변경사항
- `SseEmitter` 기반 SSE 구독 API 추가 (/api/v1/sse/coffee-chats/subscribe)
- `new-coffeechat`, `deleted-coffeechat`, `current-member-count` 이벤트 전송 메서드 구현
- 커피챗 생성/삭제/참여/퇴장 로직에 이벤트 전송 트리거 추가
- `TransactionSynchronizationManager` 활용하여 afterCommit 시점에 안전하게 이벤트 전송

## 💬 리뷰 요구사항
- 이벤트 구조 및 전송 시점에 대한 의견 있으시다면 코멘트 주세요

## 🔍 테스트 방법(선택)
- curl 기반 구독 및 이벤트 수신 테스트
  - curl 환경에서 sse 구독 API 요청 
![Group 317](https://github.com/user-attachments/assets/9b710558-f8be-45bf-b206-5fa5694f3451)
  - Postman으로 커피챗 관련 API 호출 후, 이벤트가 정상적으로 수신
![Group 315](https://github.com/user-attachments/assets/f8bb59b1-b739-47af-8706-ade8a65e6d21)
![Group 316](https://github.com/user-attachments/assets/a39151d0-2b96-4f8b-9f1d-29e1dcbff812)

Closed: #236