### PR TITLE
[FIX] 채팅방별 고정 Consumer 이름 적용으로 메시지 누락 방지

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/ChatService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/ChatService.java
@@ -179,7 +179,7 @@ public class ChatService {
     public void startListeningToCoffeeChat(String roomId){
         String streamKey = CHAT_STREAM_PREFIX + roomId;
         String consumerGroupName = CHAT_CONSUMER_GROUP_PREFIX + roomId; // 커피챗 ID를 컨슈머 그룹으로 사용
-        String consumerName = redisConfig.getConsumerName();
+        String consumerName = "room-consumer-" + roomId;
         log.info("[ChatService.startListeningToRoom] - streamKey: {}, consumerGroupName: {}, consumerName: {}", streamKey, consumerGroupName, consumerName);
 
         // 이미 구독 중이고 서버의 인메모리 맵에 존재하는지 확인

--- a/src/main/java/com/ktb/cafeboo/global/config/RedisConfig.java
+++ b/src/main/java/com/ktb/cafeboo/global/config/RedisConfig.java
@@ -53,11 +53,11 @@ public class RedisConfig {
     private String consumerName; // 개별 컨슈머 이름. @PostConstruct에서 동적으로 생성
     private String failureListKey;
 
-    @PostConstruct // ApplicationConfig의 @PostConstruct 로직도 여기로 옮깁니다.
-    public void setConsumerName() throws UnknownHostException {
-        // 각 서버 인스턴스에 고유한 컨슈머 이름을 부여
-        consumerName = InetAddress.getLocalHost().getHostName() + "-" + UUID.randomUUID().toString().substring(0, 8);
-    }
+//    @PostConstruct // ApplicationConfig의 @PostConstruct 로직도 여기로 옮깁니다.
+//    public void setConsumerName() throws UnknownHostException {
+//        // 각 서버 인스턴스에 고유한 컨슈머 이름을 부여
+//        consumerName = InetAddress.getLocalHost().getHostName() + "-" + UUID.randomUUID().toString().substring(0, 8);
+//    }
 
     /**
      * redis의 연결 정보 설정


### PR DESCRIPTION

# 📌 Pull Request
Redis Stream은 Consumer Group에 속한 여러 Consumer가 존재할 경우, 해당 그룹의 각 메시지를 그 중 단 한 명의 Consumer에게만 분배합니다.
이 방식은 Pub/Sub처럼 모든 구독자에게 메시지를 브로드캐스트하는 구조가 아닌, Work Queue 방식으로 동작합니다.

이로 인해 하나의 채팅방에 여러 Consumer가 등록되면 메시지가 분산되어 일부 사용자에게 도달하지 않는 문제가 발생합니다.
따라서 채팅방마다 하나의 고정된 Consumer를 등록하고, 해당 Consumer가 수신한 메시지를 서버가 WebSocket을 통해 모든 참여자에게 중계하는 방식으로 구조를 수정했습니다.

## ✨ 작업한 내용
- [x] Redis Consumer 이름을 서버 단위가 아닌 roomId 기반으로 고정되도록 수정
- [x] 채팅방마다 하나의 ConsumerGroup과 고정 Consumer가 생성되도록 구조 개선

## 🛠 변경사항
- RedisConfig에서 UUID 기반 consumerName 생성 로직 제거
- ChatService 내 startListeningToCoffeeChat()에서 roomId 기반으로 consumerName 생성
- 동일 채팅방에 대해 서버 인스턴스 간 Consumer 중복 생성 방지

## 💬 리뷰 요구사항
- Redis Stream 구독 구조 변경에 따른 side effect 가능성이 있습니다.
- 실제 개발 환경에 먼저 배포하여 의도대로 동작하는지 확인하고, vm이 두개인 환경에서의 테스트가 추가로 필요합니다.


