### PR TITLE
[FEAT] 소셜 로그인 응답 시, 유저의 role 정보 추가

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/auth/dto/LoginResponse.java
+++ b/src/main/java/com/ktb/cafeboo/domain/auth/dto/LoginResponse.java
@@ -4,11 +4,12 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 
 public record LoginResponse(
         String userId,
+        String role,
         String accessToken,
         boolean requiresOnboarding,
         @JsonIgnore String refreshToken
 ) {
     public LoginResponse withoutRefreshToken() {
-        return new LoginResponse(userId, accessToken, requiresOnboarding, null);
+        return new LoginResponse(userId, role, accessToken, requiresOnboarding, null);
     }
 }

--- a/src/main/java/com/ktb/cafeboo/domain/auth/service/KakaoOauthService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/auth/service/KakaoOauthService.java
@@ -7,6 +7,7 @@ import com.ktb.cafeboo.domain.user.dto.UserAlarmSettingCreateRequest;
 import com.ktb.cafeboo.domain.user.service.UserAlarmSettingService;
 import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
 import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
+import com.ktb.cafeboo.global.enums.UserRole;
 import com.ktb.cafeboo.global.infra.kakao.dto.KakaoTokenResponse;
 import com.ktb.cafeboo.global.infra.kakao.dto.KakaoUserResponse;
 import com.ktb.cafeboo.global.infra.kakao.client.KakaoTokenClient;
@@ -102,6 +103,7 @@ public class KakaoOauthService {
 
         return new LoginResponse(
                 user.getId().toString(),
+                UserRole.USER.name(),
                 accessToken,
                 requiresOnboarding,
                 refreshToken


### PR DESCRIPTION

# 📌 Pull Request

## ✨ 작업한 내용
- [x] 비회원 로그인 유저와의 구분을 위해, 소셜 로그인 응답에 "role" 필드 추가

## 🛠 변경사항
- `LoginResponse` dto 수정

## 💬 리뷰 요구사항
- x

## 🔍 테스트 방법(선택)
- Postman을 활용하여 정상적으로 응답 확인
