### PR TITLE
[FEAT] 이벤트 채팅방 기능 도입

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChat.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/model/CoffeeChat.java
@@ -111,4 +111,9 @@ public class CoffeeChat extends BaseEntity {
                 .map(coffeeChatTag -> coffeeChatTag.getTag().getName())
                 .toList();
     }
+
+    public void softDelete() {
+        this.status = CoffeeChatStatus.DELETED;
+        this.delete();
+    }
 }

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/repository/CoffeeChatRepository.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/repository/CoffeeChatRepository.java
@@ -14,15 +14,17 @@ import java.util.Optional;
 
 public interface CoffeeChatRepository extends JpaRepository<CoffeeChat, Long> {
 
-    // 사용자가 참여중인 채팅방 목록 (JOINED)
+    // 사용자가 참여중인 채팅방 목록 (JOINED) - 이벤트 우선
     @Query("""
         SELECT c FROM CoffeeChat c
         JOIN CoffeeChatMember m ON c.id = m.coffeeChat.id
         JOIN User u ON m.user.id = u.id
         WHERE m.user.id = :userId
-        AND c.status = 'ACTIVE'
+        AND c.status IN ('ACTIVE', 'EVENT')
         AND c.deletedAt IS NULL
-        ORDER BY c.createdAt DESC
+        ORDER BY 
+            CASE WHEN c.status = 'EVENT' THEN 0 ELSE 1 END,
+            c.meetingTime DESC
     """)
     List<CoffeeChat> findJoinedChats(Long userId);
 
@@ -48,12 +50,14 @@ public interface CoffeeChatRepository extends JpaRepository<CoffeeChat, Long> {
     List<CoffeeChat> findReviewableChats(Long userId, @Param("now") LocalDateTime now);
 
 
-    // 모든 활성화된 채팅방 목록 (ALL)
+    // 모든 활성화된 채팅방 목록 (ALL) - 이벤트 우선
     @Query("""
         SELECT c FROM CoffeeChat c
-        WHERE c.status = 'ACTIVE'
+        WHERE c.status IN ('ACTIVE', 'EVENT')
         AND c.deletedAt IS NULL
-        ORDER BY c.createdAt DESC
+        ORDER BY 
+            CASE WHEN c.status = 'EVENT' THEN 0 ELSE 1 END,  
+            c.createdAt DESC
     """)
     List<CoffeeChat> findAllActiveChats();
 

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatService.java
@@ -173,7 +173,7 @@ public class CoffeeChatService {
             member.delete();
         }
 
-        chat.delete();
+        chat.softDelete();
         coffeeChatRepository.save(chat);
     }
 

--- a/src/main/java/com/ktb/cafeboo/global/enums/CoffeeChatStatus.java
+++ b/src/main/java/com/ktb/cafeboo/global/enums/CoffeeChatStatus.java
@@ -1,5 +1,5 @@
 package com.ktb.cafeboo.global.enums;
 
 public enum CoffeeChatStatus {
-    ACTIVE, ENDED, DELETED
+    ACTIVE, ENDED, DELETED, EVENT
 }


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] 이벤트 채팅방 상태 및 우선 정렬 기능 추가
- [x] 채팅방 삭제 시 deletedAt만 설정되던 기존 방식에서 status = DELETED도 함께 반영되도록 리팩터링
→ 삭제된 채팅방이 명확하게 구분되어 데이터 확인 및 관리 용이

## 🛠 변경사항
- `CoffeeChatStatus`에 `EVENT` 상태 추가
- `CoffeeChatRepository`의 메서드에서 `EVENT` 상태를 우선 정렬되도록 쿼리 정렬 조건 개선
- 커피챗 삭제 서비스 로직 수정

## 💬 리뷰 요구사항
- 이벤트 오픈 시점이 얼마 남지 않아, 가장 간단한 방식으로 기능을 구현했습니다.
- 추후 이벤트가 종료된 이후, 앞으로 유사한 이벤트성 채팅방 데이터를 어떤 구조로 관리할지에 대해 함께 논의해보면 좋을 것 같습니다.

## 🔍 테스트 방법(선택)
- Postman 활용, 기능 동작 확인
