### PR TITLE
[FIX] 이벤트 채팅방 참여 오류 수정

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatService.java
@@ -24,6 +24,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -226,7 +227,7 @@ public class CoffeeChatService {
         CoffeeChat chat = coffeeChatRepository.findById(coffeechatId)
                 .orElseThrow(() -> new CustomApiException(ErrorStatus.COFFEECHAT_NOT_FOUND));
 
-        if (!chat.getStatus().equals(CoffeeChatStatus.ACTIVE)) {
+        if (!EnumSet.of(CoffeeChatStatus.ACTIVE, CoffeeChatStatus.EVENT).contains(chat.getStatus())) {
             throw new CustomApiException(ErrorStatus.COFFEECHAT_NOT_ACTIVE);
         }
 


### PR DESCRIPTION

# 📌 Pull Request

## ✨ 작업한 내용
- [x] 이벤트 커피챗 참여 시, 실패되는 오류 수정

## 🛠 변경사항
- 커피챗 참여 서비스 로직 수정 
- `EVENT` 상태 채팅방도 유효한 참여 대상으로 허용

## 💬 리뷰 요구사항
- x