### PR TITLE
[FIX] 이벤트 채팅방 메세지 조회 오류 수정

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatMessageService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatMessageService.java
@@ -13,6 +13,7 @@ import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
 import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
 import com.ktb.cafeboo.global.enums.CoffeeChatStatus;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -42,7 +43,7 @@ public class CoffeeChatMessageService {
         CoffeeChat chat = coffeeChatRepository.findById(coffeechatId)
                 .orElseThrow(() -> new CustomApiException(ErrorStatus.COFFEECHAT_NOT_FOUND));
 
-        if (!chat.getStatus().equals(CoffeeChatStatus.ACTIVE)) {
+        if (!EnumSet.of(CoffeeChatStatus.ACTIVE, CoffeeChatStatus.EVENT).contains(chat.getStatus())) {
             throw new CustomApiException(ErrorStatus.COFFEECHAT_NOT_ACTIVE);
         }
 


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] 이벤트 커피챗 메세지 불러오기 오류 수정

## 🛠 변경사항
- 커피챗 메세지 조회 서비스 로직 수정 
- `EVENT` 상태 채팅방도 유효한 참여 대상으로 허용

## 💬 리뷰 요구사항
- x