### PR TITLE
[FIX]: Redis Stream 구독 방식 변경

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/ChatService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/ChatService.java
@@ -178,73 +178,22 @@ public class ChatService {
      */
     public void startListeningToCoffeeChat(String roomId){
         String streamKey = CHAT_STREAM_PREFIX + roomId;
-        String consumerGroupName = CHAT_CONSUMER_GROUP_PREFIX + roomId; // 커피챗 ID를 컨슈머 그룹으로 사용
-        String consumerName = "room-consumer-" + roomId;
-        log.info("[ChatService.startListeningToRoom] - streamKey: {}, consumerGroupName: {}, consumerName: {}", streamKey, consumerGroupName, consumerName);
+        log.info("[ChatService.startListeningToRoom] - Registering XREAD listener for stream: {}", streamKey);
 
-        // 이미 구독 중이고 서버의 인메모리 맵에 존재하는지 확인
+        // 이미 해당 방에 리스너가 등록되어 있으면 중복 등록 방지
         if (activeRoomSubscriptions.containsKey(roomId)) {
-            log.info("[ChatService.startListeningToRoom] - 커피챗 {} 에 대응하는 Stream Listener가 이미 존재합니다.", roomId);
+            log.info("[ChatService.startListeningToRoom] - Already listening to room: {}", roomId);
             return;
         }
 
-        // Redis Stream 존재 및 consumer group 존재 여부 확인
-        boolean streamExists = false;
-        boolean groupExistsInRedis = false;
-
-        try {
-            if (redisTemplate.hasKey(streamKey)) {
-                streamExists = true;
-                XInfoGroups groups = redisTemplate.opsForStream().groups(streamKey);
-                for (StreamInfo.XInfoGroup groupInfo : groups) {
-                    if (consumerGroupName.equals(groupInfo.groupName())) {
-                        groupExistsInRedis = true;
-                        break;
-                    }
-                }
-            }
-        }
-        catch (Exception e) {
-            log.warn("[ChatService.startListeningToRoom] - Redis Stream 또는 Consumer Group 정보 조회 중 오류 발생 (무시): {}", e.getMessage());
-            // 예외 발생 시 groupExistsInRedis를 false로 유지하여 그룹 생성을 시도하게 함 (안전하게)
-        }
-
-        if (!groupExistsInRedis) {
-            try {
-                // RedisTemplate의 createGroup(streamKey, ReadOffset.from("0-0"), consumerGroupName) 오버로드는
-                // 스트림이 존재하지 않을 경우 자동으로 생성(MKSTREAM)하는 역할을 겸합니다.
-                redisTemplate.opsForStream().createGroup(streamKey, ReadOffset.from("0-0"), consumerGroupName);
-                log.info("[ChatService.startListeningToRoom] - Stream {}에 Consumer group {}가 생성되었습니다.", streamKey, consumerGroupName);
-                groupExistsInRedis = true; // 새로 생성 성공
-            } catch (Exception e) {
-                if (e.getMessage() != null && e.getMessage().contains("BUSYGROUP Consumer Group name already exists")) {
-                    log.info("Consumer group {} already exists for stream {}", consumerGroupName, streamKey);
-                    groupExistsInRedis = true; // BUSYGROUP이라면 이미 존재하므로 True로 설정
-                } else {
-                    log.error("Error creating consumer group {}: {}", consumerGroupName, e.getMessage(), e);
-                    return; // 다른 심각한 그룹 생성 오류 발생 시 리스너 등록 중단
-                }
-            }
-        } else {
-            log.info("[ChatService.startListeningToRoom] - Consumer group {} 이 Redis에 이미 존재합니다. 재사용합니다.", consumerGroupName);
-        }
-
-        // 2. ✨ StreamReadRequest를 사용하여 리스너 등록 방식 변경
-        StreamReadRequest<String> readRequest = StreamReadRequest.builder(
-                StreamOffset.create(streamKey, ReadOffset.lastConsumed())) // 해당 그룹의 마지막으로 소비한 오프셋부터 읽음
-            .consumer(Consumer.from(consumerGroupName, consumerName)) // 컨슈머 그룹과 컨슈머 이름
-            .autoAcknowledge(true) // onMessage() 성공 시 자동 ACK. 메시지 처리 실패 시 재처리를 위해 이 줄을 제거할 수 있음
-            .build();
-
-        // StreamMessageListenerContainer에 리스너 등록
-        // 이 Subscription이 XREADGROUP BLOCK 명령을 내부적으로 처리합니다.
-        Subscription subscription = streamMessageListenerContainer.register(
-            readRequest, // ✨ StreamReadRequest 객체 전달
-            redisStreamListener // 메시지 도착 시 onMessage()가 호출될 리스너 인스턴스
+        // XREAD 방식으로 스트림 구독 (브로드캐스트)
+        Subscription subscription = streamMessageListenerContainer.receive(
+                StreamOffset.create(streamKey, ReadOffset.latest()),
+                redisStreamListener
         );
 
         activeRoomSubscriptions.put(roomId, subscription);
-        log.info("Stream listener registered for chat room {} with group {} and consumer {}", roomId, consumerGroupName, consumerName);
+        log.info("[ChatService.startListeningToRoom] - XREAD listener registered for room: {}", roomId);
     }
 
     // ✨ 기존 CoffeeChatController에 있던 getChatRoomMessages 로직을 여기로 이동


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] Redis Stream 구독 방식 `XREADGROUP` -> `XREAD` 으로 수정
: 각 채팅방에 대해 단독 Consumer Group을 생성하는 방식 대신, 브로드캐스트 기반의 단순 소비 방식(XREAD)으로 전환
- [x] 멀티 VM 환경에서 동일 채팅방 리스닝 시 발생하던 메시지 누락 문제 해결

## 🛠 변경사항
- `streamMessageListenerContainer.register()`를 사용한 XREADGROUP 기반 리스너 등록 방식 제거
- 대신 `streamMessageListenerContainer.receive()`를 사용하여 XREAD 방식으로 적용

## 💬 리뷰 요구사항
- #241 에서 제안주신 내용 그대로 적용하였으나, 
구독 시 수신할 메세지 위치 지정해주는 부분을 `ReadOffset.lastConsumed()` 대신 `ReadOffset.latest()` 으로 수정하였습니다.

구분 | ReadOffset.lastConsumed() | ReadOffset.latest()
-- | -- | --
주 사용처 | XREADGROUP 전용 | XREAD, XREADGROUP 공통
의미 | 해당 Consumer가 마지막으로 읽은 이후 메시지부터 읽기 | 스트림에 새로 들어올 메시지만 읽기
동작 방식 | PEL(Pending Entries List)에 기록된 이후 메시지 | 현재 시점 이후의 메시지만 읽음

- `XREAD` 에서는 소비 상태를 추적하지 않기 때문에 `lastConsumed()`가 무의미하며,
기존 메세지는 채팅방 진입 시 별도의 Rest API를 통해 불러오기 때문에, 새로 들어오는 메세지만 수신하면 됩니다.
따라서, `latest()`를 적용하였습니다.

Fixes: #238 
Closed: #241
