### PR TITLE
[REFACTOR] 비즈니스 로직 성능 개선

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/caffeinediary/controller/CaffeineIntakeController.java
+++ b/src/main/java/com/ktb/cafeboo/domain/caffeinediary/controller/CaffeineIntakeController.java
@@ -42,19 +42,22 @@ public class CaffeineIntakeController {
 
         try{
             // 1. 서비스 메서드 호출
+            log.info("[POST /api/v1/caffeine-intakes] 카페인 섭취 기록 실행");
             CaffeineIntakeResponse response = caffeineIntakeService.recordCaffeineIntake(userId, request);
-
+            log.info("[POST /api/v1/caffeine-intakes] 카페인 섭취 기록 완료");
             // 2. 응답 반환
             return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(ApiResponse.of(SuccessStatus.CAFFEINE_INTAKE_RECORDED, response));
         }
         catch(CustomApiException e){
+            log.error("[POST /api/v1/caffeine-intakes] 카페인 섭취 기록 오류 : {}", e.getMessage());
             return ResponseEntity
                 .status(e.getErrorCode().getStatus()) // ErrorStatus에서 정의된 HTTP 상태 코드 사용
                 .body(ApiResponse.of(e.getErrorCode(), null));
         }
         catch (Exception e) {
+            log.error("[POST /api/v1/caffeine-intakes] 카페인 섭취 기록 오류 : {}", e.getMessage());
             return ResponseEntity
                 .status(ErrorStatus.INTERNAL_SERVER_ERROR.getStatus()) // ErrorStatus에서 정의된 HTTP 상태 코드 사용
                 .body(ApiResponse.of(ErrorStatus.INTERNAL_SERVER_ERROR, null));
@@ -70,8 +73,9 @@ public class CaffeineIntakeController {
 
         try{
             // 1. 서비스 메서드 호출
+            log.info("[PATCH /api/v1/caffeine-intakes/{}] 카페인 섭취 수정 시작", id);
             CaffeineIntakeResponse response = caffeineIntakeService.updateCaffeineIntake(id, request);
-
+            log.info("[PATCH /api/v1/caffeine-intakes/{}] 카페인 섭취 수정 완료", id);
             // 2. 응답 반환
             return ResponseEntity.ok(ApiResponse.of(SuccessStatus.CAFFEINE_INTAKE_UPDATED, response));
         }

--- a/src/main/java/com/ktb/cafeboo/domain/caffeinediary/model/CaffeineResidual.java
+++ b/src/main/java/com/ktb/cafeboo/domain/caffeinediary/model/CaffeineResidual.java
@@ -2,10 +2,8 @@ package com.ktb.cafeboo.domain.caffeinediary.model;
 
 import com.ktb.cafeboo.domain.user.model.User;
 import com.ktb.cafeboo.global.BaseEntity;
-import jakarta.persistence.Entity;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
@@ -18,7 +16,12 @@ import org.hibernate.annotations.Where;
 @Getter
 @Setter
 @Entity
-@Table(name = "CaffeineResiduals")
+@Table(
+        name = "CaffeineResiduals",
+        indexes = {
+                @Index(name = "idx_user_target_hour", columnList = "user_id, targetDate, hour")
+        }
+)
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/src/main/java/com/ktb/cafeboo/domain/caffeinediary/repository/CaffeineResidualRepository.java
+++ b/src/main/java/com/ktb/cafeboo/domain/caffeinediary/repository/CaffeineResidualRepository.java
@@ -33,4 +33,18 @@ public interface CaffeineResidualRepository extends JpaRepository<CaffeineResidu
         @Param("startTime") LocalDateTime startTime,
         @Param("endTime") LocalDateTime endTime
     );
+
+    // 특정 사용자, 특정 날짜 범위, 특정 시간 범위에 해당하는 모든 잔존량 데이터를 가져오는 쿼리
+    @Query("SELECT cr FROM CaffeineResidual cr " +
+            "WHERE cr.user = :user " +
+            "AND cr.targetDate BETWEEN :startDate AND :endDate " + // 날짜 범위 (시간 00:00:00 기준)
+            "AND cr.hour BETWEEN :startHour AND :endHour " +
+            "AND cr.deletedAt IS NULL")
+    List<CaffeineResidual> findByUserAndTargetDateRangeAndHourRange(
+            @Param("user") User user,
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate,
+            @Param("startHour") Integer startHour,
+            @Param("endHour") Integer endHour
+    );
 }

--- a/src/main/java/com/ktb/cafeboo/domain/caffeinediary/service/CaffeineIntakeService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/caffeinediary/service/CaffeineIntakeService.java
@@ -82,7 +82,7 @@ public class CaffeineIntakeService {
         intakeRepository.save(intake);
 
         // 2. 잔존량 계산
-        caffeineResidualService.updateResidualAmounts(userId, request.intakeTime(), request.caffeineAmount());
+        caffeineResidualService.updateResidualAmounts(user, request.intakeTime(), request.caffeineAmount());
 
         // 3. DailyStatistics 업데이트
         dailyStatisticsService.updateDailyStatistics(user, LocalDate.from(request.intakeTime()), request.caffeineAmount());
@@ -162,13 +162,13 @@ public class CaffeineIntakeService {
                     request.intakeTime() != null ? request.intakeTime() : intake.getIntakeTime();
 
             // 기존 시간 기준 삭제 ->  수정 이전의 잔존량 삭제
-            caffeineResidualService.modifyResidualAmounts(user.getId(), previousIntakeTime,
+            caffeineResidualService.modifyResidualAmounts(user, previousIntakeTime,
                 previousCaffeineAmount);
             dailyStatisticsService.updateDailyStatistics(user, LocalDate.from(previousIntakeTime),
                 previousCaffeineAmount * -1);
 
             // 새로운 시간 기준으로 update -> 수정 후의 잔존량 계산 및 저장
-            caffeineResidualService.updateResidualAmounts(user.getId(), newIntakeTime,
+            caffeineResidualService.updateResidualAmounts(user, newIntakeTime,
                 newCaffeineAmount);
             dailyStatisticsService.updateDailyStatistics(user, LocalDate.from(newIntakeTime),
                 newCaffeineAmount);
@@ -204,7 +204,7 @@ public class CaffeineIntakeService {
             int previousDrinkCount = intake.getDrinkCount();
 
             // 2. 해당 섭취 내역의 영향이 있는 시간 범위 내의 카페인 잔존량 수치 수정
-            caffeineResidualService.modifyResidualAmounts(user.getId(), previousIntakeTime, previousCaffeineAmount);
+            caffeineResidualService.modifyResidualAmounts(user, previousIntakeTime, previousCaffeineAmount);
             dailyStatisticsService.updateDailyStatistics(user, LocalDate.from(previousIntakeTime), previousCaffeineAmount * -1);
 
             // 3. 해당 데이터 CaffeineIntakes 테이블에서 삭제

--- a/src/main/java/com/ktb/cafeboo/domain/report/service/DailyStatisticsService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/report/service/DailyStatisticsService.java
@@ -90,36 +90,6 @@ public class DailyStatisticsService {
 
         CaffeineResidual residualAtSleep = caffeineResidualService.findByUserAndTargetDateAndHour(user, date.atStartOfDay(), user.getHealthInfo().getSleepTime().getHour());
 
-//        PredictCanIntakeCaffeineRequest request = PredictCanIntakeCaffeineRequest.builder()
-//            .userId(user.getId().toString())
-//            .currentTime(convertTimeToFloat(LocalTime.now()))
-//            .sleepTime(convertTimeToFloat(user.getHealthInfo().getSleepTime()))
-//            .caffeineLimit(Math.round(user.getCaffeinInfo().getDailyCaffeineLimitMg()))
-//            .currentCaffeine(Math.round(statistics.getTotalCaffeineMg()))
-//            .caffeineSensitivity(user.getCaffeinInfo().getCaffeineSensitivity())
-//            .targetResidualAtSleep(50f)
-//            .residualAtSleep(residualAtSleep.getResidueAmountMg())
-//            .gender(user.getHealthInfo().getGender())
-//            .age(user.getHealthInfo().getAge())
-//            .weight(user.getHealthInfo().getWeight())
-//            .height(user.getHealthInfo().getHeight())
-//            .isSmoker(user.getHealthInfo().getSmoking() ? 1 : 0)
-//            .takeHormonalContraceptive(user.getHealthInfo().getTakingBirthPill() ? 1 : 0)
-//            .build();
-//
-//        PredictCanIntakeCaffeineResponse response = aiServerClient.predictCanIntakeCaffeine(request);
-//
-//        String message = "";
-//
-//        if(Objects.equals(response.getStatus(), "success")){
-//            if(Objects.equals(response.getData().getCaffeineStatus(), "N")){
-//                message += "카페인을 추가로 섭취하면 수면에 영향을 줄 수 있어요.";
-//            }
-//            else if (Objects.equals(response.getData().getCaffeineStatus(), "Y")){
-//                message += "카페인을 추가로 섭취해도 수면에 영향이 없어요.";
-//            }
-//        }
-
         int currentCaffeine = Math.round(statistics.getTotalCaffeineMg());
         double caffeineResidualAtSleep = residualAtSleep.getResidueAmountMg();
 
@@ -186,23 +156,6 @@ public class DailyStatisticsService {
         int month = Integer.parseInt(targetMonth);
         int week = Integer.parseInt(targetWeek);
 
-//        // 주어진 year와 month로 해당 달의 첫 번째 날짜를 얻습니다.
-//        LocalDate firstDayOfMonth = LocalDate.of(year, month, 1);
-//
-//        // 해당 달의 첫 번째 주 월요일을 찾습니다.
-//        LocalDate firstMondayOfMonth = firstDayOfMonth.with(TemporalAdjusters.firstInMonth(DayOfWeek.MONDAY));
-//
-//        // 만약 첫 번째 날짜가 월요일보다 앞선다면, 그 주는 이전 달의 마지막 주에 해당할 수 있습니다.
-//        // 이를 보정하기 위해 첫 번째 월요일이 없다면 해당 달의 1일로 시작하는 주를 기준으로 합니다.
-//        LocalDate firstWeekStart = firstMondayOfMonth.getMonthValue() != month ?
-//            firstDayOfMonth : firstMondayOfMonth;
-//
-//        // 첫 번째 주 시작 날짜에 (weekOfMonth - 1) 주를 더하여 해당 월의 weekOfMonth 번째 주의 시작 날짜를 얻습니다.
-//        LocalDate startDate = firstWeekStart.plusWeeks(week - 1);
-//
-//        LocalDate startOfWeek = startDate.with(DayOfWeek.MONDAY);
-//        LocalDate endOfWeek = startOfWeek.plusDays(6);
-
         LocalDate startOfMonth = LocalDate.of(year, month, 1);;
         DayOfWeek dayOfWeek = startOfMonth.getDayOfWeek();
 
@@ -221,17 +174,6 @@ public class DailyStatisticsService {
             endOfMonth = endOfMonth.minusWeeks(1);
         }
 
-//        // 주어진 year와 month로 해당 달의 첫 번째 날짜를 얻습니다.
-//        LocalDate startOfMonth = LocalDate.of(year, month, 1);
-//
-//        // 해당 달의 첫 번째 주 월요일을 찾습니다.
-//        LocalDate firstMondayOfMonth = firstDayOfMonth.with(TemporalAdjusters.firstInMonth(DayOfWeek.MONDAY));
-//
-//        // 만약 첫 번째 날짜가 월요일보다 앞선다면, 그 주는 이전 달의 마지막 주에 해당할 수 있습니다.
-//        // 이를 보정하기 위해 첫 번째 월요일이 없다면 해당 달의 1일로 시작하는 주를 기준으로 합니다.
-//        LocalDate firstWeekStart = firstMondayOfMonth.getMonthValue() != month ?
-//            firstDayOfMonth : firstMondayOfMonth;
-//
 //        // 첫 번째 주 시작 날짜에 (weekOfMonth - 1) 주를 더하여 해당 월의 weekOfMonth 번째 주의 시작 날짜를 얻습니다.
         LocalDate startDate = startOfMonth.plusWeeks(week - 1).with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
         LocalDate endDate = startDate.plusDays(6);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,6 +14,10 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
+spring.jpa.properties.hibernate.jdbc.batch_size=50
+spring.jpa.properties.hibernate.order_inserts=true
+spring.jpa.properties.hibernate.order_updates=true
+
 
 # oauth
 spring.security.oauth2.client.registration.kakao.client-id=${KAKAO_CLIENT_ID}
@@ -62,3 +66,7 @@ censorship.whitelist-filename: censorship-whitelist-keywords.txt
 
 # Profile
 spring.profiles.active=local
+
+# HikariCP
+spring.datasource.hikari.maximum-pool-size=25
+spring.datasource.hikari.minimum-idle=8


### PR DESCRIPTION
# 📌 Pull Request
https://github.com/100-hours-a-week/13-Cafeboo-BE/issues/254 에서 논의된 성능에 문제가 있는 API 비즈니스 로직에 대한 수정사항 

## ✨ 작업한 내용
- [x] 카페인 잔존량 데이터 조회 방식 개선
- [x] 복합 인덱스 적용

## 🛠 변경사항
- CaffeineIntakeService 내부에서 caffeineResidualService의 메서드 호출 시 넘겨주는 파라미터를 Long 타입에서 User 타입으로 변경 진행했습니다. 불필요한 DB 요청을 줄이는 것으로 고부하 상황에서 DB I/O 발생에 대한 오버헤드가 줄어들 것으로 예상합니다. 

- CaffeineResidualService에서 이터를 일일히 조회하며 잔존량 관련 데이터에 변화를 적용하는 방식 대신 Map을 통해 미리 불러온 후 변화량이 반영되도록 동작 방식을 변경했습니다. 


## 💬 리뷰 요구사항

`Jmeter`를 활용해 섭취 내역 등록에 대한 부하 테스트를 진행했습니다. 조건은 다음과 같이 설정했습니다. 
- \# of Threads : 15
- Ramp-up period : 20
- Loop Count: 300 

기존 방식
<img width="878" height="511" alt="before - controller" src="https://github.com/user-attachments/assets/40ea193f-47f5-41b9-8edd-66a28fd86941" />  

개선된 방식
<img width="878" height="566" alt="before - updateResidualAmounts" src="https://github.com/user-attachments/assets/143455b2-6c21-436b-8e28-d0fe8d608be7" />

  

기존에 구현한 updateResidualAmounts() 메서드에서는 범위 내에 해당되는 잔존량 데이터에 대해 매번 DB에서 해당되는 데이터를 조회하도록 했습니다. 이러한 방식은 다음과 같은 이유로 성능에서 병목이 발생할 수 있습니다. 

1. 네트워크 왕복 시간
2. 데이터베이스 연결 및 자원 오버헤드

이 중, 해당 방식을 적용하면 한 번에 모든 잔존량 데이터를 모아서 요청을 보내기 때문에 네트워크 왕복 시간 (요청, 응답) 측면에서 성능 향상을 기대할 수 있을 것입니다. 

다만, 해당 방식이 모든 방면에서 무조건적으로 긍정적인 개선점만 가져오는 것은 아닙니다. 동일 부하 테스트에서의 비즈니스 로직 수행시간을 보면 해당 부분에 대해 확인할 수 있습니다.

개선 전  
<img width="878" height="566" alt="before - updateResidualAmounts" src="https://github.com/user-attachments/assets/a324cb16-982b-4698-a9f3-3d4cee478bb0" />


<br>

개선 이후  
<img width="878" height="566" alt="after, x index - updateResidualAmounts" src="https://github.com/user-attachments/assets/4409a4c7-efa9-4146-b6de-e764d54fe83f" />



<br/>

  
큰 차이점은 updateResidualAmounts(), updateDailyStatistics() 메서드의 수행에 걸린 시간입니다. 개선 전에는 updateResidualAmounts() 수행에 시간이 오래 걸리고, updateDailyStatistics() 수행이 빨랐다면, 개선 후는 반대의 양상을 보여주고 있습니다. 

해당 차이는 데이터 조회 방식 변경에 따른 캐시 미스 및 데이터베이스 쿼리 효율성 변화에서 비롯됩니다. 대량 데이터를 조회 및 수정하고 saveAll을 실행한 후, DB에 단일 데이터 조회를 요청하게 될 때 저장된 데이터의 내용이 변경되어 더 이상 캐시가 유효하지 않거나 쿼리 자체의 복잡성이 증가되어 updateDailyStatistics() 의 수행 시간이 길어지게 되었을 가능성이 있습니다. 

이러한 단점에도 실제 수행 결과를 보았을 때, 약 30% 정도의 유의미한 성능 개선이 이뤄졌기에 해당 방안의 적용했을 때의 장단점에 대해 같이 생각해보시고 의견 나눠주시면 감사하겠습니다. 


## 테스트 방법
- IntelliJ Ultimate 버전의 Profiler 기능 활용해 수행 시간 기록 수집 및 비교 진행

