### PR TITLE
[FEAT] SSE 연결 유지를 위한 heartbeat 이벤트 전송 기능 추가

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatService.java
@@ -190,7 +190,7 @@ public class CoffeeChatService {
         chat.softDelete();
         coffeeChatRepository.save(chat);
 
-        coffeeChatSseService.sendDeletedCoffeeChat(coffeechatId);
+        sseSender.sendAfterCommit(() -> coffeeChatSseService.sendDeletedCoffeeChat(coffeechatId));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatSseService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatSseService.java
@@ -5,6 +5,7 @@ import com.ktb.cafeboo.domain.coffeechat.dto.sse.DeletedCoffeeChatPayload;
 import com.ktb.cafeboo.domain.coffeechat.dto.sse.NewCoffeeChatPayload;
 import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChat;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -104,7 +105,6 @@ public class CoffeeChatSseService {
         });
     }
 
-
     public void sendDeletedCoffeeChat(Long coffeeChatId) {
         DeletedCoffeeChatPayload payload = new DeletedCoffeeChatPayload(coffeeChatId.toString());
 
@@ -120,4 +120,18 @@ public class CoffeeChatSseService {
         });
     }
 
+    // 1분마다 heartbeat 보내는 스케줄러 메서드
+    @Scheduled(fixedRate = 60000)
+    public void sendHeartbeatToAll() {
+        emitters.forEach((userId, emitter) -> {
+            try {
+                emitter.send(SseEmitter.event()
+                        .name("heartbeat")
+                        .data("ping"));
+            } catch (IOException e) {
+                emitter.complete();
+                emitters.remove(userId);
+            }
+        });
+    }
 }


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업한 내용
- [x] SSE 연결의 안정성 향상을 위해 1분 간격의 heartbeat 전송 추가

## 🛠 변경사항
- `@Scheduled(fixedRate = 60000)` 스케줄러를 통해 모든 SSE 연결 대상에게 1분 간격으로 heartbeat(ping) 이벤트 전송

## 💬 리뷰 요구사항
- x

## 🔍 테스트 방법(선택)
<img width="458" height="122" alt="스크린샷 2025-07-21 오후 5 15 58" src="https://github.com/user-attachments/assets/7af3f6e8-ed04-4e4f-94d8-ce268f2ff0f9" />

1분 간격의 이벤트 발생 확인
