### PR TITLE
[FEAT] 채팅 메세지 캐싱 전략 적용

### DIFF
--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/common/MessageDto.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/dto/common/MessageDto.java
@@ -1,5 +1,7 @@
 package com.ktb.cafeboo.domain.coffeechat.dto.common;
 
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatMember;
+import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatMessage;
 import com.ktb.cafeboo.global.enums.MessageType;
 import java.time.LocalDateTime;
 
@@ -9,4 +11,19 @@ public record MessageDto(
         String content,
         MessageType messageType,
         LocalDateTime sentAt
-) {}
+) {
+    public static MessageDto from(CoffeeChatMessage message, CoffeeChatMember sender) {
+        return new MessageDto(
+                String.valueOf(message.getId()),
+                new MemberDto(
+                        String.valueOf(sender.getId()),
+                        sender.getChatNickname(),
+                        sender.getProfileImageUrl(),
+                        sender.isHost()
+                ),
+                message.getContent(),
+                message.getType(),
+                message.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/ChatService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/ChatService.java
@@ -2,6 +2,7 @@ package com.ktb.cafeboo.domain.coffeechat.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ktb.cafeboo.domain.coffeechat.dto.StompMessagePublish;
+import com.ktb.cafeboo.domain.coffeechat.dto.common.MessageDto;
 import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChat;
 import com.ktb.cafeboo.domain.coffeechat.model.CoffeeChatMember;
 import com.ktb.cafeboo.domain.coffeechat.dto.StompMessage;
@@ -9,6 +10,7 @@ import com.ktb.cafeboo.domain.coffeechat.repository.CoffeeChatMemberRepository;
 import com.ktb.cafeboo.domain.coffeechat.repository.CoffeeChatRepository;
 import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
 import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
+import com.ktb.cafeboo.global.cache.ChatMessageCacheService;
 import com.ktb.cafeboo.global.censorship.CensorshipStrategy;
 import com.ktb.cafeboo.global.censorship.TextCensorshipFilter;
 import com.ktb.cafeboo.global.config.RedisConfig;
@@ -73,6 +75,7 @@ public class ChatService {
     private final CoffeeChatMessageService coffeeChatMessageService;
     private final TextCensorshipFilter textCensorshipFilter;
     private final KafkaMessageProducer kafkaMessageProducer;
+    private final ChatMessageCacheService chatMessageCacheService;
 
     private static final String CHAT_STREAM_PREFIX = "coffeechat:room:";
     private static final String CHAT_CONSUMER_GROUP_PREFIX = "coffeechat:group:";
@@ -158,6 +161,11 @@ public class ChatService {
                 .build();
 
             CoffeeChatMessage savedMessage = coffeeChatMessageService.save(coffeeChatMessage);
+
+            // 캐시에 메시지 추가
+            MessageDto messageDto = MessageDto.from(savedMessage, sender);  // Dto로 변환
+            chatMessageCacheService.cacheMessage(chat.getId(), messageDto); // Redis 캐시 push
+            log.info("[ChatService] 새로운 메세지 redis 캐싱 업데이트");
 
             StompMessagePublish messagePublish = StompMessagePublish.from(savedMessage, sender);
 

--- a/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatMessageService.java
+++ b/src/main/java/com/ktb/cafeboo/domain/coffeechat/service/CoffeeChatMessageService.java
@@ -11,27 +11,27 @@ import com.ktb.cafeboo.domain.coffeechat.repository.CoffeeChatMessageRepository;
 import com.ktb.cafeboo.domain.coffeechat.repository.CoffeeChatRepository;
 import com.ktb.cafeboo.global.apiPayload.code.status.ErrorStatus;
 import com.ktb.cafeboo.global.apiPayload.exception.CustomApiException;
+import com.ktb.cafeboo.global.cache.ChatMessageCacheService;
 import com.ktb.cafeboo.global.enums.CoffeeChatStatus;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.Optional;
+
+import java.util.*;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class CoffeeChatMessageService {
-
     private final CoffeeChatRepository coffeeChatRepository;
     private final CoffeeChatMessageRepository messageRepository;
     private final CoffeeChatMemberRepository memberRepository;
+    private final ChatMessageCacheService chatMessageCacheService;
 
     @Value("${DEFAULT_PROFILE_IMAGE_URL}")
     private String defaultProfileImageUrl;
@@ -50,56 +50,65 @@ public class CoffeeChatMessageService {
         CoffeeChatMember member = memberRepository.findByCoffeeChatIdAndUserId(coffeechatId, userId)
                 .orElseThrow(() -> new CustomApiException(ErrorStatus.COFFEECHAT_MEMBER_NOT_FOUND));
 
-        List<CoffeeChatMessage> messages = fetchMessagesByCursor(coffeechatId, cursor, limit, order);
-        log.info("[CoffeeChatMessageService.getMessages] 커피챗 메시지 조회 크기 : {}", messages.size());
+        ChatMessageCacheService.CachedMessagesResult cached = chatMessageCacheService.getMessagesIfCacheHit(coffeechatId, cursor, limit);
 
-        boolean hasNext = messages.size() > limit;
-        if (hasNext) {
-            messages = messages.subList(0, limit);
+        List<MessageDto> messageDtos = cached.messages();
+        boolean hasNext = cached.hasNext();
+
+        if (messageDtos.isEmpty()) {
+            List<CoffeeChatMessage> messages = fetchMessagesByCursor(coffeechatId, cursor, limit, order);
+            log.info("[CoffeeChatMessageService.getMessages] 커피챗 메시지 조회 크기 : {}", messages.size());
+
+            hasNext = messages.size() > limit;
+            if (hasNext) {
+                messages = messages.subList(0, limit);
+            }
+
+            messageDtos = messages.stream()
+                    .map(m -> {
+                        CoffeeChatMember sender = m.getSender();
+
+                        String senderId = Optional.ofNullable(sender)
+                                .map(s -> s.getId().toString())
+                                .orElse(null);
+
+                        String senderChatNickname = Optional.ofNullable(sender)
+                                .map(CoffeeChatMember::getChatNickname)
+                                .orElse("<알 수 없음>");
+
+                        String senderProfileImageUrl = Optional.ofNullable(sender)
+                                .map(CoffeeChatMember::getProfileImageUrl)
+                                .orElse(defaultProfileImageUrl);
+
+                        boolean senderIsHost = Optional.ofNullable(sender)
+                                .map(CoffeeChatMember::isHost)
+                                .orElse(false);
+
+                        return new MessageDto(
+                                String.valueOf(m.getId()),
+                                new MemberDto(
+                                        senderId,
+                                        senderChatNickname,
+                                        senderProfileImageUrl,
+                                        senderIsHost
+                                ),
+                                m.getContent(),
+                                m.getType(),
+                                m.getCreatedAt()
+                        );
+                    })
+                    .collect(Collectors.toList());
+
+            Collections.reverse(messageDtos); // 최신순 정렬
         }
-
-        List<MessageDto> messageDtos = messages.stream()
-                .map(m -> {
-                    CoffeeChatMember sender = m.getSender();
-
-                    // Optional.ofNullable을 사용하여 sender가 null인 경우를 안전하게 처리
-                    String senderId = Optional.ofNullable(sender)
-                        .map(s -> s.getId().toString())
-                        .orElse(null); // sender가 null이면 ID도 null
-
-                    String senderChatNickname = Optional.ofNullable(sender)
-                        .map(CoffeeChatMember::getChatNickname)
-                        .orElse("<알 수 없음>"); // sender가 null이면 "<알수없음>"
-
-                    String senderProfileImageUrl = Optional.ofNullable(sender)
-                        .map(CoffeeChatMember::getProfileImageUrl)
-                        .orElse(defaultProfileImageUrl); // sender가 null이면 기본 이미지 URL
-                    // 예: "/images/default_profile.png"
-
-                    boolean senderIsHost = Optional.ofNullable(sender)
-                        .map(CoffeeChatMember::isHost)
-                        .orElse(false); // sender가 null이면 호스트 아님
-
-                    return new MessageDto(
-                            String.valueOf(m.getId()),
-                            new MemberDto(
-                                senderId,
-                                senderChatNickname,
-                                senderProfileImageUrl,
-                                senderIsHost
-                            ),
-                            m.getContent(),
-                            m.getType(),
-                            m.getCreatedAt()
-                    );
-                })
-                .collect(Collectors.toList());
-
-        Collections.reverse(messageDtos);
         log.info("[CoffeeChatMessageService.getMessages] 커피챗 메시지 DTO 크기 : {}", messageDtos.size());
 
         String nextCursor =
             !messageDtos.isEmpty() ? String.valueOf(messageDtos.getFirst().messageId()) : "0";
+
+        if (cached.needsWarmup()) {
+            chatMessageCacheService.warmUpCache(coffeechatId, messageDtos);
+        }
 
         return new CoffeeChatMessagesResponse(
                 coffeechatId.toString(),

--- a/src/main/java/com/ktb/cafeboo/global/cache/ChatMessageCacheService.java
+++ b/src/main/java/com/ktb/cafeboo/global/cache/ChatMessageCacheService.java
@@ -1,0 +1,128 @@
+package com.ktb.cafeboo.global.cache;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ktb.cafeboo.domain.coffeechat.dto.common.MessageDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.IntStream;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatMessageCacheService {
+    private final RedisTemplate<String, String> redisTemplate;
+    private final RedisCacheMetrics redisCacheMetrics;
+    private final ObjectMapper objectMapper;
+    private static final int MAX_CACHE_SIZE = 100;
+
+    public record CachedMessagesResult(List<MessageDto> messages, boolean hasNext, boolean needsWarmup) {}
+
+    public void warmUpCache(Long roomId, List<MessageDto> messageDtoList) {
+        String key = "chat:room:" + roomId + ":messages";
+
+        // 최신 메시지가 앞에 오도록 순서 뒤집기
+        List<String> jsonList = messageDtoList.stream()
+                .map(this::convertToJson)
+                .filter(Objects::nonNull)
+                .toList();
+
+        redisTemplate.delete(key); // 기존 캐시 제거
+        if (!jsonList.isEmpty()) {
+            redisTemplate.opsForList().leftPushAll(key, jsonList);
+            redisTemplate.opsForList().trim(key, 0, MAX_CACHE_SIZE - 1);
+            redisTemplate.expire(key, Duration.ofHours(24));
+        }
+
+        log.info("[warmUpCache] 캐시 워밍업 완료 - roomId={}, count={}", roomId, jsonList.size());
+    }
+
+    public void cacheMessage(Long roomId, MessageDto messageDto) {
+        String key = "chat:room:" + roomId + ":messages";
+
+        Boolean hasKey = redisTemplate.hasKey(key);
+        if (Boolean.FALSE.equals(hasKey)) {
+            log.debug("[cacheMessage] 캐시 키 없음 - 저장 생략, roomId={}", roomId);
+            return;
+        }
+
+        String messageJson = convertToJson(messageDto);
+        redisTemplate.opsForList().leftPush(key, messageJson);
+        redisTemplate.opsForList().trim(key, 0, MAX_CACHE_SIZE - 1);
+
+        log.debug("[cacheMessage] 캐시 저장 - roomId={}, messageId={}", roomId, messageDto.messageId());
+    }
+
+    public CachedMessagesResult getMessagesIfCacheHit(Long roomId, String cursor, int limit) {
+        String key = "chat:room:" + roomId + ":messages";
+        List<String> cachedJsonList = redisTemplate.opsForList().range(key, 0, MAX_CACHE_SIZE - 1);
+
+        if (cachedJsonList == null || cachedJsonList.isEmpty()) {
+            redisCacheMetrics.incrementMiss();
+            log.debug("[getMessagesIfCacheHit] 캐시 미스 - roomId={}, 캐시 비어있음", roomId);
+            return new CachedMessagesResult(List.of(), false, true); // 캐시 miss
+        }
+
+        List<MessageDto> cachedMessages = new ArrayList<>(
+                cachedJsonList.stream()
+                        .map(json -> {
+                            try {
+                                return objectMapper.readValue(json, MessageDto.class);
+                            } catch (JsonProcessingException e) {
+                                log.warn("[getMessagesIfCacheHit] 메시지 역직렬화 실패 - json={}", json);
+                                return null;
+                            }
+                        })
+                        .filter(Objects::nonNull)
+                        .toList()
+        );
+        Collections.reverse(cachedMessages);
+
+        if (cursor.equals("0")) {
+            List<MessageDto> result = cachedMessages.subList(0, Math.min(limit, cachedMessages.size()));
+            boolean hasNext = cachedMessages.size() > limit;
+            redisCacheMetrics.incrementHit();
+            log.debug("[getMessagesIfCacheHit] 캐시 히트 - roomId={}, cursor=0, resultSize={}, hasNext={}",
+                    roomId, result.size(), hasNext);
+            return new CachedMessagesResult(result, hasNext, false);
+        }
+
+        int index = IntStream.range(0, cachedMessages.size())
+                .filter(i -> cachedMessages.get(i).messageId().equals(cursor))
+                .findFirst()
+                .orElse(-1);
+
+        if (index == -1) {
+            // 캐시 대상이 아닌 범위의 요청이므로 캐시 미스 통계에 포함하지 않음
+            //redisCacheMetrics.incrementMiss();
+            log.debug("[ChatMessageCacheService] 캐시된 100개 범위를 벗어난 커서 요청: {}", cursor);
+            return new CachedMessagesResult(List.of(), false, false); // 커서 못 찾음 ⇒ miss
+        }
+
+        int toIndex = Math.min(index + limit, cachedMessages.size());
+        List<MessageDto> result = cachedMessages.subList(index, toIndex);
+
+        boolean hasNext = toIndex < cachedMessages.size();
+
+        redisCacheMetrics.incrementHit();
+        log.debug("[getMessagesIfCacheHit] 캐시 히트 - roomId={}, cursor={}, resultSize={}, hasNext={}",
+                roomId, cursor, result.size(), hasNext);
+        return new CachedMessagesResult(result, hasNext, false);
+    }
+
+    private String convertToJson(MessageDto dto) {
+        try {
+            return objectMapper.writeValueAsString(dto);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("메시지 직렬화 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/ktb/cafeboo/global/cache/RedisCacheMetrics.java
+++ b/src/main/java/com/ktb/cafeboo/global/cache/RedisCacheMetrics.java
@@ -1,0 +1,46 @@
+package com.ktb.cafeboo.global.cache;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Component
+@RequiredArgsConstructor
+public class RedisCacheMetrics {
+
+    private final MeterRegistry meterRegistry;
+    private final AtomicInteger hitCount = new AtomicInteger(0);
+    private final AtomicInteger missCount = new AtomicInteger(0);
+
+    @PostConstruct
+    public void initMetrics() {
+        Gauge.builder("chat_message_cache_hit", hitCount, AtomicInteger::get)
+                .description("Chat message cache hit count")
+                .register(meterRegistry);
+
+        Gauge.builder("chat_message_cache_miss", missCount, AtomicInteger::get)
+                .description("Chat message cache miss count")
+                .register(meterRegistry);
+    }
+
+    public void incrementHit() {
+        hitCount.incrementAndGet();
+    }
+
+    public void incrementMiss() {
+        missCount.incrementAndGet();
+    }
+
+    public double getHitRatio() {
+        int hits = hitCount.get();
+        int misses = missCount.get();
+        int total = hits + misses;
+
+        if (total == 0) return 0.0;
+        return (double) hits / total;
+    }
+}


### PR DESCRIPTION

# 📌 Pull Request

## ✨ 작업한 내용
- [x] 커피챗 채팅 메시지에 Redis 기반 캐싱 기능을 적용하였습니다.
- [x] 채팅방 입장 시 메시지 목록을 빠르게 불러오기 위한 캐시 워밍업 및 저장 로직을 구현했습니다.

## 🛠 변경사항
- `ChatMessageCacheService` 클래스 추가
    - `warmUpCache`: DB에서 불러온 메시지를 Redis 리스트로 저장 (MAX 100개, TTL 24시간)
    - `cacheMessage`: 새 메시지 도착 시 기존 캐시가 존재하면 리스트 앞에 추가 및 크기 유지
    - `getMessagesIfCacheHit`: cursor 기반 메시지 페이징 조회, 없으면 cache miss 처리
- 캐시 키: `chat:room:{roomId}:messages`
- TTL: 24시간 고정 (커피챗 유효시간과 동일)

## 💬 리뷰 요구사항
- x

## 🔍 테스트 방법(선택)

- 캐싱 로그
<img width="938" height="222" alt="스크린샷 2025-07-24 오후 7 07 04" src="https://github.com/user-attachments/assets/439fd369-fc93-4eeb-bb0e-ddaafa4b64a6" />
