### PR TITLE
[FIX]: 메시지 캐시 저장 방향 leftPush → rightPush로 변경

### DIFF
--- a/src/main/java/com/ktb/cafeboo/global/cache/ChatMessageCacheService.java
+++ b/src/main/java/com/ktb/cafeboo/global/cache/ChatMessageCacheService.java
@@ -37,7 +37,7 @@ public class ChatMessageCacheService {
 
         redisTemplate.delete(key); // 기존 캐시 제거
         if (!jsonList.isEmpty()) {
-            redisTemplate.opsForList().leftPushAll(key, jsonList);
+            redisTemplate.opsForList().rightPushAll(key, jsonList);
             redisTemplate.opsForList().trim(key, 0, MAX_CACHE_SIZE - 1);
             redisTemplate.expire(key, Duration.ofHours(24));
         }
@@ -55,7 +55,7 @@ public class ChatMessageCacheService {
         }
 
         String messageJson = convertToJson(messageDto);
-        redisTemplate.opsForList().leftPush(key, messageJson);
+        redisTemplate.opsForList().rightPush(key, messageJson);
         redisTemplate.opsForList().trim(key, 0, MAX_CACHE_SIZE - 1);
 
         log.debug("[cacheMessage] 캐시 저장 - roomId={}, messageId={}", roomId, messageDto.messageId());
@@ -84,7 +84,6 @@ public class ChatMessageCacheService {
                         .filter(Objects::nonNull)
                         .toList()
         );
-        Collections.reverse(cachedMessages);
 
         if (cursor.equals("0")) {
             List<MessageDto> result = cachedMessages.subList(0, Math.min(limit, cachedMessages.size()));


### PR DESCRIPTION

# 📌 Pull Request

## ✨ 작업한 내용
- [x] Redis 캐시 저장 방식 변경 (leftPush → rightPush)

## 🛠 변경사항
- [x] Redis에 저장되는 메시지 순서를 클라이언트 조회 방향과 일치시키기 위해 `leftPush` → `rightPush`로 변경
- [x] getMessagesIfCacheHit()에서 Collections.reverse 제거하여 정렬 중복 해소

## 💬 리뷰 요구사항
- x

## 🔍 테스트 방법(선택)